### PR TITLE
Static Analysis Checks: Common Operations (I)

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -450,8 +450,11 @@ Signature: ``Collection::compact(...$values);``
 contains
 ~~~~~~~~
 
-Check if the collection contains one or more values. Note that if multiple values are passed the operation
-acts like a logical ``OR``.
+Check if the collection contains one or more values.
+
+.. warning:: The `values` parameter is variadic and will be evaluated as a logical ``OR``.
+             If you're looking for a logical ``AND``, you have to make separate calls to this method;
+             note the calls cannot be in succession because the collection will contain a boolean after the first call.
 
 Interface: `Containsable`_
 
@@ -580,7 +583,7 @@ dropWhile
 Iterate over the collection items and takes from it its elements from the moment when the condition fails for the
 first time till the end of the list.
 
-.. warning:: The `callbacks` parameter is variadic and they are evaluated as a logical ``OR``.
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 
@@ -638,7 +641,7 @@ every
 
 This operation tests whether all elements in the collection pass the test implemented by the provided callback(s).
 
-.. warning:: The `callbacks` parameter is variadic and they are evaluated as a logical ``OR``.
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 
@@ -962,7 +965,7 @@ has
 
 Check if the collection has values.
 
-.. warning:: The `callbacks` parameter is variadic and they are evaluated as a logical ``OR``.
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 
@@ -1428,7 +1431,7 @@ partition
 
 With one or multiple callable, partition the items into 2 subgroups of items.
 
-.. warning:: The `callbacks` parameter is variadic and they are evaluated as a logical ``OR``.
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 
@@ -1752,7 +1755,7 @@ since
 
 Skip items until the callback is met.
 
-.. warning:: The `callbacks` parameter is variadic and they are evaluated as a logical ``OR``.
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 
@@ -1902,7 +1905,7 @@ Iterate over the collection items while the provided callback(s) are satisfied.
 
 It stops iterating when the callback(s) are not met.
 
-.. warning:: The `callbacks` parameter is variadic and they are evaluated as a logical ``OR``.
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 
@@ -2028,7 +2031,7 @@ until
 
 Iterate over the collection items until the provided callback(s) are satisfied.
 
-.. warning:: The `callbacks` parameter is variadic and they are evaluated as a logical ``OR``.
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -450,16 +450,23 @@ Signature: ``Collection::compact(...$values);``
 contains
 ~~~~~~~~
 
-Check if the collection contains one or more values.
+Check if the collection contains one or more values. Note that if multiple values are passed the operation
+acts like a logical ``OR``.
 
 Interface: `Containsable`_
 
-Signature: ``Collection::contains(...$value);``
+Signature: ``Collection::contains(...$values);``
 
 .. code-block:: php
 
     $collection = Collection::fromIterable(range('a', 'c'))
         ->contains('d'); // [false]
