### PR TITLE
Fix installation instructions

### DIFF
--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -5,6 +5,6 @@ The easiest way to install it is through Composer_
 
 .. code-block:: bash
 
-    composer require loophp/collection:^2
+    composer require loophp/collection
 
 .. _Composer: https://getcomposer.org


### PR DESCRIPTION
There's no version 2 yet. 
I removed the version completely to let composer choose the best matching version automatically.