### PR TITLE
Fix minimum PHP version in the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
 PHP Collection
 ==============
 
-Collection is a functional utility library for PHP greater than 7.1.3.
+Collection is a functional utility library for PHP greater than 7.4.
 
 It's similar to `other available collection libraries`_ based on regular PHP arrays,
 but with a lazy mechanism under the hood that strives to do as little work as possible while being as flexible

--- a/docs/pages/requirements.rst
+++ b/docs/pages/requirements.rst
@@ -4,7 +4,7 @@ Requirements
 PHP
 ---
 
-PHP greater than 7.1.3 is required.
+PHP greater than 7.4 is required.
 
 Dependencies
 ------------


### PR DESCRIPTION
This PR

* [x] Fixes the minimum PHP version in the docs (it's PHP >= 7.4 [since version 3](https://github.com/loophp/collection/releases/tag/3.0.0))