+
+    $collection = Collection::fromIterable(range('a', 'c'))
+        ->contains('a', 'z'); // [true]
+
+    $collection = Collection::fromIterable(['a' => 'b', 'c' => 'd'])
+        ->contains('d'); // ['c' => true]
 
     if ($collection->contains('d')->current()) {
         // do something

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -678,7 +678,7 @@ Signature: ``Collection::explode(...$items);``
 falsy
 ~~~~~
 
-Check if the collection contains *any falsy* values. A value is determined to be *falsy* by applying a ``bool`` cast.
+Check if the collection contains *only falsy* values. A value is determined to be *falsy* by applying a ``bool`` cast.
 
 Interface: `Falsyable`_
 
@@ -689,7 +689,7 @@ Signature: ``Collection::falsy();``
     $truthyCollection = Collection::fromIterable([2, 3, 4])
         ->falsy(); // [false]
 
-    $falsyCollection = Collection::fromIterable(['a', '', 'c', 'd'])
+    $falsyCollection = Collection::fromIterable(['', null, 0])
         ->falsy(); // [true]
 
     if ($falsyCollection->falsy()->current()) {
@@ -1927,7 +1927,7 @@ Signature: ``Collection::transpose();``
 truthy
 ~~~~~~
 
-Check if the collection contains *any truthy* values. Opposite of ``falsy``.
+Check if the collection contains *only truthy* values. Opposite of ``falsy``.
 A value is determined to be *truthy* by applying a ``bool`` cast.
 
 Interface: `Truthyable`_

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -316,13 +316,15 @@ Chunk a collection of items into chunks of items of a given size.
 
 Interface: `Chunkable`_
 
-Signature: ``Collection::chunk(int $size);``
+Signature: ``Collection::chunk(int ...$sizes);``
 
 .. code-block:: php
 
-    $collection = Collection::fromIterable(range(0, 10));
+    $collection = Collection::fromIterable(range(0, 6))
+        ->chunk(2); // [[0, 1], [2, 3], [4, 5], [6]]
 
-    $collection->chunk(2);
+    $collection = Collection::fromIterable(range(0, 6))
+        ->chunk(1, 2); // [[0], [1, 2], [3], [4, 5], [6]]
 
 coalesce
 ~~~~~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1453,7 +1453,7 @@ Custom operations and operations provided in the API can be combined together.
 
 Interface: `Pipeable`_
 
-Signature: ``Collection::pipe(callable ...$callables);``
+Signature: ``Collection::pipe(callable ...$callbacks);``
 
 .. code-block:: php
 

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -39,6 +39,16 @@ parameters:
 
   # Psalm
   tasks.psalm.blocking: true
+  tasks.psalm.ignore_patterns:
+      - "/.github/"
+      - "/.idea/"
+      - "/build/"
+      - "/benchmarks/"
+      - "/node_modules/"
+      - "/resource/"
+      - "/spec/"
+      - "/var/"
+      - "/vendor/"
 
   extra_tasks:
     phpspec:

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -671,6 +671,10 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable(range('A', 'C'))
             ->contains('C', 'unknown', 'A')
             ->shouldIterateAs([true]);
+
+        $this::fromIterable(['a' => 'b', 'c' => 'd'])
+            ->contains('d')
+            ->shouldIterateAs(['c' => true]);
     }
 
     public function it_can_convert_use_a_string_as_parameter(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -711,6 +711,10 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable(['a'])
             ->current(0)
             ->shouldReturn('a');
+
+        $this::fromIterable(new ArrayIterator())
+            ->current()
+            ->shouldBeNull();
     }
 
     public function it_can_cycle(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -232,9 +232,9 @@ final class Collection implements CollectionInterface
         return new self(Compact::of()(...$values), $this->getIterator());
     }
 
-    public function contains(...$value): CollectionInterface
+    public function contains(...$values): CollectionInterface
     {
-        return new self(Contains::of()(...$value), $this->getIterator());
+        return new self(Contains::of()(...$values), $this->getIterator());
     }
 
     public function count(): int

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -605,9 +605,9 @@ final class Collection implements CollectionInterface
         return new self(Permutate::of(), $this->getIterator());
     }
 
-    public function pipe(callable ...$callables): CollectionInterface
+    public function pipe(callable ...$callbacks): CollectionInterface
     {
-        return new self(Pipe::of()(...$callables), $this->getIterator());
+        return new self(Pipe::of()(...$callbacks), $this->getIterator());
     }
 
     public function pluck($pluck, $default = null): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -553,10 +553,6 @@ final class Collection implements CollectionInterface
 
     public function match(callable $callback, ?callable $matcher = null): CollectionInterface
     {
-        // @todo: Rename this in next major version.
-        // We cannot use Match::class because PHP 8 has
-        // a new "match" function and we cannot use the same name.
-        // @See https://github.com/loophp/collection/issues/56
         return new self(MatchOne::of()($matcher ?? static fn (): bool => true)($callback), $this->getIterator());
     }
 

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -136,7 +136,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Combinateable<TKey, T>
  * @template-extends Combineable<TKey, T>
  * @template-extends Compactable<TKey, T>
- * @template-extends Containsable<int, bool>
+ * @template-extends Containsable<TKey, T>
  * @template-extends Currentable<TKey, T>
  * @template-extends Cycleable<TKey, T>
  * @template-extends Diffable<TKey, T>

--- a/src/Contract/Operation/Chunkable.php
+++ b/src/Contract/Operation/Chunkable.php
@@ -20,7 +20,7 @@ interface Chunkable
     /**
      * Chunk the collection into chunks of the given size.
      *
-     * @return \loophp\collection\Collection<int, list<T>>
+     * @return Collection<int, list<T>>
      */
     public function chunk(int ...$sizes): Collection;
 }

