### PR TITLE
Fix minimum PHP version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Description
 
-Collection is a functional utility library for PHP greater than 7.1.3.
+Collection is a functional utility library for PHP greater than 7.4.
 
 It's similar to [other collection libraries][Other collection libraries] based on regular PHP arrays,
 but with a lazy mechanism under the hood that strives to do as little work as possible while being as flexible


### PR DESCRIPTION
This PR

* [x] Fixes the minimum PHP version in the readme (it's PHP >= 7.4 since version 3)

It is a followup of #69 