### PR TITLE
Operation Interfaces return Collection Interface

### DIFF
--- a/src/Contract/Operation/Associateable.php
+++ b/src/Contract/Operation/Associateable.php
@@ -22,7 +22,7 @@ interface Associateable
      * @param null|callable(TKey, TKey, T, Iterator<TKey, T>):(T|TKey) $callbackForKeys
      * @param null|callable(T, TKey, T, Iterator<TKey, T>):(T|TKey) $callbackForValues
      *
-     * @return \loophp\collection\Collection<T|TKey, T|TKey>
+     * @return Collection<T|TKey, T|TKey>
      */
     public function associate(?callable $callbackForKeys = null, ?callable $callbackForValues = null): Collection;
 }

--- a/src/Contract/Operation/AsyncMapable.php
+++ b/src/Contract/Operation/AsyncMapable.php
@@ -20,7 +20,7 @@ interface AsyncMapable
     /**
      * Asynchronously apply callbacks to a collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function asyncMap(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Cacheable.php
+++ b/src/Contract/Operation/Cacheable.php
@@ -19,7 +19,7 @@ use Psr\Cache\CacheItemPoolInterface;
 interface Cacheable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function cache(?CacheItemPoolInterface $cache = null): Collection;
 }

--- a/src/Contract/Operation/Coalesceable.php
+++ b/src/Contract/Operation/Coalesceable.php
@@ -20,7 +20,7 @@ interface Coalesceable
     /**
      * Return the first non-nullsy value of the collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function coalesce(): Collection;
 }

--- a/src/Contract/Operation/Collapseable.php
+++ b/src/Contract/Operation/Collapseable.php
@@ -20,7 +20,7 @@ interface Collapseable
     /**
      * Collapse a collection of items into a simple flat collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function collapse(): Collection;
 }

--- a/src/Contract/Operation/Columnable.php
+++ b/src/Contract/Operation/Columnable.php
@@ -22,7 +22,7 @@ interface Columnable
      *
      * @param int|string $column
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function column($column): Collection;
 }

--- a/src/Contract/Operation/Combinateable.php
+++ b/src/Contract/Operation/Combinateable.php
@@ -23,7 +23,7 @@ interface Combinateable
      * @param int $length
      *   The length.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function combinate(?int $length = null): Collection;
 }

--- a/src/Contract/Operation/Combineable.php
+++ b/src/Contract/Operation/Combineable.php
@@ -22,7 +22,7 @@ interface Combineable
      *
      * @param mixed ...$keys
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function combine(...$keys): Collection;
 }

--- a/src/Contract/Operation/Compactable.php
+++ b/src/Contract/Operation/Compactable.php
@@ -22,7 +22,7 @@ interface Compactable
      *
      * @param T ...$values
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function compact(...$values): Collection;
 }

--- a/src/Contract/Operation/Cycleable.php
+++ b/src/Contract/Operation/Cycleable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Cycleable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function cycle(): Collection;
 }

--- a/src/Contract/Operation/Diffable.php
+++ b/src/Contract/Operation/Diffable.php
@@ -20,7 +20,7 @@ interface Diffable
     /**
      * @param mixed ...$values
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function diff(...$values): Collection;
 }

--- a/src/Contract/Operation/Diffkeysable.php
+++ b/src/Contract/Operation/Diffkeysable.php
@@ -20,7 +20,7 @@ interface Diffkeysable
     /**
      * @param mixed ...$values
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function diffKeys(...$values): Collection;
 }

--- a/src/Contract/Operation/Distinctable.php
+++ b/src/Contract/Operation/Distinctable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Distinctable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function distinct(): Collection;
 }

--- a/src/Contract/Operation/DropWhileable.php
+++ b/src/Contract/Operation/DropWhileable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface DropWhileable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function dropWhile(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Dropable.php
+++ b/src/Contract/Operation/Dropable.php
@@ -22,7 +22,7 @@ interface Dropable
      *
      * @param int ...$counts
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function drop(int ...$counts): Collection;
 }

--- a/src/Contract/Operation/Dumpable.php
+++ b/src/Contract/Operation/Dumpable.php
@@ -19,7 +19,7 @@ use loophp\collection\Contract\Collection;
 interface Dumpable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function dump(string $name = '', int $size = 1, ?Closure $closure = null): Collection;
 }

--- a/src/Contract/Operation/Duplicateable.php
+++ b/src/Contract/Operation/Duplicateable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Duplicateable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function duplicate(): Collection;
 }

--- a/src/Contract/Operation/Everyable.php
+++ b/src/Contract/Operation/Everyable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Everyable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, bool>
+     * @return Collection<TKey, bool>
      */
     public function every(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Explodeable.php
+++ b/src/Contract/Operation/Explodeable.php
@@ -22,7 +22,7 @@ interface Explodeable
      *
      * @param mixed ...$explodes
      *
-     * @return \loophp\collection\Collection<int, list<T>>
+     * @return Collection<int, list<T>>
      */
     public function explode(...$explodes): Collection;
 }