--- a/src/Contract/Operation/Containsable.php
+++ b/src/Contract/Operation/Containsable.php
@@ -18,9 +18,9 @@ use loophp\collection\Contract\Collection;
 interface Containsable
 {
     /**
-     * @param T ...$value
+     * @param T ...$values
      *
-     * @return \loophp\collection\Collection<int, bool>
+     * @return Collection<TKey, bool>
      */
-    public function contains(...$value): Collection;
+    public function contains(...$values): Collection;
 }

--- a/src/Contract/Operation/Currentable.php
+++ b/src/Contract/Operation/Currentable.php
@@ -16,7 +16,7 @@ namespace loophp\collection\Contract\Operation;
 interface Currentable
 {
     /**
-     * @return T
+     * @return T|null
      */
     public function current(int $index = 0);
 }

--- a/src/Contract/Operation/Pipeable.php
+++ b/src/Contract/Operation/Pipeable.php
@@ -20,9 +20,9 @@ use loophp\collection\Contract\Collection;
 interface Pipeable
 {
     /**
-     * @param callable(Iterator<TKey, T>): Generator<TKey, T> ...$callables
+     * @param callable(Iterator<TKey, T>): Generator<TKey, T> ...$callbacks
      *
      * @return \loophp\collection\Collection<TKey, T>
      */
-    public function pipe(callable ...$callables): Collection;
+    public function pipe(callable ...$callbacks): Collection;
 }

--- a/src/Operation/Contains.php
+++ b/src/Operation/Contains.php
@@ -20,7 +20,7 @@ use Iterator;
 final class Contains extends AbstractOperation
 {
     /**
-     * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<int, bool>
+     * @return Closure(T ...$values): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
@@ -28,7 +28,7 @@ final class Contains extends AbstractOperation
             /**
              * @param T ...$values
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+             * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
              */
             static function (...$values): Closure {
                 $callback =
@@ -41,7 +41,7 @@ final class Contains extends AbstractOperation
                          */
                         static fn ($right): bool => $left === $right;
 
-                /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $matchOne */
+                /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $matchOne */
                 $matchOne = MatchOne::of()(static fn (): bool => true)(...array_map($callback, $values));
 
                 // Point free style.

--- a/src/Operation/Current.php
+++ b/src/Operation/Current.php
@@ -20,7 +20,7 @@ use Iterator;
 final class Current extends AbstractOperation
 {
     /**
-     * @return Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(int $index): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {

--- a/tests/static-analysis/append.php
+++ b/tests/static-analysis/append.php
@@ -15,25 +15,25 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 /**
  * @param CollectionInterface<int, int> $collection
  */
-function appendT_checkList(CollectionInterface $collection): void
+function append_checkList(CollectionInterface $collection): void
 {
 }
 /**
  * @param CollectionInterface<int, array<string, int>> $collection
  */
-function appendT_checkListWithMap(CollectionInterface $collection): void
+function append_checkListWithMap(CollectionInterface $collection): void
 {
 }
 /**
  * @param CollectionInterface<string, int> $collection
  */
-function appendT_checkMap(CollectionInterface $collection): void
+function append_checkMap(CollectionInterface $collection): void
 {
 }
 /**
  * @param CollectionInterface<int|string, int|string> $collection
  */
-function appendT_checkMixed(CollectionInterface $collection): void
+function append_checkMixed(CollectionInterface $collection): void
 {
 }
 
@@ -44,12 +44,12 @@ function appendT_checkMixed(CollectionInterface $collection): void
 // multiple parameters passed too append() as potentially part of a union type.
 
 //## SUCCESS ###
-appendT_checkList(Collection::empty()->append(1));
-appendT_checkList(Collection::empty()->append(1, 2));
-appendT_checkList(Collection::empty()->append(...[1, 2]));
-appendT_checkList(Collection::fromIterable([5])->append(2));
-appendT_checkList(Collection::fromIterable([5])->append(1, 2));
-appendT_checkList(Collection::fromIterable([5])->append(...[1, 2]));
+append_checkList(Collection::empty()->append(1));
+append_checkList(Collection::empty()->append(1, 2));
+append_checkList(Collection::empty()->append(...[1, 2]));
+append_checkList(Collection::fromIterable([5])->append(2));
+append_checkList(Collection::fromIterable([5])->append(1, 2));
+append_checkList(Collection::fromIterable([5])->append(...[1, 2]));
 
 // Analysers sometime need to know the type of the first item in the collection or the appended one
 // otherwise they might narrow it down too much, i.e. only allow array{foo: int} or array{bar: 2}
@@ -57,29 +57,29 @@ appendT_checkList(Collection::fromIterable([5])->append(...[1, 2]));
 $foo = ['foo' => 1];
 /** @var array<string, int> $bar */
 $bar = ['bar' => 2];
-appendT_checkListWithMap(Collection::empty()->append($foo));
-appendT_checkListWithMap(Collection::empty()->append($foo, ['bar' => 2]));
-appendT_checkListWithMap(Collection::empty()->append(...[$foo, $bar]));
-appendT_checkListWithMap(Collection::fromIterable([1 => $foo])->append($bar));
+append_checkListWithMap(Collection::empty()->append($foo));
+append_checkListWithMap(Collection::empty()->append($foo, ['bar' => 2]));
+append_checkListWithMap(Collection::empty()->append(...[$foo, $bar]));
+append_checkListWithMap(Collection::fromIterable([1 => $foo])->append($bar));
 
 // These should work but they don't due to the way analysers interpret empty()
 // or variadic parameters of different types passed to append()
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-appendT_checkMixed(Collection::empty()->append(1, '2'));
+append_checkMixed(Collection::empty()->append(1, '2'));
 /** @psalm-suppress InvalidArgument */
-appendT_checkMixed(Collection::empty()->append(...[1, '2']));
+append_checkMixed(Collection::empty()->append(...[1, '2']));
 /** @phpstan-ignore-next-line */
-appendT_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1, '3'));
+append_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1, '3'));
 
 //## VALID FAILURE ###
