### PR TITLE
Introduce MapN | Deprecate Map With Multiple Callbacks | Static Analysis Checks

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1225,7 +1225,11 @@ Signature: ``Collection::lines();``
 map
 ~~~
 
-Apply one or more supplied callbacks to every item of a collection and use the return value.
+Apply a single callback to every item of a collection and use the return value.
+
+.. warning:: An earlier version of this operation allowed usage with multiple callbacks. This behaviour
+        is deprecated and will be removed in a future major version; ``mapN`` should be used instead, or,
+        alternatively, multiple successive ``map`` calls can achieve the same result.
 
 .. warning:: Keys are preserved, use the ``Collection::normalize`` operation if you want to re-index the keys.
 
@@ -1235,12 +1239,37 @@ Signature: ``Collection::map(callable ...$callbacks);``
 
 .. code-block:: php
 
-    $mapper = static function($value, $key) {
-        return $value * 2;
-    };
+    $square = static fn (int $val): int => $val ** 2;
+    $toString = static fn (int $val): string => (string) $val;
+    $appendBar = static fn (int $val): string => $val . 'bar';
 
-    $collection = Collection::fromIterable(range(1, 5))
-        ->map($mapper); // [2, 4, 6, 8, 10]
+    $collection = Collection::fromIterable(range(1, 3))
+        ->map($square)
+        ->map($toString)
+        ->map($appendBar); // ['1bar', '4bar', '9bar']
+
+mapN
+~~~~
+
+Apply one or more callbacks to every item of a collection and use the return value.
+
+.. tip:: This operation is best used when multiple callbacks need to be applied. If you only want to apply
+        a single callback, ``map`` should be prefered as it benefits from more specific type hints.
+
+.. warning:: Keys are preserved, use the ``Collection::normalize`` operation if you want to re-index the keys.
+
+Interface: `MapNable`_
+
+Signature: ``Collection::mapN(callable ...$callbacks);``
+
+.. code-block:: php
+
+    $square = static fn (int $val): int => $val ** 2;
+    $toString = static fn (int $val): string => (string) $val;
+    $appendBar = static fn (int $val): string => $val . 'bar';
+
+    $collection = Collection::fromIterable(range(1, 3))
+        ->mapN($square, $toString, $appendBar); // ['1bar', '4bar', '9bar']
 
 match
 ~~~~~
@@ -2291,6 +2320,7 @@ Signature: ``Collection::zip(iterable ...$iterables);``
 .. _Limitable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Limitable.php
 .. _Linesable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Linesable.php
 .. _Mapable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Mapable.php
+.. _MapNable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/MapNable.php
 .. _Matchable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Matchable.php
 .. _Mergeable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Mergeable.php
 .. _Normalizeable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Normalizeable.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: docs/pages/code/operations/since.php
 
 		-
-			message: "#^Generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Mapable\\<mixed, mixed\\> in PHPDoc tag @extends does not specify all template types of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Mapable\\: TKey, T, V$#"
-			count: 1
-			path: src/Contract/Collection.php
-
-		-
 			message: "#^Interface loophp\\\\collection\\\\Contract\\\\Collection extends generic interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Partitionable but does not specify its types\\: TKey, T$#"
 			count: 1
 			path: src/Contract/Collection.php

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1866,9 +1866,9 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs(['1', '4', '9']);
 
         $this::fromIterable(range(1, 3))
-            ->map(static fn (int $item): int => $item ** 2)
-            ->map(static fn (int $item): string => (string) $item)
-            ->map(static fn (string $item): string => $item . 'bar')
+            ->mapN(static fn (int $item): int => $item ** 2)
+            ->mapN(static fn (int $item): string => (string) $item)
+            ->mapN(static fn (string $item): string => $item . 'bar')
             ->shouldIterateAs(['1bar', '4bar', '9bar']);
     }
 

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -21,7 +21,6 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Operation;
 use loophp\collection\Operation\AbstractOperation;
 use OutOfBoundsException;
