### PR TITLE
SA Checks: fromIterable, empty

### DIFF
--- a/docs/pages/code/simple.php
+++ b/docs/pages/code/simple.php
@@ -167,7 +167,7 @@ $hugeFile = __DIR__ . '/vendor/composer/autoload_static.php';
 Collection::fromIterable($readFileLineByLine($hugeFile))
     // Add the line number at the end of the line, as comment.
     ->map(
-        static function ($value, $key) {
+        static function ($value, $key): string {
             return str_replace(\PHP_EOL, ' // line ' . $key . \PHP_EOL, $value);
         }
     )

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -2,11 +2,27 @@ imports:
   - { resource: vendor/drupol/php-conventions/config/php73/grumphp.yml }
 
 parameters:
-  tasks.phpcsfixer.config: .php-cs-fixer.dist.php
+  # GrumPHP License
   tasks.license.holder: Pol Dellaiera
   tasks.license.date_from: 2019
 
+  # PHP CS Fixer
+  tasks.phpcsfixer.config: .php-cs-fixer.dist.php
+
+  # PHPStan
   tasks.phpstan.blocking: true
+  tasks.phpstan.ignore_patterns:
+    - "/.github/"
+    - "/.idea/"
+    - "/build/"
+    - "/benchmarks/"
+    - "/node_modules/"
+    - "/resource/"
+    - "/spec/"
+    - "/var/"
+    - "/vendor/"
+
+  # Psalm
   tasks.psalm.blocking: true
 
   extra_tasks:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,16 +6,6 @@ parameters:
 			path: docs/pages/code/operations/since.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:empty\\(\\) return type with generic interface loophp\\\\collection\\\\Contract\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/Collection.php
-
-		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:fromIterable\\(\\) return type with generic class loophp\\\\collection\\\\Collection does not specify its types\\: TKey, T$#"
-			count: 1
-			path: src/Collection.php
-
-		-
 			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, string\\>, Closure\\(string, string\\)\\: loophp\\\\collection\\\\Iterator\\\\StringIterator\\<mixed, string\\> given\\.$#"
 			count: 1
 			path: src/Collection.php

--- a/phpstan-docs-baseline.neon
+++ b/phpstan-docs-baseline.neon
@@ -1,0 +1,32 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$iterable of static method loophp\\\\collection\\\\Collection\\<mixed,mixed\\>\\:\\:fromIterable\\(\\) expects iterable\\<\\(int\\|string\\), Symfony\\\\Contracts\\\\HttpClient\\\\ChunkInterface\\>, Symfony\\\\Contracts\\\\HttpClient\\\\ResponseStreamInterface given\\.$#"
+			count: 1
+			path: docs/pages/code/lazy-json-parsing.php
+
+		-
+			message: "#^Unable to resolve the template type NewTKey in call to method static method loophp\\\\collection\\\\Collection\\<mixed,mixed\\>\\:\\:fromIterable\\(\\)$#"
+			count: 4
+			path: docs/pages/code/lazy-json-parsing.php
+
+		-
+			message: "#^Unable to resolve the template type NewT in call to method static method loophp\\\\collection\\\\Collection\\<mixed,mixed\\>\\:\\:fromIterable\\(\\)$#"
+			count: 1
+			path: docs/pages/code/parse-git-log.php
+
+		-
+			message: "#^Unable to resolve the template type NewTKey in call to method static method loophp\\\\collection\\\\Collection\\<mixed,mixed\\>\\:\\:fromIterable\\(\\)$#"
+			count: 1
+			path: docs/pages/code/parse-git-log.php
+
+		-
+			message: "#^Unable to resolve the template type NewTKey in call to method static method loophp\\\\collection\\\\Collection\\<mixed,mixed\\>\\:\\:fromIterable\\(\\)$#"
+			count: 2
+			path: docs/pages/code/primes.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function mb_strtolower expects string, int given\\.$#"
+			count: 1
+			path: docs/pages/code/simple.php
+

--- a/phpstan-unsupported-baseline.neon
+++ b/phpstan-unsupported-baseline.neon
@@ -1,0 +1,27 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\<mixed, mixed\\> in PHPDoc tag @extends does not specify all template types of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\: TKey, T, NewTKey, NewT$#"
+			count: 1
+			path: src/Contract/Collection.php
+
+		-
+			message: "#^Type mixed in generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\<mixed, mixed\\> in PHPDoc tag @extends is not subtype of template type TKey of int of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\.$#"
+			count: 1
+			path: src/Contract/Collection.php
+
+		-
+			message: "#^PHPDoc tag @template T for class loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable with bound type array\\<int, int\\|NewT\\|string\\> is not supported\\.$#"
+			count: 1
+			path: src/Contract/Operation/Unpackable.php
+
+		-
+			message: "#^PHPDoc tag @template T for interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable with bound type array\\<int, int\\|NewT\\|string\\> is not supported\\.$#"
+			count: 1
+			path: src/Contract/Operation/Unpackable.php
+
+		-
+			message: "#^PHPDoc tag @template T for class loophp\\\\collection\\\\Operation\\\\Unpack with bound type array\\<int, int\\|NewT\\|string\\> is not supported\\.$#"
+			count: 1
+			path: src/Operation/Unpack.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,2 +1,4 @@
 includes:
 	- phpstan-baseline.neon
+	- phpstan-docs-baseline.neon
+	- phpstan-unsupported-baseline.neon

--- a/spec/loophp/collection/Iterator/IterableIteratorSpec.php
+++ b/spec/loophp/collection/Iterator/IterableIteratorSpec.php
@@ -9,78 +9,79 @@ declare(strict_types=1);
 
 namespace spec\loophp\collection\Iterator;
 
+use ArrayIterator;
+use Generator;
 use loophp\collection\Iterator\IterableIterator;
 use PhpSpec\ObjectBehavior;
 
 class IterableIteratorSpec extends ObjectBehavior
 {
-    public function it_can_be_constructed_with_a_callable_which_is_not_a_generator(): void
+    public function it_can_get_a_string_key(): void
     {
-        $this
-            ->beConstructedWith(range(1, 5));
+        $this->beConstructedWith(['foo' => 1, 'bar' => 2]);
+
+        $this->key()->shouldReturn('foo');
+        $this->next();
+        $this->key()->shouldReturn('bar');
     }
 
-    public function it_can_get_a_key(): void
+    public function it_can_get_an_int_key(): void
     {
-        $this
-            ->beConstructedWith(range(1, 5));
+        $this->beConstructedWith(range(1, 5));
 
-        $this
-            ->key()
-            ->shouldReturn(0);
+        $this->key()->shouldReturn(0);
+        $this->next();
+        $this->key()->shouldReturn(1);
     }
 
-    public function it_can_rewind()
+    public function it_can_rewind(): void
     {
-        $iterable = ['foo'];
+        $this->beConstructedWith(['foo']);
 
-        $this
-            ->beConstructedWith($iterable);
+        $this->current()->shouldReturn('foo');
 
-        $this
-            ->current()
-            ->shouldReturn('foo');
+        $this->next();
+        $this->current()->shouldReturn(null);
 
-        $this
-            ->next();
-
-        $this
-            ->current()
-            ->shouldReturn(null);
-
-        $this
-            ->rewind();
-
-        $this
-            ->current()
-            ->shouldReturn('foo');
+        $this->rewind();
+        $this->current()->shouldReturn('foo');
     }
 
     public function it_can_use_next(): void
     {
-        $this
-            ->beConstructedWith(range(1, 5));
+        $this->beConstructedWith(range(1, 5));
 
-        $this
-            ->next()
-            ->shouldBeNull();
+        $this->next()->shouldBeNull();
 
-        $this
-            ->current()
-            ->shouldReturn(2);
+        $this->current()->shouldReturn(2);
     }
 
-    public function it_is_initializable(): void
+    public function it_is_initializable_from_array(): void
     {
-        $iterable = ['foo', 'bar', 'baz'];
-
-        $this
-            ->beConstructedWith($iterable);
+        $this->beConstructedWith(['foo', 'bar', 'baz']);
 
         $this->shouldHaveType(IterableIterator::class);
 
-        $this
-            ->current()
-            ->shouldBeEqualTo('foo');
+        $this->current()->shouldBeEqualTo('foo');
+    }
+
+    public function it_is_initializable_from_generator(): void
+    {
+        $gen = static fn (): Generator => yield from ['foo', 'bar', 'baz'];
+
+        $this->beConstructedWith($gen());
+
+        $this->shouldHaveType(IterableIterator::class);
+
+        $this->current()->shouldBeEqualTo('foo');
+    }
+
+    public function it_is_initializable_from_iterator(): void
+    {
+        $this->beConstructedWith(new ArrayIterator(['foo', 'bar', 'baz']));
+
+        $this->shouldHaveType(IterableIterator::class);
+
+        $this->current()->shouldBeEqualTo('foo');
     }
 }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -291,13 +291,17 @@ final class Collection implements CollectionInterface
     /**
      * Create a new instance with no items.
      *
-     * @psalm-template NewTKey
-     * @psalm-template NewTKey of array-key
-     * @psalm-template NewT
+     * @template NewTKey of array-key
+     * @template NewT
+     *
+     * @return self<NewTKey, NewT>
      */
     public static function empty(): CollectionInterface
     {
-        return self::fromIterable([]);
+        /** @var array<NewTKey, NewT> $emptyArray */
+        $emptyArray = [];
+
+        return self::fromIterable($emptyArray);
     }
 
     public function every(callable ...$callbacks): CollectionInterface
@@ -366,8 +370,8 @@ final class Collection implements CollectionInterface
     }
 
     /**
-     * @psalm-template NewTKey of array-key
-     * @psalm-template NewT
+     * @template NewTKey of array-key
+     * @template NewT
      *
      * @param callable(mixed ...$parameters): iterable<NewTKey, NewT> $callable
      * @param mixed ...$parameters
@@ -391,21 +395,16 @@ final class Collection implements CollectionInterface
     }
 
     /**
-     * @psalm-template NewTKey
-     * @psalm-template NewTKey of array-key
-     * @psalm-template NewT
+     * @template NewTKey of array-key
+     * @template NewT
      *
-     * @param iterable<mixed> $iterable
-     * @psalm-param iterable<NewTKey, NewT> $iterable
+     * @param iterable<NewTKey, NewT> $iterable
+     *
+     * @return self<NewTKey, NewT>
      */
     public static function fromIterable(iterable $iterable): self
     {
         return new self(
-            /**
-             * @psalm-param iterable<TKey, T> $iterable
-             *
-             * @psalm-return Iterator<TKey, T>
-             */
             static fn (iterable $iterable): Iterator => new IterableIterator($iterable),
             $iterable
         );

--- a/src/Contract/Operation/Columnable.php
+++ b/src/Contract/Operation/Columnable.php
@@ -21,9 +21,9 @@ interface Columnable
     /**
      * Return the values from a single column in the input iterables.
      *
-     * @param int|string $index
+     * @param int|string $column
      *
      * @psalm-return \loophp\collection\Collection<TKey, T>
      */
-    public function column($index): Collection;
+    public function column($column): Collection;
 }