-appendT_checkList(Collection::empty()->append(1, 'foo')); // @phpstan-ignore-line
-appendT_checkList(Collection::fromIterable([5])->append('foo')); // @phpstan-ignore-line
-appendT_checkList(Collection::fromIterable([5])->append('foo', 1)); // @phpstan-ignore-line
+append_checkList(Collection::empty()->append(1, 'foo')); // @phpstan-ignore-line
+append_checkList(Collection::fromIterable([5])->append('foo')); // @phpstan-ignore-line
+append_checkList(Collection::fromIterable([5])->append('foo', 1)); // @phpstan-ignore-line
 
 /** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
-appendT_checkListWithMap(Collection::empty()->append($foo, ['bar' => 'baz']));
+append_checkListWithMap(Collection::empty()->append($foo, ['bar' => 'baz']));
 /** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
-appendT_checkListWithMap(Collection::fromIterable([1 => $foo])->append(['bar' => 'baz']));
+append_checkListWithMap(Collection::fromIterable([1 => $foo])->append(['bar' => 'baz']));
 
 /**
  * Append will transform any Collection<string, int> into Collection<int|TKey, int>.
@@ -87,11 +87,11 @@ appendT_checkListWithMap(Collection::fromIterable([1 => $foo])->append(['bar' =>
  * @psalm-suppress InvalidScalarArgument
  * @phpstan-ignore-next-line
  */
-appendT_checkMap(Collection::fromIterable($foo)->append(3));
+append_checkMap(Collection::fromIterable($foo)->append(3));
 
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-appendT_checkMixed(Collection::empty()->append(1, [3]));
+append_checkMixed(Collection::empty()->append(1, [3]));
 /** @psalm-suppress InvalidArgument */
-appendT_checkMixed(Collection::empty()->append(...[1, [3]]));
+append_checkMixed(Collection::empty()->append(...[1, [3]]));
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-appendT_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1, ['3']));
+append_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1, ['3']));