-use PhpSpec\Exception\Example\ErrorException;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\ObjectBehavior;

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -22,11 +22,13 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Operation;
 use loophp\collection\Operation\AbstractOperation;
 use OutOfBoundsException;
+use PhpSpec\Exception\Example\ErrorException;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\ObjectBehavior;
 use stdClass;
 use function gettype;
+use const E_USER_DEPRECATED;
 use const INF;
 use const PHP_EOL;
 use const PHP_VERSION_ID;
@@ -231,6 +233,7 @@ class CollectionSpec extends ObjectBehavior
 
         $this->beConstructedThrough('fromIterable', [['c' => 3, 'b' => 2, 'a' => 1]]);
 
+        // Note this will work in PHP 8 but fails during testing due to: https://github.com/phpspec/phpspec/issues/1375
         if (PHP_VERSION_ID >= 80000) {
             $this
                 ->asyncMap($callback1, $callback2)
@@ -1822,28 +1825,51 @@ class CollectionSpec extends ObjectBehavior
         $input = array_combine(range('A', 'E'), range('A', 'E'));
 
         $this::fromIterable($input)
-            ->map(static function (string $item): string {
-                return $item . $item;
-            })
+            ->map(static fn (string $item): string => $item . $item)
             ->shouldIterateAs(['A' => 'AA', 'B' => 'BB', 'C' => 'CC', 'D' => 'DD', 'E' => 'EE']);
 
-        $callback1 = static function (string $a): string {
-            return $a . $a;
-        };
+        $square = static fn (int $a): int => $a ** 2;
+        $toString = static fn (int $a): string => (string) $a;
+        $appendBar = static fn (string $a): string => $a . 'bar';
 
-        $callback2 = static function (string $a): string {
-            return '[' . $a . ']';
-        };
+        $this::fromIterable(range(1, 3))
+            ->map($square)
+            ->map($toString)
+            ->map($appendBar)
+            ->shouldIterateAs(['1bar', '4bar', '9bar']);
 
-        $this::fromIterable(range('a', 'e'))
-            ->map($callback1, $callback2)
-            ->shouldIterateAs([
-                '[aa]',
-                '[bb]',
-                '[cc]',
-                '[dd]',
-                '[ee]',
-            ]);
+        // Note this will work in PHP 8 but fails during testing due to: https://github.com/phpspec/phpspec/issues/1375
+        if (PHP_VERSION_ID >= 80000) {
+            $this::fromIterable(range(1, 3))
+                ->map($square, $toString)
+                ->shouldThrow(ErrorException::class)->during('all');
+        } else {
+            $this::fromIterable(range(1, 3))
+                ->map($square, $toString)
+                ->shouldIterateAs(['1', '4', '9']);
+        }
+    }
+
+    public function it_can_mapN(): void
+    {
+        $input = array_combine(range('A', 'E'), range('A', 'E'));
+
+        $this::fromIterable($input)
+            ->mapN(static fn (string $item): string => $item . $item)
+            ->shouldIterateAs(['A' => 'AA', 'B' => 'BB', 'C' => 'CC', 'D' => 'DD', 'E' => 'EE']);
+
+        $square = static fn (int $a): int => $a ** 2;
+        $toString = static fn (int $a): string => (string) $a;
+
+        $this::fromIterable(range(1, 3))
+            ->mapN($square, $toString)
+            ->shouldIterateAs(['1', '4', '9']);
+
+        $this::fromIterable(range(1, 3))
+            ->map(static fn (int $item): int => $item ** 2)
+            ->map(static fn (int $item): string => (string) $item)
+            ->map(static fn (string $item): string => $item . 'bar')
+            ->shouldIterateAs(['1bar', '4bar', '9bar']);
     }
 
     public function it_can_match(): void
