### PR TITLE
collection: remove static factory methods from contract

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -292,6 +292,13 @@ final class Collection implements CollectionInterface
         return new self(Duplicate::of(), $this->getIterator());
     }
 
+    /**
+     * Create a new instance with no items.
+     *
+     * @psalm-template NewTKey
+     * @psalm-template NewTKey of array-key
+     * @psalm-template NewT
+     */
     public static function empty(): CollectionInterface
     {
         return self::fromIterable([]);
@@ -362,6 +369,13 @@ final class Collection implements CollectionInterface
         return new self(Frequency::of(), $this->getIterator());
     }
 
+    /**
+     * @psalm-template NewTKey
+     * @psalm-template NewTKey of array-key
+     * @psalm-template NewT
+     *
+     * @param mixed ...$parameters
+     */
     public static function fromCallable(callable $callable, ...$parameters): self
     {
         return new self($callable, ...$parameters);
@@ -378,6 +392,14 @@ final class Collection implements CollectionInterface
         );
     }
 
+    /**
+     * @psalm-template NewTKey
+     * @psalm-template NewTKey of array-key
+     * @psalm-template NewT
+     *
+     * @param iterable<mixed> $iterable
+     * @psalm-param iterable<NewTKey, NewT> $iterable
+     */
     public static function fromIterable(iterable $iterable): self
     {
         return new self(
@@ -391,6 +413,9 @@ final class Collection implements CollectionInterface
         );
     }
 
+    /**
+     * @param resource $resource
+     */
     public static function fromResource($resource): self
     {
         return new self(

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -332,43 +332,6 @@ interface Collection extends
     Zipable
 {
     /**
-     * Create a new instance with no items.
-     *
-     * @psalm-template NewTKey
-     * @psalm-template NewTKey of array-key
-     * @psalm-template NewT
-     */
-    public static function empty(): self;
-
-    /**
-     * @psalm-template NewTKey
-     * @psalm-template NewTKey of array-key
-     * @psalm-template NewT
-     *
-     * @param mixed ...$parameters
-     */
-    public static function fromCallable(callable $callable, ...$parameters): self;
-
-    public static function fromFile(string $filepath): self;
-
-    /**
-     * @psalm-template NewTKey
-     * @psalm-template NewTKey of array-key
-     * @psalm-template NewT
-     *
-     * @param iterable<mixed> $iterable
-     * @psalm-param iterable<NewTKey, NewT> $iterable
-     */
-    public static function fromIterable(iterable $iterable): self;
-
-    /**
-     * @param resource $resource
-     */
-    public static function fromResource($resource): self;
-
-    public static function fromString(string $string, string $delimiter = ''): self;
-
-    /**
      * @psalm-return \Iterator<TKey, T>
      */
     public function getIterator(): Iterator;


### PR DESCRIPTION
Those static factory methods are tied to how the default implementation works, and makes it hard to provide an alternative implementation.

For exemple, I have some use cases where I already know the number of items in the iterable, and I would like to pass it to the alternative implementation to avoid calling `iterator_count()`