### PR TITLE
Static Analysis Checks: Common Operations (III)

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -682,9 +682,7 @@ Signature: ``Collection::explode(...$items);``
 
 .. code-block:: php
 
-    $string = 'I am a text.';
-
-    $collection = Collection::fromIterable($string)
+    $collection = Collection::fromString('I am a text.')
         ->explode(' '); // [['I', 'a', 'm', 'a', 't', 'e', 'x', 't', '.']]
 
 falsy

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1762,6 +1762,14 @@ class CollectionSpec extends ObjectBehavior
             ->shouldReturn('a');
 
         $this::fromIterable($input)
+            ->key()
+            ->shouldReturn('a');
+
+        $this::fromIterable($input)
+            ->key(9)
+            ->shouldReturn(null);
+
+        $this::fromIterable($input)
             ->key(4)
             ->shouldReturn('e');
     }

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -2707,19 +2707,30 @@ class CollectionSpec extends ObjectBehavior
 
     public function it_can_squash(): void
     {
-        $input = [16, 4, -9, 9];
-
-        $this::fromIterable($input)
+        $this::fromIterable([16, 4, -9, 9])
             ->map(
                 static function (int $value): int {
                     if (0 > $value) {
-                        throw new Exception('Error');
+                        throw new Exception('This should error');
                     }
 
                     return (int) sqrt($value);
                 }
             )
             ->shouldThrow(Exception::class)
+            ->during('squash');
+
+        $this::fromIterable([16, 4, 9, 9])
+            ->map(
+                static function (int $value): int {
+                    if (-100 > $value) {
+                        throw new Exception('This should not error');
+                    }
+
+                    return (int) sqrt($value);
+                }
+            )
+            ->shouldNotThrow(Exception::class)
             ->during('squash');
     }
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -439,6 +439,10 @@ final class Collection implements CollectionInterface
         );
     }
 