--- a/src/Contract/Operation/Falsyable.php
+++ b/src/Contract/Operation/Falsyable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Falsyable
 {
     /**
-     * @return \loophp\collection\Collection<int, bool>
+     * @return Collection<int, bool>
      */
     public function falsy(): Collection;
 }

--- a/src/Contract/Operation/Filterable.php
+++ b/src/Contract/Operation/Filterable.php
@@ -22,7 +22,7 @@ interface Filterable
      *
      * @param callable ...$callbacks
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function filter(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Firstable.php
+++ b/src/Contract/Operation/Firstable.php
@@ -20,7 +20,7 @@ interface Firstable
     /**
      * Get the first item from the collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function first(): Collection;
 }

--- a/src/Contract/Operation/Flattenable.php
+++ b/src/Contract/Operation/Flattenable.php
@@ -22,7 +22,7 @@ interface Flattenable
     /**
      * Flatten a collection of items into a simple flat collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function flatten(int $depth = PHP_INT_MAX): Collection;
 }

--- a/src/Contract/Operation/Flipable.php
+++ b/src/Contract/Operation/Flipable.php
@@ -20,7 +20,7 @@ interface Flipable
     /**
      * Flip keys and items in a collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function flip(): Collection;
 }

--- a/src/Contract/Operation/FoldLeft1able.php
+++ b/src/Contract/Operation/FoldLeft1able.php
@@ -21,7 +21,7 @@ interface FoldLeft1able
     /**
      * @param callable(T, T, TKey, Iterator<TKey, T>): T $callback
      *
-     * @return \loophp\collection\Collection<TKey, T|null>
+     * @return Collection<TKey, T|null>
      */
     public function foldLeft1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/FoldLeftable.php
+++ b/src/Contract/Operation/FoldLeftable.php
@@ -24,7 +24,7 @@ interface FoldLeftable
      * @param callable(T, T, TKey, Iterator<TKey, T>): T $callback
      * @param T|null $initial
      *
-     * @return \loophp\collection\Collection<TKey, T|null>
+     * @return Collection<TKey, T|null>
      */
     public function foldLeft(callable $callback, $initial = null): Collection;
 }

--- a/src/Contract/Operation/FoldRight1able.php
+++ b/src/Contract/Operation/FoldRight1able.php
@@ -21,7 +21,7 @@ interface FoldRight1able
     /**
      * @param callable(T, T, TKey, Iterator<TKey, T>): T $callback
      *
-     * @return \loophp\collection\Collection<TKey, T|null>
+     * @return Collection<TKey, T|null>
      */
     public function foldRight1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/FoldRightable.php
+++ b/src/Contract/Operation/FoldRightable.php
@@ -24,7 +24,7 @@ interface FoldRightable
      * @param callable(T, T, TKey, Iterator<TKey, T>): T $callback
      * @param T|null $initial
      *
