### PR TITLE
Adding More Static Analysis Checks

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1018,14 +1018,10 @@ Signature: ``Collection::has(callable ...$callbacks);``
 .. code-block:: php
 
     Collection::fromIterable(range('A', 'C'))
-        ->has(
-            static fn ($value, $key, Iterator $iterator): string => 'A'
-        ); // [true]
+        ->has(static fn (): string => 'B'); // [1 => true]
 
     Collection::fromIterable(range('A', 'C'))
-        ->has(
-            static fn ($value, $key, Iterator $iterator): string => 'D'
-        ); // [false]
+        ->has(static fn (): string => 'D'); // [0 => false]
 
     Collection::fromIterable(range('A', 'C'))
         ->has(

--- a/src/Contract/Operation/Hasable.php
+++ b/src/Contract/Operation/Hasable.php
@@ -19,9 +19,9 @@ use loophp\collection\Contract\Collection;
 interface Hasable
 {
     /**
-     * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
+     * @param callable(T, TKey, Iterator<TKey, T>): T ...$callbacks
      *
-     * @return Collection<int, bool>
+     * @return Collection<TKey, bool>
      */
     public function has(callable ...$callbacks): Collection;
 }

--- a/src/Operation/Has.php
+++ b/src/Operation/Has.php
@@ -22,7 +22,7 @@ use Iterator;
 final class Has extends AbstractOperation
 {
     /**
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...$callbacks): Closure(Iterator<TKey, T>): Generator<TKey, bool>
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {

--- a/src/Operation/Has.php
+++ b/src/Operation/Has.php
@@ -22,7 +22,7 @@ use Iterator;
 final class Has extends AbstractOperation
 {
     /**
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...): Closure(Iterator<TKey, T>): Generator<int|TKey, bool>
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...$callbacks): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
@@ -30,10 +30,10 @@ final class Has extends AbstractOperation
             /**
              * @param callable(T, TKey, Iterator<TKey, T>): T ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int|TKey, bool>
+             * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
              */
             static function (callable ...$callbacks): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<int|TKey, bool> $pipe */
+                /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
                 $pipe = MatchOne::of()(static fn (): bool => true)(
                     ...array_map(
                         static fn (callable $callback): callable =>

--- a/tests/static-analysis/falsy.php
+++ b/tests/static-analysis/falsy.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, bool> $collection
+ */
+function falsy_checkList(CollectionInterface $collection): void
+{
+}
+function falsy_checkBool(bool $value): void
+{
+}
+
+falsy_checkList(Collection::fromIterable([1, 2, 3])->falsy());
+falsy_checkList(Collection::fromIterable([1, 2, 3])->falsy()->falsy());
+falsy_checkList(Collection::fromIterable([null, ''])->falsy());
+falsy_checkList(Collection::fromIterable(['foo' => 'bar'])->falsy());
+
+// This retrieval method doesn't cause static analysis complaints
+// but is not always reliable because of that.
+falsy_checkBool(Collection::fromIterable([1, 2, 3])->falsy()->all()[0]);
+falsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->falsy()->all()[2]);
+
+// VALID failures below -> `current` can return `NULL` if the collection is empty
+
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+falsy_checkBool(Collection::fromIterable([1, 2, 3])->falsy()->current());
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+falsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->falsy()->current());
+
+// explicit check is needed for PHPStan because the value is of type `bool|null`
+if (true === Collection::fromIterable([1, 2, 3])->falsy()->current()) {
+}

--- a/tests/static-analysis/has.php
+++ b/tests/static-analysis/has.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, bool> $collection
+ */
+function has_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, bool> $collection
+ */
+function has_checkMap(CollectionInterface $collection): void
+{
+}
+function has_checkBool(bool $value): void
+{
+}
+
+$number2 = static fn (): int => 2;
+$number3 = static fn (): int => 2;
+$square = static fn (int $value): int => $value ** 2;
+$withKey = static fn (int $value, int $key): int => 1 < $key ? 3 : 1;
+
+$letterF = static fn (): string => 'f';
+$letterZ = static fn (): string => 'z';
+$letterB = static fn (): string => 'b';
+$capital = static fn (string $value): string => strtoupper($value);
+$withStringKey = static fn (string $value, string $key): string => 'foo' === $key ? 'f' : 'b';
+
+has_checkList(Collection::fromIterable([1, 2, 3])->has($number2));
+has_checkList(Collection::fromIterable(range(1, 3))->has($number2, $number2));
+has_checkList(Collection::fromIterable([1, 2, 3])->has($withKey));
+
+has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF));
+has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF, $letterB));
+has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($withStringKey));
+
+// These are valid and should work, however Psalm restricts the values that the callable
+// is allowed to return to the values contained in the collection
+
+/** @psalm-suppress ArgumentTypeCoercion */
+has_checkList(Collection::fromIterable([1, 2, 3])->has($square));
+/** @psalm-suppress InvalidArgument */
+has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterZ));
+/** @psalm-suppress ArgumentTypeCoercion */
+has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($capital));
+
+// This retrieval method doesn't cause static analysis complaints
+// but is not always reliable because of that.
+has_checkBool(Collection::fromIterable([1, 2, 3])->has($number2)->all()[0]);
+has_checkBool(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF)->all()['foo']);
+/** @psalm-suppress InvalidArrayOffset -> in this case Psalm can tell that the key won't exist */
+has_checkBool(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF)->all()['randomKey']);
+
+// VALID failures below -> `current` can return `NULL` if the collection is empty
+
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+has_checkBool(Collection::fromIterable([1, 2, 3])->has($number2)->current());
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+has_checkBool(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF)->current());
+
+// explicit check is needed for PHPStan because the value is of type `bool|null`
+if (true === Collection::fromIterable([1, 2, 3])->has($number2)->current()) {
+}