--- a/src/Contract/Operation/GroupByable.php
+++ b/src/Contract/Operation/GroupByable.php
@@ -21,5 +21,5 @@ interface GroupByable
     /**
      * @psalm-return \loophp\collection\Collection<TKey, T>
      */
-    public function groupBy(?callable $callback = null): Collection;
+    public function groupBy(?callable $callable = null): Collection;
 }

--- a/src/Contract/Operation/Unpackable.php
+++ b/src/Contract/Operation/Unpackable.php
@@ -12,14 +12,16 @@ namespace loophp\collection\Contract\Operation;
 use loophp\collection\Contract\Collection;
 
 /**
- * @psalm-template TKey
- * @psalm-template TKey of array-key
- * @psalm-template T
+ * @template TKey of int
+ * @template T of array{0: NewTKey, 1: NewT}
+ *
+ * @template NewTKey of array-key
+ * @template NewT
  */
 interface Unpackable
 {
     /**
-     * @psalm-return \loophp\collection\Collection<TKey, T>
+     * @return \loophp\collection\Collection<NewTKey, NewT>
      */
     public function unpack(): Collection;
 }

--- a/src/Iterator/IterableIterator.php
+++ b/src/Iterator/IterableIterator.php
@@ -22,20 +22,12 @@ use Generator;
 final class IterableIterator extends ProxyIterator
 {
     /**
-     * @param iterable<mixed> $iterable
-     * @psalm-param iterable<TKey, T> $iterable
+     * @param iterable<TKey, T> $iterable
      */
     public function __construct(iterable $iterable)
     {
         $this->iterator = new ClosureIterator(
-            /**
-             * @psalm-param iterable<TKey, T> $iterable
-             */
-            static function (iterable $iterable): Generator {
-                foreach ($iterable as $key => $value) {
-                    yield $key => $value;
-                }
-            },
+            static fn (iterable $iterable): Generator => yield from $iterable,
             $iterable
         );
     }

--- a/src/Operation/Unpack.php
+++ b/src/Operation/Unpack.php
@@ -15,14 +15,16 @@ use Iterator;
 use loophp\collection\Iterator\IterableIterator;
 
 /**
- * @psalm-template TKey
- * @psalm-template TKey of array-key
- * @psalm-template T
+ * @template NewTKey of array-key
+ * @template NewT
+ *
+ * @template TKey of int
+ * @template T of array{0: NewTKey, 1: NewT}
  */
 final class Unpack extends AbstractOperation
 {
     /**
-     * @psalm-return Closure(Iterator<int, array{0: TKey, 1: T}>): Generator<T, T>
+     * @return Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
      */
     public function __invoke(): Closure
     {
@@ -30,25 +32,23 @@ final class Unpack extends AbstractOperation
 
         $callbackForKeys =
             /**
-             * @param mixed $initial
-             * @psalm-param T $initial
-             * @psalm-param array{0: TKey, 1: T} $value
+             * @param NewTKey $initial
+             * @param T $value
              *
-             * @psalm-return TKey
+             * @return NewTKey
              */
             static fn ($initial, int $key, array $value) => $value[0];
 
         $callbackForValues =
             /**
-             * @param mixed $initial
-             * @psalm-param T $initial
-             * @psalm-param array{0: TKey, 1: T} $value
+             * @param NewT $initial
+             * @param T $value
              *
-             * @psalm-return T
+             * @return NewT
              */
             static fn ($initial, int $key, array $value) => $value[1];
 
-        /** @psalm-var Closure(Iterator<int, array{0: TKey, 1: T}>): Generator<T, T> $pipe */
+        /** @var Closure(Iterator<TKey, T>): Generator<NewTKey, NewT> $pipe */
         $pipe = Pipe::of()(
             Map::of()($toIterableIterator, Chunk::of()(2)),
             Unwrap::of(),

--- a/tests/static-analysis/empty.php
+++ b/tests/static-analysis/empty.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+/**
+ * @param Collection<int, int> $collection
+ */
+function checkNumeric(Collection $collection): void
+{
+}
+/**
+ * @param Collection<string, int> $collection
+ */
+function checkMap(Collection $collection): void
+{
+}
+
+checkNumeric(Collection::empty());
+checkMap(Collection::empty());

--- a/tests/static-analysis/fromIterator.php
+++ b/tests/static-analysis/fromIterator.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+/**
+ * @param Collection<int, int> $collection
+ */
+function checkNumeric(Collection $collection): void
+{
+}
+/**
+ * @param Collection<string, int> $collection
+ */
+function checkMap(Collection $collection): void
+{
+}
+/** @var Closure(): Generator<int, int> $generatorNumeric */
+$generatorNumeric = static fn (): Generator => yield from range(1, 3);
+/** @var Closure(): Generator<string, int> $generatorMap */
+$generatorMap = static fn (): Generator => yield 'myKey' => 1;
+
+/** @var array<int, int> $arrayNumeric */
+$arrayNumeric = range(1, 3);
+/** @var array<string, int> $arrayMap */
+$arrayMap = ['foo' => 1, 'bar' => 2];
+
+/** @var ArrayIterator<int, int> $arrayIteratorNumeric */
+$arrayIteratorNumeric = new ArrayIterator(range(1, 3));
+/** @var ArrayIterator<string, int> $arrayIteratorMap */
+$arrayIteratorMap = new ArrayIterator(['foo' => 1, 'bar' => 2]);
+
+checkNumeric(Collection::fromIterable($generatorNumeric()));
+checkMap(Collection::fromIterable($generatorMap()));
+
+checkNumeric(Collection::fromIterable($arrayNumeric));
+checkMap(Collection::fromIterable($arrayMap));
+
+checkNumeric(Collection::fromIterable($arrayIteratorNumeric));
+checkMap(Collection::fromIterable($arrayIteratorMap));


### PR DESCRIPTION
This PR adds to the static analysis checks: `fromIterable`, `empty`.

* [x] add checks
* [x] add PHPStan analysis for `tests/` in GrumPHP
* [x] a couple of tweaks to `IterableIterator`
* [x] fixing a bunch of static analysis issues around `Unpack` -> surfaced by the `squash` operation now that `fromIterable` has the right type hints
* [x] added some more PHPStan baselines for specific purposes 