-     * @return \loophp\collection\Collection<TKey, T|null>
+     * @return Collection<TKey, T|null>
      */
     public function foldRight(callable $callback, $initial = null): Collection;
 }

--- a/src/Contract/Operation/Forgetable.php
+++ b/src/Contract/Operation/Forgetable.php
@@ -22,7 +22,7 @@ interface Forgetable
      *
      * @param mixed ...$keys
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function forget(...$keys): Collection;
 }

--- a/src/Contract/Operation/Frequencyable.php
+++ b/src/Contract/Operation/Frequencyable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Frequencyable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function frequency(): Collection;
 }

--- a/src/Contract/Operation/Getable.php
+++ b/src/Contract/Operation/Getable.php
@@ -23,7 +23,7 @@ interface Getable
      * @param TKey $key
      * @param T|null $default
      *
-     * @return \loophp\collection\Collection<TKey, T|null>
+     * @return Collection<TKey, T|null>
      */
     public function get($key, $default = null): Collection;
 }

--- a/src/Contract/Operation/GroupByable.php
+++ b/src/Contract/Operation/GroupByable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface GroupByable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function groupBy(?callable $callable = null): Collection;
 }

--- a/src/Contract/Operation/Groupable.php
+++ b/src/Contract/Operation/Groupable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Groupable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function group(): Collection;
 }

--- a/src/Contract/Operation/Hasable.php
+++ b/src/Contract/Operation/Hasable.php
@@ -21,7 +21,7 @@ interface Hasable
     /**
      * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
      *
-     * @return \loophp\collection\Collection<int, bool>
+     * @return Collection<int, bool>
      */
     public function has(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Headable.php
+++ b/src/Contract/Operation/Headable.php
@@ -20,7 +20,7 @@ interface Headable
     /**
      * Get the first item from the collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function head(): Collection;
 }

--- a/src/Contract/Operation/IfThenElseable.php
+++ b/src/Contract/Operation/IfThenElseable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface IfThenElseable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function ifThenElse(callable $condition, callable $then, ?callable $else = null): Collection;
 }

--- a/src/Contract/Operation/Implodeable.php
+++ b/src/Contract/Operation/Implodeable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Implodeable
 {
     /**
-     * @return \loophp\collection\Collection<int, string>
+     * @return Collection<int, string>
      */
     public function implode(string $glue = ''): Collection;
 }

--- a/src/Contract/Operation/Initable.php
+++ b/src/Contract/Operation/Initable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Initable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function init(): Collection;
 }

--- a/src/Contract/Operation/Initsable.php
+++ b/src/Contract/Operation/Initsable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Initsable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function inits(): Collection;
 }

--- a/src/Contract/Operation/Intersectable.php
+++ b/src/Contract/Operation/Intersectable.php
@@ -20,7 +20,7 @@ interface Intersectable
     /**
      * @param mixed ...$values
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function intersect(...$values): Collection;
 }

--- a/src/Contract/Operation/Intersectkeysable.php
+++ b/src/Contract/Operation/Intersectkeysable.php
@@ -20,7 +20,7 @@ interface Intersectkeysable
     /**
      * @param mixed ...$values
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function intersectKeys(...$values): Collection;
 }

--- a/src/Contract/Operation/Intersperseable.php
+++ b/src/Contract/Operation/Intersperseable.php
@@ -23,7 +23,7 @@ interface Intersperseable
      *
      * @param mixed $element
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function intersperse($element, int $every = 1, int $startAt = 0): Collection;
 }

--- a/src/Contract/Operation/Keysable.php
+++ b/src/Contract/Operation/Keysable.php
@@ -20,7 +20,7 @@ interface Keysable
     /**
      * Get the keys of the items.
      *
-     * @return \loophp\collection\Collection<int, TKey>
+     * @return Collection<int, TKey>
      */
     public function keys(): Collection;
 }