--- a/tests/static-analysis/matching.php
+++ b/tests/static-analysis/matching.php
@@ -16,21 +16,21 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 /**
  * @param CollectionInterface<int, int> $collection
  */
-function matching_checkListInt(CollectionInterface $collection): void
+function matching_checkList(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<int, string> $collection
+ * @param CollectionInterface<string, string> $collection
  */
-function matching_checkListString(CollectionInterface $collection): void
+function matching_checkMap(CollectionInterface $collection): void
 {
 }
 
 $criteria = Criteria::create()->where(Criteria::expr()->gt('age', 18));
 
-matching_checkListInt(Collection::fromIterable([1, 2, 3])->matching($criteria));
-matching_checkListInt(Collection::fromIterable([1, 2, 3])->matching($criteria)->matching($criteria));
+matching_checkList(Collection::fromIterable([1, 2, 3])->matching($criteria));
+matching_checkList(Collection::fromIterable([1, 2, 3])->matching($criteria)->matching($criteria));
 
-matching_checkListString(Collection::fromIterable(range('a', 'e'))->matching($criteria));
-matching_checkListString(Collection::fromIterable(range('a', 'e'))->matching($criteria)->matching($criteria));
+matching_checkMap(Collection::fromIterable(['foo' => 'bar'])->matching($criteria));
+matching_checkMap(Collection::fromIterable(['foo' => 'bar'])->matching($criteria)->matching($criteria));

--- a/tests/static-analysis/nullsy.php
+++ b/tests/static-analysis/nullsy.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, bool> $collection
+ */
+function nullsy_checkList(CollectionInterface $collection): void
+{
+}
+function nullsy_checkBool(bool $value): void
+{
+}
+
+nullsy_checkList(Collection::fromIterable([1, 2, 3])->nullsy());
+nullsy_checkList(Collection::fromIterable([1, 2, 3])->nullsy()->nullsy());
+nullsy_checkList(Collection::fromIterable([null, ''])->nullsy());
+nullsy_checkList(Collection::fromIterable(['foo' => 'bar'])->nullsy());
+
+// This retrieval method doesn't cause static analysis complaints
+// but is not always reliable because of that.
+nullsy_checkBool(Collection::fromIterable([1, 2, 3])->nullsy()->all()[0]);
+nullsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->nullsy()->all()[2]);
+
+// VALID failures below -> `current` can return `NULL` if the collection is empty
+
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+nullsy_checkBool(Collection::fromIterable([1, 2, 3])->nullsy()->current());
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+nullsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->nullsy()->current());
+
+// explicit check is needed for PHPStan because the value is of type `bool|null`
+if (true === Collection::fromIterable([1, 2, 3])->nullsy()->current()) {
+}

--- a/tests/static-analysis/strict.php
+++ b/tests/static-analysis/strict.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function strict_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function strict_checkMap(CollectionInterface $collection): void
+{
+}
+
+$callback =
+    /** @param mixed $value */
+    static fn ($value): string => gettype($value);
+
+strict_checkList(Collection::fromIterable([1, 2, 3])->strict());
+strict_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->strict());
+
+strict_checkList(Collection::fromIterable([1, 2, 3])->strict($callback));
+strict_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->strict($callback));

--- a/tests/static-analysis/truthy.php
+++ b/tests/static-analysis/truthy.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, bool> $collection
+ */
+function truthy_checkList(CollectionInterface $collection): void
+{
+}
+function truthy_checkBool(bool $value): void
+{
+}
+
+truthy_checkList(Collection::fromIterable([1, 2, 3])->truthy());
+truthy_checkList(Collection::fromIterable([1, 2, 3])->truthy()->truthy());
+truthy_checkList(Collection::fromIterable([null, ''])->truthy());
+truthy_checkList(Collection::fromIterable(['foo' => 'bar'])->truthy());
+
+// This retrieval method doesn't cause static analysis complaints
+// but is not always reliable because of that.
+truthy_checkBool(Collection::fromIterable([1, 2, 3])->truthy()->all()[0]);
+truthy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->truthy()->all()[2]);
+
+// VALID failures below -> `current` can return `NULL` if the collection is empty
+
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+truthy_checkBool(Collection::fromIterable([1, 2, 3])->truthy()->current());
+/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+truthy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->truthy()->current());
+
+// explicit check is needed for PHPStan because the value is of type `bool|null`
+if (true === Collection::fromIterable([1, 2, 3])->truthy()->current()) {
+}


### PR DESCRIPTION
This PR continues to add static analysis checks for existing operations

* [x] Falsy
* [x] Nullsy
* [x] Truthy
* [x] Has
* [x] Strict