--- a/tests/static-analysis/apply.php
+++ b/tests/static-analysis/apply.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function apply_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function apply_checkMap(CollectionInterface $collection): void
+{
+}
+
+$echoCallbackTrue = static function (string $item): bool {
+    echo $item;
+
+    return true;
+};
+$echoCallbackFalse = static function (string $item): bool {
+    echo $item;
+
+    return false;
+};
+
+apply_checkList(Collection::fromIterable(['foo', 'bar'])->apply($echoCallbackTrue));
+apply_checkList(Collection::fromIterable(['foo', 'bar'])->apply($echoCallbackFalse));
+apply_checkList(Collection::fromIterable(['foo', 'bar'])->apply($echoCallbackTrue, $echoCallbackFalse));
+
+$echoCallbackTrue = static function (string $item, string $key): bool {
+    echo $item, $key;
+
+    return true;
+};
+$echoCallbackFalse = static function (string $item, string $key): bool {
+    echo $item, $key;
+
+    return false;
+};
+
+apply_checkMap(Collection::fromIterable(['foo' => 'bar'])->apply($echoCallbackTrue));
+apply_checkMap(Collection::fromIterable(['foo' => 'bar'])->apply($echoCallbackFalse));
+apply_checkMap(Collection::fromIterable(['foo' => 'bar'])->apply($echoCallbackTrue, $echoCallbackFalse));

--- a/tests/static-analysis/chunk.php
+++ b/tests/static-analysis/chunk.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, list<int>> $collection
+ */
+function chunk_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, list<string>> $collection
+ */
+function chunk_checkMap(CollectionInterface $collection): void
+{
+}
+
+chunk_checkList(Collection::fromIterable(range(0, 6))->chunk(1));
+chunk_checkList(Collection::fromIterable(range(0, 6))->chunk(1, 2));
+
+// These should work but Psalm restricts type to list<'baz'|'taz'>
+/** @psalm-suppress InvalidArgument */
+chunk_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->chunk(1));
+/** @psalm-suppress InvalidArgument */
+chunk_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->chunk(0, 1));

--- a/tests/static-analysis/contains.php
+++ b/tests/static-analysis/contains.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, bool> $collection
+ */
+function contains_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, bool> $collection
+ */
+function contains_checkMap(CollectionInterface $collection): void
+{
+}
+function contains_checkBool(bool $value): void
+{
+}
+
+contains_checkList(Collection::fromIterable([1, 2, 3])->contains(2));
+contains_checkList(Collection::fromIterable(range(1, 3))->contains(2, 4));
+
+contains_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar'));
+/** @psalm-suppress InvalidArgument -> Psalm is smart and knows that 'abc' cannot be in there */
+contains_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar', 'abc'));
+
+// VALID failures below -> `current` can return `NULL` if the collection is empty
+
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+contains_checkBool(Collection::fromIterable([1, 2, 3])->contains(2)->current());
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+contains_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar')->current());

--- a/tests/static-analysis/contains.php
+++ b/tests/static-analysis/contains.php
@@ -41,3 +41,7 @@ contains_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->co
 contains_checkBool(Collection::fromIterable([1, 2, 3])->contains(2)->current());
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
 contains_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar')->current());
+
+// explicit check is needed for PHPStan because the value is of type `bool|null`
+if (true === Collection::fromIterable([1, 2, 3])->contains(2)->current()) {
+}

--- a/tests/static-analysis/count.php
+++ b/tests/static-analysis/count.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+function count_check(int $count): void
+{
+}
+
+count_check(Collection::fromIterable(range(0, 6))->count());

--- a/tests/static-analysis/current.php
+++ b/tests/static-analysis/current.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+function current_checkNullable(?int $nullable): void
+{
+}
+function current_checkNonNullable(int $nonNullable): void
+{
+}
+
+current_checkNullable(Collection::fromIterable(range(0, 6))->current());
+current_checkNullable(Collection::empty()->current());
+
+// VALID failures because `current` can return `NULL` when the collection is empty
+
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line  */
+current_checkNonNullable(Collection::fromIterable(range(0, 6))->current());
+/** @psalm-suppress NullArgument PHPStan is lost here, type inference for `empty` is not as good as Psalm */
+current_checkNonNullable(Collection::empty()->current());


### PR DESCRIPTION
This PR adds more static analysis checks for commonly-used methods, and fixes a few type hints in the process.

- [x] apply
- [x] chunk
- [x] contains
- [x] count
- [x] current