--- a/src/Contract/Operation/Lastable.php
+++ b/src/Contract/Operation/Lastable.php
@@ -20,7 +20,7 @@ interface Lastable
     /**
      * Get the last item from the collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function last(): Collection;
 }

--- a/src/Contract/Operation/Limitable.php
+++ b/src/Contract/Operation/Limitable.php
@@ -20,7 +20,7 @@ interface Limitable
     /**
      * Limit the amount of items in the collection to...
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function limit(int $count = -1, int $offset = 0): Collection;
 }

--- a/src/Contract/Operation/Linesable.php
+++ b/src/Contract/Operation/Linesable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Linesable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function lines(): Collection;
 }

--- a/src/Contract/Operation/Mapable.php
+++ b/src/Contract/Operation/Mapable.php
@@ -24,7 +24,7 @@ interface Mapable
      *
      * @param callable(T, TKey, Iterator<TKey, T>): V ...$callbacks
      *
-     * @return \loophp\collection\Collection<TKey, V>
+     * @return Collection<TKey, V>
      */
     public function map(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Matchable.php
+++ b/src/Contract/Operation/Matchable.php
@@ -22,7 +22,7 @@ interface Matchable
      * @param callable(T, TKey, Iterator<TKey, T>): bool $callback
      * @param null|callable(T, TKey, Iterator<TKey, T>): T $matcher
      *
-     * @return \loophp\collection\Collection<int, bool>
+     * @return Collection<int, bool>
      */
     public function match(callable $callback, ?callable $matcher = null): Collection;
 }

--- a/src/Contract/Operation/Mergeable.php
+++ b/src/Contract/Operation/Mergeable.php
@@ -22,7 +22,7 @@ interface Mergeable
      *
      * @param iterable<mixed> ...$sources
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function merge(iterable ...$sources): Collection;
 }

--- a/src/Contract/Operation/Normalizeable.php
+++ b/src/Contract/Operation/Normalizeable.php
@@ -20,7 +20,7 @@ interface Normalizeable
     /**
      * Replace, reorder and use numeric keys on a collection.
      *
-     * @return \loophp\collection\Collection<int, T>
+     * @return Collection<int, T>
      */
     public function normalize(): Collection;
 }

--- a/src/Contract/Operation/Nthable.php
+++ b/src/Contract/Operation/Nthable.php
@@ -20,7 +20,7 @@ interface Nthable
     /**
      * Get every n-th element of a collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function nth(int $step, int $offset = 0): Collection;
 }

--- a/src/Contract/Operation/Nullsyable.php
+++ b/src/Contract/Operation/Nullsyable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Nullsyable
 {
     /**
-     * @return \loophp\collection\Collection<int, bool>
+     * @return Collection<int, bool>
      */
     public function nullsy(): Collection;
 }

--- a/src/Contract/Operation/Packable.php
+++ b/src/Contract/Operation/Packable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Packable
 {
     /**
-     * @return \loophp\collection\Collection<int, array{0: TKey, 1: T}>
+     * @return Collection<int, array{0: TKey, 1: T}>
      */
     public function pack(): Collection;
 }

--- a/src/Contract/Operation/Padable.php
+++ b/src/Contract/Operation/Padable.php
@@ -22,7 +22,7 @@ interface Padable
      *
      * @param mixed $value
      *
-     * @return \loophp\collection\Collection<int|TKey, T>
+     * @return Collection<int|TKey, T>
      */
     public function pad(int $size, $value): Collection;
 }

--- a/src/Contract/Operation/Pairable.php
+++ b/src/Contract/Operation/Pairable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Pairable
 {
     /**
-     * @return \loophp\collection\Collection<T|TKey, T>
+     * @return Collection<T|TKey, T>
      */
     public function pair(): Collection;
 }