@@ -3573,6 +3599,16 @@ class CollectionSpec extends ObjectBehavior
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(Collection::class);
+    }
+
+    public function it_shows_deprecation_for_map_multiple_callbacks(): void
+    {
+        $square = static fn (int $a): int => $a ** 2;
+        $toString = static fn (int $a): string => (string) $a;
+
+        $this::fromIterable(range(1, 3))
+            ->map($square, $toString)
+            ->shouldTrigger(E_USER_DEPRECATED)->during('all');
     }
 
     public function let(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -70,6 +70,7 @@ use loophp\collection\Operation\Last;
 use loophp\collection\Operation\Limit;
 use loophp\collection\Operation\Lines;
 use loophp\collection\Operation\Map;
+use loophp\collection\Operation\MapN;
 use loophp\collection\Operation\MatchOne;
 use loophp\collection\Operation\Merge;
 use loophp\collection\Operation\Normalize;
@@ -550,6 +551,11 @@ final class Collection implements CollectionInterface
     public function map(callable ...$callbacks): CollectionInterface
     {
         return new self(Map::of()(...$callbacks), $this->getIterator());
+    }
+
+    public function mapN(callable ...$callbacks): CollectionInterface
+    {
+        return new self(MapN::of()(...$callbacks), $this->getIterator());
     }
 
     public function match(callable $callback, ?callable $matcher = null): CollectionInterface

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -67,6 +67,7 @@ use loophp\collection\Contract\Operation\Lastable;
 use loophp\collection\Contract\Operation\Limitable;
 use loophp\collection\Contract\Operation\Linesable;
 use loophp\collection\Contract\Operation\Mapable;
+use loophp\collection\Contract\Operation\MapNable;
 use loophp\collection\Contract\Operation\Matchable;
 use loophp\collection\Contract\Operation\Mergeable;
 use loophp\collection\Contract\Operation\Normalizeable;
@@ -178,6 +179,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Limitable<TKey, T>
  * @template-extends Linesable<TKey, T>
  * @template-extends Mapable<TKey, T>
+ * @template-extends MapNable<TKey, T>
  * @template-extends Matchable<TKey, T>
  * @template-extends Mergeable<TKey, T>
  * @template-extends Normalizeable<TKey, T>
@@ -286,6 +288,7 @@ interface Collection extends
     Limitable,
     Linesable,
     Mapable,
+    MapNable,
     Matchable,
     Mergeable,
     Normalizeable,

--- a/src/Contract/Operation/MapNable.php
+++ b/src/Contract/Operation/MapNable.php
@@ -16,18 +16,14 @@ use loophp\collection\Contract\Collection;
  * @template TKey
  * @template T
  */
-interface Mapable
+interface MapNable
 {
     /**
      * Apply one or more callbacks to a collection and use the return value.
-     * Usage with multiple callbacks is deprecated and will be removed in a future major version.
-     * Use mapN instead for multiple callbacks.
      *
-     * @template V
+     * @param callable(mixed, mixed, Iterator<TKey, T>): mixed ...$callbacks
      *
-     * @param callable(T, TKey, Iterator<TKey, T>): V ...$callbacks
-     *
-     * @return Collection<TKey, V>
+     * @return Collection<mixed, mixed>
      */
-    public function map(callable ...$callbacks): Collection;
+    public function mapN(callable ...$callbacks): Collection;
 }

--- a/src/Operation/Map.php
+++ b/src/Operation/Map.php
@@ -43,7 +43,7 @@ final class Map extends AbstractOperation
                 static function (Iterator $iterator) use ($callbacks): Generator {
                     if (count($callbacks) > 1) {
                         @trigger_error(
-                            'Using `map` with multiple callbacks is deprecated, and will be removed in a future major version; use `mapN` instead.',
+                            'Using `Map` with multiple callbacks is deprecated, and will be removed in a future major version; use `MapN` instead.',
                             E_USER_DEPRECATED
                         );
                     }

--- a/src/Operation/Map.php
+++ b/src/Operation/Map.php
@@ -12,7 +12,9 @@ namespace loophp\collection\Operation;
 use Closure;
 use Generator;
 use Iterator;
+
 use function count;
+
 use const E_USER_DEPRECATED;
 
 /**

--- a/src/Operation/MapN.php
+++ b/src/Operation/MapN.php
@@ -12,8 +12,6 @@ namespace loophp\collection\Operation;
 use Closure;
 use Generator;
 use Iterator;
-use function count;
-use const E_USER_DEPRECATED;
 
 /**
  * @template TKey
@@ -21,43 +19,36 @@ use const E_USER_DEPRECATED;
  *
  * phpcs:disable Generic.Files.LineLength.TooLong
  */
-final class Map extends AbstractOperation
+final class MapN extends AbstractOperation
 {
     /**
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(mixed, mixed, Iterator<TKey, T>): mixed ...): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T, TKey, Iterator<TKey, T>): T ...$callbacks
+             * @param callable(mixed, mixed, Iterator<TKey, T>): mixed ...$callbacks
              */
             static fn (callable ...$callbacks): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
-                 * @return Generator<TKey, T>
+                 * @return Generator<mixed, mixed>
                  */
                 static function (Iterator $iterator) use ($callbacks): Generator {
-                    if (count($callbacks) > 1) {
-                        @trigger_error(
-                            'Using `map` with multiple callbacks is deprecated, and will be removed in a future major version; use `mapN` instead.',
-                            E_USER_DEPRECATED
-                        );
-                    }
-
                     $callbackFactory =
                         /**
-                         * @param TKey $key
+                         * @param mixed $key
                          *
-                         * @return Closure(T, callable(T, TKey, Iterator<TKey, T>): T): T
+                         * @return Closure(mixed, callable(mixed, mixed, Iterator<TKey, T>): mixed): mixed
                          */
                         static fn ($key): Closure =>
                             /**
-                             * @param T $carry
-                             * @param callable(T, TKey, Iterator<TKey, T>): T $callback
+                             * @param mixed $carry
+                             * @param callable(mixed, mixed, Iterator<TKey, T>): mixed $callback
                              *
-                             * @return T
+                             * @return mixed
                              */
                             static fn ($carry, callable $callback) => $callback($carry, $key, $iterator);
 

--- a/src/Operation/Unpack.php
+++ b/src/Operation/Unpack.php
@@ -50,7 +50,7 @@ final class Unpack extends AbstractOperation
 
         /** @var Closure(Iterator<TKey, T>): Generator<NewTKey, NewT> $pipe */
         $pipe = Pipe::of()(
-            Map::of()($toIterableIterator, Chunk::of()(2)),
+            MapN::of()($toIterableIterator, Chunk::of()(2)),
             Unwrap::of(),
             Associate::of()($callbackForKeys)($callbackForValues)
         );

--- a/tests/static-analysis/map.php
+++ b/tests/static-analysis/map.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function map_checkListInt(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function map_checkListString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function map_checkMapString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, stdClass> $collection
+ */
+function map_checkMapClass(CollectionInterface $collection): void
+{
+}
+
+$square = static fn (int $val): int => $val ** 2;
+$toString = static fn (int $val): string => (string) $val;
+$appendBar = static fn (string $val): string => "{$val}bar";
+$toClass = static function (string $val): stdClass {
+    $class = new stdClass();
+    $class->val = $val;
+
+    return $class;
+};
+
+map_checkListInt(Collection::fromIterable([1, 2, 3])->map($square));
+map_checkListInt(Collection::fromIterable([1, 2, 3])->map($square)->map($square));
+
+map_checkMapClass(Collection::fromIterable(['foo' => 'bar', 'bar' => 'baz'])->map($toClass));
+
+// This should work but static analysers restrict the return type
+// E.g: `numeric&string` or `non-empty-string`
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+map_checkListString(Collection::fromIterable([1, 2, 3])->map($toString));
+/** @psalm-suppress InvalidArgument */
+map_checkMapString(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->map($appendBar));
+/** @psalm-suppress InvalidArgument */
+map_checkListString(Collection::fromIterable(['foo', 'bar'])->map($appendBar));
+/** @psalm-suppress InvalidArgument */
+map_checkListString(Collection::fromIterable([1, 2, 3])->map($square)->map($toString)->map($appendBar));
+
+// VALID failures due to usage with wrong types
+
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+map_checkListInt(Collection::fromIterable(['foo' => 'bar'])->map($square));
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+map_checkListString(Collection::fromIterable(['foo' => 'bar'])->map($square, $toString));
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+map_checkMapString(Collection::fromIterable([1, 2, 3])->map($appendBar));
+/** @psalm-suppress InvalidArgument, InvalidScalarArgument @phpstan-ignore-next-line */
+map_checkMapClass(Collection::fromIterable([1, 2, 3])->map($appendBar, $toClass));
+
+// VALID failures due to usage with multiple callbacks, which cannot be properly typed
+// `mapN` should be used instead for these use cases, which is more lenient due to `mixed` type hints
+
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+map_checkListString(Collection::fromIterable([1, 2, 3])->map($square, $toString));
+
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+map_checkMapClass(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->map($appendBar, $toClass));

--- a/tests/static-analysis/map.php
+++ b/tests/static-analysis/map.php
@@ -39,7 +39,7 @@ function map_checkMapClass(CollectionInterface $collection): void
 
 $square = static fn (int $val): int => $val ** 2;
 $toString = static fn (int $val): string => (string) $val;
-$appendBar = static fn (string $val): string => "{$val}bar";
+$appendBar = static fn (string $val): string => $val . 'bar';
 $toClass = static function (string $val): stdClass {
     $class = new stdClass();
     $class->val = $val;

--- a/tests/static-analysis/mapN.php
+++ b/tests/static-analysis/mapN.php
@@ -39,7 +39,7 @@ function mapN_checkMapClass(CollectionInterface $collection): void
 
 $square = static fn (int $val): int => $val ** 2;
 $toString = static fn (int $val): string => (string) $val;
-$appendBar = static fn (string $val): string => "{$val}bar";
+$appendBar = static fn (string $val): string => $val . 'bar';
 $toClass = static function (string $val): stdClass {
     $class = new stdClass();
     $class->val = $val;

--- a/tests/static-analysis/mapN.php
+++ b/tests/static-analysis/mapN.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function mapN_checkListInt(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function mapN_checkListString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function mapN_checkMapString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, stdClass> $collection
+ */
+function mapN_checkMapClass(CollectionInterface $collection): void
+{
+}
+
+$square = static fn (int $val): int => $val ** 2;
+$toString = static fn (int $val): string => (string) $val;
+$appendBar = static fn (string $val): string => "{$val}bar";
+$toClass = static function (string $val): stdClass {
+    $class = new stdClass();
+    $class->val = $val;
+
+    return $class;
+};
+
+mapN_checkListInt(Collection::fromIterable([1, 2, 3])->mapN($square));
+mapN_checkListString(Collection::fromIterable([1, 2, 3])->mapN($square, $toString));
+
+mapN_checkMapString(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->mapN($appendBar));
+mapN_checkMapClass(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->mapN($appendBar, $toClass));
+
+// Below are INVALID but are allowed by static analysis due to `mixed` usage in `mapN`.
+// This is necessary in order to allow the flexibility that `mapN` requires with multiple callbacks.
+
+mapN_checkListInt(Collection::fromIterable(['foo' => 'bar'])->mapN($square));
+mapN_checkListString(Collection::fromIterable(['foo' => 'bar'])->mapN($square, $toString));
+
+mapN_checkMapString(Collection::fromIterable([1, 2, 3])->mapN($appendBar));
+mapN_checkMapClass(Collection::fromIterable([1, 2, 3])->mapN($appendBar, $toClass));


### PR DESCRIPTION
This PR introduces `MapN` based on the discussions in https://github.com/loophp/collection/pull/77, and deprecates `Map` usage with multiple callbacks.

* [x] `MapN` code (same as `Map` but with more `mixed` type hints)
* [x] Deprecate `Map` with multiple callbacks
* [x] `Map` stays backwards compatible
* [x] Tests
* [x] Static analysis checks
* [x] Documentation