+    /**
+     * @param TKey $key
+     * @param T|null $default
+     */
     public function get($key, $default = null): CollectionInterface
     {
         return new self(Get::of()($key)($default), $this->getIterator());

--- a/src/Contract/Operation/Everyable.php
+++ b/src/Contract/Operation/Everyable.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
+use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -18,6 +19,8 @@ use loophp\collection\Contract\Collection;
 interface Everyable
 {
     /**
+     * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
+     *
      * @return Collection<TKey, bool>
      */
     public function every(callable ...$callbacks): Collection;

--- a/src/Contract/Operation/Keyable.php
+++ b/src/Contract/Operation/Keyable.php
@@ -16,7 +16,7 @@ namespace loophp\collection\Contract\Operation;
 interface Keyable
 {
     /**
-     * @return T|TKey
+     * @return TKey|null
      */
     public function key(int $index = 0);
 }

--- a/src/Operation/Every.php
+++ b/src/Operation/Every.php
@@ -22,7 +22,7 @@ use Iterator;
 final class Every extends AbstractOperation
 {
     /**
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(Iterator<TKey, T>): Generator<int|TKey, bool>
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
@@ -30,14 +30,14 @@ final class Every extends AbstractOperation
             /**
              * @param callable(T, TKey, Iterator<TKey, T>): bool ...$matchers
              *
-             * @return Closure(...callable(T, TKey, Iterator<TKey, T>): bool): Closure(Iterator<TKey, T>): Generator<int|TKey, bool>
+             * @return Closure(...callable(T, TKey, Iterator<TKey, T>): bool): Closure(Iterator<TKey, T>): Generator<TKey, bool>
              */
             static function (callable ...$matchers): Closure {
                 return
                     /**
                      * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
                      *
-                     * @return Closure(Iterator<TKey, T>): Generator<int|TKey, bool>
+                     * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
                      */
                     static function (callable ...$callbacks) use ($matchers): Closure {
                         $callbackReducer =
@@ -78,7 +78,7 @@ final class Every extends AbstractOperation
                                      */
                                     static fn ($value, $key, Iterator $iterator): bool => $reducer1($value, $key, $iterator) !== $reducer2($value, $key, $iterator);
 
-                        /** @var Closure(Iterator<TKey, T>): Generator<TKey|int, bool> $pipe */
+                        /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
                         $pipe = Pipe::of()(
                             Map::of()($mapCallback($callbackReducer($callbacks))($callbackReducer($matchers))),
                             DropWhile::of()(static fn (bool $value): bool => true === $value),

--- a/src/Operation/Get.php
+++ b/src/Operation/Get.php
@@ -20,21 +20,21 @@ use Iterator;
 final class Get extends AbstractOperation
 {
     /**
-     * @return Closure((T | TKey)):Closure (T): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+     * @return Closure(TKey): Closure (T|null): Closure(Iterator<TKey, T>): Generator<TKey, T|null>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param T|TKey $keyToGet
+             * @param TKey $keyToGet
              *
-             * @return Closure(T): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+             * @return Closure(T|null): Closure(Iterator<TKey, T>): Generator<TKey, T|null>
              */
             static fn ($keyToGet): Closure =>
                 /**
-                 * @param T $default
+                 * @param T|null $default
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T|null>
                  */
                 static function ($default) use ($keyToGet): Closure {
                     $filterCallback =
@@ -44,7 +44,7 @@ final class Get extends AbstractOperation
                          */
                         static fn ($value, $key): bool => $key === $keyToGet;
 
-                    /** @var Closure(Iterator<TKey, T>):(Generator<int|TKey, T>) $pipe */
+                    /** @var Closure(Iterator<TKey, T>): (Generator<TKey, T|null>) $pipe */
                     $pipe = Pipe::of()(
                         Filter::of()($filterCallback),
                         Append::of()($default),

--- a/src/Operation/Normalize.php
+++ b/src/Operation/Normalize.php
@@ -20,7 +20,7 @@ use Iterator;
 final class Normalize extends AbstractOperation
 {
     /**
-     * @return Closure(Iterator<TKey, T>): Generator<int, T, mixed, void>
+     * @return Closure(Iterator<TKey, T>): Generator<int, T>
      */
     public function __invoke(): Closure
     {
@@ -28,7 +28,7 @@ final class Normalize extends AbstractOperation
             /**
              * @param Iterator<TKey, T> $iterator
              *
-             * @return Generator<int, T, mixed, void>
+             * @return Generator<int, T>
              */
             static function (Iterator $iterator): Generator {
                 foreach ($iterator as $value) {

--- a/tests/static-analysis/every.php
+++ b/tests/static-analysis/every.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, bool> $collection
+ */
+function every_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, bool> $collection
+ */
+function every_checkMap(CollectionInterface $collection): void
+{
+}
+function every_checkBool(bool $value): void
+{
+}
+
+$even = static fn (int $val): bool => $val % 2 === 0;
+$negative = static fn (int $val): bool => 0 > $val;
+$bar = static fn (string $val): bool => 'bar' === $val;
+$long = static fn (string $val): bool => mb_strlen($val) > 3;
+
+every_checkList(Collection::fromIterable([1, 2, 3])->every($even));
+every_checkList(Collection::fromIterable([-1, 2, -3])->every($even, $negative));
+
+every_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->every($bar));
+every_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'looooooooong'])->every($bar, $long));
+
+// VALID failures below -> `current` can return `NULL` if the collection is empty
+
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+every_checkList(Collection::fromIterable([1, 2, 3])->every($even)->current());
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+every_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->every($bar)->current());
+
+// explicit check is needed for PHPStan because the value is of type `bool|null`
+if (true === Collection::fromIterable([1, 2, 3])->every($even)->current()) {
+}

--- a/tests/static-analysis/every.php
+++ b/tests/static-analysis/every.php
@@ -42,9 +42,9 @@ every_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'looooooooong'
 // VALID failures below -> `current` can return `NULL` if the collection is empty
 
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-every_checkList(Collection::fromIterable([1, 2, 3])->every($even)->current());
+every_checkBool(Collection::fromIterable([1, 2, 3])->every($even)->current());
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-every_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->every($bar)->current());
+every_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->every($bar)->current());
 
 // explicit check is needed for PHPStan because the value is of type `bool|null`
 if (true === Collection::fromIterable([1, 2, 3])->every($even)->current()) {

--- a/tests/static-analysis/get.php
+++ b/tests/static-analysis/get.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function get_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, int|null> $collection
+ */
+function get_checkListNullable(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function get_checkMap(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string|null> $collection
+ */
+function get_checkMapNullable(CollectionInterface $collection): void
+{
+}
+function get_checkIntElement(int $value): void
+{
+}
+function get_checkNullableInt(?int $value): void
+{
+}
+function get_checkStringElement(string $value): void
+{
+}
+function get_checkNullableString(?string $value): void
+{
+}
+
+get_checkListNullable(Collection::fromIterable([1, 2, 3])->get(1));
+get_checkMapNullable(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo'));
+
+get_checkNullableInt(Collection::fromIterable([1, 2, 3])->get(1)->current());
+get_checkNullableString(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo')->current());
+
+// These should work but Psalm narrows the type to 1|2|3|null and 'a'|'b'|null
+/** @psalm-suppress InvalidArgument */
+get_checkListNullable(Collection::fromIterable([1, 2, 3])->get(1, -1));
+/** @psalm-suppress InvalidArgument */
+get_checkMapNullable(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo', 'x'));
+
+// VALID failures - `get` returns `Collection<TKey, T|null>`
+/** @phpstan-ignore-next-line */
+get_checkList(Collection::fromIterable([1, 2, 3])->get(1));
+/** @phpstan-ignore-next-line */
+get_checkMap(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo'));
+
+// VALID failures - `current` can return `NULL`
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+get_checkIntElement(Collection::fromIterable([1, 2, 3])->get(1)->current());
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+get_checkStringElement(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo')->current());
+
+// VALID but inconvenient failures - although a non-null default is provided to `get`, `current` can return `NULL`
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+get_checkIntElement(Collection::fromIterable([1, 2, 3])->get(1, 2)->current());
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+get_checkStringElement(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo', 'a')->current());

--- a/tests/static-analysis/key.php
+++ b/tests/static-analysis/key.php
@@ -31,14 +31,14 @@ key_checkNullableString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->
 key_checkNullableString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key(1));
 
 // VALID failure -> `key` can return `NULL` because `current` can return `NULL`
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
 key_checkInt(Collection::fromIterable([1, 2, 3])->key());
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
 key_checkInt(Collection::fromIterable([1, 2, 3])->key(2));
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
 key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key());
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
 key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key(1));
 
 // VALID failure -> mixed key

--- a/tests/static-analysis/key.php
+++ b/tests/static-analysis/key.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+function key_checkInt(int $key): void
+{
+}
+
+function key_checkNullableInt(?int $key): void
+{
+}
+function key_checkString(string $key): void
+{
+}
+function key_checkNullableString(?string $key): void
+{
+}
+
+key_checkNullableInt(Collection::fromIterable([1, 2, 3])->key());
+key_checkNullableInt(Collection::fromIterable([1, 2, 3])->key(2));
+key_checkNullableString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key());
+key_checkNullableString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key(1));
+
+// VALID failure -> `key` can return `NULL` because `current` can return `NULL`
+/** @psalm-suppress PossiblyNullArgument */
+key_checkInt(Collection::fromIterable([1, 2, 3])->key());
+/** @psalm-suppress PossiblyNullArgument */
+key_checkInt(Collection::fromIterable([1, 2, 3])->key(2));
+
+/** @psalm-suppress PossiblyNullArgument */
+key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key());
+/** @psalm-suppress PossiblyNullArgument */
+key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key(1));
+
+// VALID failure -> mixed key
+/** @psalm-suppress PossiblyInvalidArgument @phpstan-ignore-next-line */
+key_checkInt(Collection::fromIterable([1, 2, 'foo' => 4])->key());
+/** @psalm-suppress PossiblyInvalidArgument @phpstan-ignore-next-line */
+key_checkString(Collection::fromIterable([1, 2, 'foo' => 4])->key());

--- a/tests/static-analysis/keys.php
+++ b/tests/static-analysis/keys.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function keys_checkIntList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function keys_checkStringList(CollectionInterface $collection): void
+{
+}
+
+keys_checkIntList(Collection::fromIterable([1, 2, 3])->keys());
+keys_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->keys());
+
+// VALID failure -> mixed keys
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+keys_checkIntList(Collection::fromIterable([1, 2, 'foo' => 4])->keys());
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+keys_checkStringList(Collection::fromIterable([1, 2, 'foo' => 4])->keys());

--- a/tests/static-analysis/normalize.php
+++ b/tests/static-analysis/normalize.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function normalize_checkIntList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function normalize_checkStringList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function normalize_checkStringMap(CollectionInterface $collection): void
+{
+}
+
+normalize_checkIntList(Collection::fromIterable([1, 2, 3])->normalize());
+normalize_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->normalize());
+
+// VALID failure -> `normalize` always returns a collection with `int` keys
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+normalize_checkStringMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->normalize());

--- a/tests/static-analysis/squash.php
+++ b/tests/static-analysis/squash.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function squash_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function squash_checkStringList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function squash_checkMap(CollectionInterface $collection): void
+{
+}
+
+squash_checkList(Collection::fromIterable([1, 2, 3])->squash());
+squash_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->squash());
+squash_checkStringList(Collection::fromIterable(['a', 'b', 'c'])->squash());
+
+// These work because `normalize` always changes the key to `int`
+squash_checkList(Collection::fromIterable(['foo' => 1, 'bar' => 2])->normalize()->squash());
+squash_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->normalize()->squash());
+
+// VALID failures -> `squash` does not change the key and value types
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+squash_checkList(Collection::fromIterable(['a', 'b', 'c'])->squash());
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+squash_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->squash());
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+squash_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->squash());


### PR DESCRIPTION
This PR adds more static analysis checks for commonly-used methods, and fixes a few type hints in the process.

- [x] every
- [x] get
- [x] key
- [x] keys
- [x] normalize
- [x] squash

Follows #109.