--- a/src/Contract/Operation/Partitionable.php
+++ b/src/Contract/Operation/Partitionable.php
@@ -20,7 +20,7 @@ interface Partitionable
     /**
      * @param callable(T, TKey):bool ...$callbacks
      *
-     * @return \loophp\collection\Collection<int, array<int, array{0: TKey, 1: T}>>
+     * @return Collection<int, array<int, array{0: TKey, 1: T}>>
      */
     public function partition(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Permutateable.php
+++ b/src/Contract/Operation/Permutateable.php
@@ -20,7 +20,7 @@ interface Permutateable
     /**
      * Find all the permutations of a collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function permutate(): Collection;
 }

--- a/src/Contract/Operation/Pipeable.php
+++ b/src/Contract/Operation/Pipeable.php
@@ -22,7 +22,7 @@ interface Pipeable
     /**
      * @param callable(Iterator<TKey, T>): Generator<TKey, T> ...$callbacks
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function pipe(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Pluckable.php
+++ b/src/Contract/Operation/Pluckable.php
@@ -23,7 +23,7 @@ interface Pluckable
      * @param array<int, string>|array-key $pluck
      * @param mixed|null $default
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function pluck($pluck, $default = null): Collection;
 }

--- a/src/Contract/Operation/Prependable.php
+++ b/src/Contract/Operation/Prependable.php
@@ -22,7 +22,7 @@ interface Prependable
      *
      * @param mixed ...$items
      *
-     * @return \loophp\collection\Collection<int|TKey, T>
+     * @return Collection<int|TKey, T>
      */
     public function prepend(...$items): Collection;
 }

--- a/src/Contract/Operation/Productable.php
+++ b/src/Contract/Operation/Productable.php
@@ -22,7 +22,7 @@ interface Productable
      *
      * @param iterable<mixed> ...$iterables
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function product(iterable ...$iterables): Collection;
 }

--- a/src/Contract/Operation/RSampleable.php
+++ b/src/Contract/Operation/RSampleable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface RSampleable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function rsample(float $probability): Collection;
 }

--- a/src/Contract/Operation/Randomable.php
+++ b/src/Contract/Operation/Randomable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Randomable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function random(int $size = 1): Collection;
 }

--- a/src/Contract/Operation/Rangeable.php
+++ b/src/Contract/Operation/Rangeable.php
@@ -22,7 +22,7 @@ interface Rangeable
      * @template TKey
      * @template T
      *
-     * @return \loophp\collection\Collection<int, float>
+     * @return Collection<int, float>
      */
     public static function range(float $start = 0.0, float $end = INF, float $step = 1.0): Collection;
 }

--- a/src/Contract/Operation/Reductionable.php
+++ b/src/Contract/Operation/Reductionable.php
@@ -22,7 +22,7 @@ interface Reductionable
      *
      * @param mixed $initial
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function reduction(callable $callback, $initial = null): Collection;
 }

