### PR TITLE
collection: implements missing \Countable interface

### DIFF
--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract;
 
+use Countable;
 use Iterator;
 use IteratorAggregate;
 use JsonSerializable;
@@ -229,6 +230,7 @@ interface Collection extends
     Combineable,
     Compactable,
     Containsable,
+    Countable,
     Currentable,
     Cycleable,
     Diffable,


### PR DESCRIPTION
`loophp\collection\Collection` has a `count()` method, but `loophp\collection\Contract\Collection` doesn't implement the `\Countable` interface, making it useless. This PR fix this.