--- a/src/Contract/Operation/Reverseable.php
+++ b/src/Contract/Operation/Reverseable.php
@@ -20,7 +20,7 @@ interface Reverseable
     /**
      * Reverse order items of a collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function reverse(): Collection;
 }

--- a/src/Contract/Operation/Scaleable.php
+++ b/src/Contract/Operation/Scaleable.php
@@ -20,7 +20,7 @@ interface Scaleable
     /**
      * Scale/normalize values.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function scale(
         float $lowerBound,

--- a/src/Contract/Operation/ScanLeft1able.php
+++ b/src/Contract/Operation/ScanLeft1able.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface ScanLeft1able
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function scanLeft1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/ScanLeftable.php
+++ b/src/Contract/Operation/ScanLeftable.php
@@ -20,7 +20,7 @@ interface ScanLeftable
     /**
      * @param T|null $initial
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function scanLeft(callable $callback, $initial = null): Collection;
 }

--- a/src/Contract/Operation/ScanRight1able.php
+++ b/src/Contract/Operation/ScanRight1able.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface ScanRight1able
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function scanRight1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/ScanRightable.php
+++ b/src/Contract/Operation/ScanRightable.php
@@ -20,7 +20,7 @@ interface ScanRightable
     /**
      * @param T|null $initial
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function scanRight(callable $callback, $initial = null): Collection;
 }

--- a/src/Contract/Operation/Shuffleable.php
+++ b/src/Contract/Operation/Shuffleable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Shuffleable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function shuffle(): Collection;
 }

--- a/src/Contract/Operation/Sinceable.php
+++ b/src/Contract/Operation/Sinceable.php
@@ -20,7 +20,7 @@ interface Sinceable
     /**
      * @param callable(T, TKey):bool ...$callbacks
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function since(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Sliceable.php
+++ b/src/Contract/Operation/Sliceable.php
@@ -20,7 +20,7 @@ interface Sliceable
     /**
      * Get a slice of a collection.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function slice(int $offset, int $length = -1): Collection;
 }

--- a/src/Contract/Operation/Sortable.php
+++ b/src/Contract/Operation/Sortable.php
@@ -24,7 +24,7 @@ interface Sortable
     /**
      * Sort a collection using a callback.
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function sort(int $type = Sortable::BY_VALUES, ?callable $callback = null): Collection;
 }

--- a/src/Contract/Operation/Spanable.php
+++ b/src/Contract/Operation/Spanable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Spanable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function span(callable $callback): Collection;
 }

--- a/src/Contract/Operation/Splitable.php
+++ b/src/Contract/Operation/Splitable.php
@@ -28,7 +28,7 @@ interface Splitable
      *
      * @param callable ...$callbacks
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function split(int $type = Splitable::BEFORE, callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Squashable.php
+++ b/src/Contract/Operation/Squashable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Squashable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function squash(): Collection;
 }

--- a/src/Contract/Operation/Tailable.php
+++ b/src/Contract/Operation/Tailable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Tailable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function tail(): Collection;
 }

--- a/src/Contract/Operation/Tailsable.php
+++ b/src/Contract/Operation/Tailsable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Tailsable
 {
     /**
-     * @return \loophp\collection\Collection<int, list<T>>
+     * @return Collection<int, list<T>>
      */
     public function tails(): Collection;
 }

--- a/src/Contract/Operation/TakeWhileable.php
+++ b/src/Contract/Operation/TakeWhileable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface TakeWhileable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function takeWhile(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Timesable.php
+++ b/src/Contract/Operation/Timesable.php
@@ -22,7 +22,7 @@ interface Timesable
      *
      * @param null|callable(int): (int|T) $callback
      *
-     * @return \loophp\collection\Collection<int, int|T>
+     * @return Collection<int, int|T>
      */
     public static function times(int $number = 0, ?callable $callback = null): Collection;
 }

--- a/src/Contract/Operation/Transposeable.php
+++ b/src/Contract/Operation/Transposeable.php
@@ -20,7 +20,7 @@ interface Transposeable
     /**
      * Matrix transposition.
      *
-     * @return \loophp\collection\Collection<TKey, list<T>>
+     * @return Collection<TKey, list<T>>
      */
     public function transpose(): Collection;
 }

--- a/src/Contract/Operation/Truthyable.php
+++ b/src/Contract/Operation/Truthyable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Truthyable
 {
     /**
-     * @return \loophp\collection\Collection<int, bool>
+     * @return Collection<int, bool>
      */
     public function truthy(): Collection;
 }

--- a/src/Contract/Operation/Unfoldable.php
+++ b/src/Contract/Operation/Unfoldable.php
@@ -21,7 +21,7 @@ interface Unfoldable
      * @param callable(mixed|T...): (mixed|array<TKey, T>) $callback
      * @param T ...$parameters
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public static function unfold(callable $callback, ...$parameters): Collection;
 }

--- a/src/Contract/Operation/Unlinesable.php
+++ b/src/Contract/Operation/Unlinesable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Unlinesable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, string>
+     * @return Collection<TKey, string>
      */
     public function unlines(): Collection;
 }

--- a/src/Contract/Operation/Unpackable.php
+++ b/src/Contract/Operation/Unpackable.php
@@ -21,7 +21,7 @@ use loophp\collection\Contract\Collection;
 interface Unpackable
 {
     /**
-     * @return \loophp\collection\Collection<NewTKey, NewT>
+     * @return Collection<NewTKey, NewT>
      */
     public function unpack(): Collection;
 }

--- a/src/Contract/Operation/Unpairable.php
+++ b/src/Contract/Operation/Unpairable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Unpairable
 {
     /**
-     * @return \loophp\collection\Collection<int, array{0: TKey, 1: T}>
+     * @return Collection<int, array{0: TKey, 1: T}>
      */
     public function unpair(): Collection;
 }

--- a/src/Contract/Operation/Untilable.php
+++ b/src/Contract/Operation/Untilable.php
@@ -20,7 +20,7 @@ interface Untilable
     /**
      * @param callable(T, TKey):bool ...$callbacks
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function until(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/Unwindowable.php
+++ b/src/Contract/Operation/Unwindowable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Unwindowable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function unwindow(): Collection;
 }

--- a/src/Contract/Operation/Unwordsable.php
+++ b/src/Contract/Operation/Unwordsable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Unwordsable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, string>
+     * @return Collection<TKey, string>
      */
     public function unwords(): Collection;
 }

--- a/src/Contract/Operation/Unwrapable.php
+++ b/src/Contract/Operation/Unwrapable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Unwrapable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function unwrap(): Collection;
 }

--- a/src/Contract/Operation/Unzipable.php
+++ b/src/Contract/Operation/Unzipable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Unzipable
 {
     /**
-     * @return \loophp\collection\Collection<TKey,T>
+     * @return Collection<TKey,T>
      */
     public function unzip(): Collection;
 }

--- a/src/Contract/Operation/Whenable.php
+++ b/src/Contract/Operation/Whenable.php
@@ -23,7 +23,7 @@ interface Whenable
      * @param callable(Iterator<TKey, T>): iterable<TKey, T> $whenTrue
      * @param callable(Iterator<TKey, T>): iterable<TKey, T> $whenFalse
      *
-     * @return \loophp\collection\Collection<TKey, T>
+     * @return Collection<TKey, T>
      */
     public function when(callable $predicate, callable $whenTrue, ?callable $whenFalse = null): Collection;
 }

--- a/src/Contract/Operation/Windowable.php
+++ b/src/Contract/Operation/Windowable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Windowable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, list<T>|T>
+     * @return Collection<TKey, list<T>|T>
      */
     public function window(int $size): Collection;
 }

--- a/src/Contract/Operation/Wordsable.php
+++ b/src/Contract/Operation/Wordsable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Wordsable
 {
     /**
-     * @return \loophp\collection\Collection<TKey, string>
+     * @return Collection<TKey, string>
      */
     public function words(): Collection;
 }

--- a/src/Contract/Operation/Wrapable.php
+++ b/src/Contract/Operation/Wrapable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Wrapable
 {
     /**
-     * @return \loophp\collection\Collection<int, array<TKey, T>>
+     * @return Collection<int, array<TKey, T>>
      */
     public function wrap(): Collection;
 }

--- a/src/Contract/Operation/Zipable.php
+++ b/src/Contract/Operation/Zipable.php
@@ -22,7 +22,7 @@ interface Zipable
      *
      * @param iterable<mixed> ...$iterables
      *
-     * @return \loophp\collection\Collection<TKey,T>
+     * @return Collection<TKey,T>
      */
     public function zip(iterable ...$iterables): Collection;
 }

--- a/tests/static-analysis/fromFile.php
+++ b/tests/static-analysis/fromFile.php
@@ -13,7 +13,7 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param Collection<int, string> $collection
+ * @param CollectionInterface<int, string> $collection
  */
 function fromFile_check(CollectionInterface $collection): void
 {


### PR DESCRIPTION
This PR corrects the return type on Operation Contracts (Interfaces), which return the Collection Contract (Interface), _not_ the Collection class implementation
