### PR TITLE
Show Collection is Immutable & Operations Pure

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -136,6 +136,8 @@ use const PHP_INT_MIN;
  * @template TKey
  * @template T
  *
+ * @psalm-immutable
+ *
  * phpcs:disable Generic.Files.LineLength.TooLong
  *
  * @implements \loophp\collection\Contract\Collection<TKey, T>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -133,10 +133,10 @@ use const PHP_INT_MAX;
 use const PHP_INT_MIN;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
- *
- * @psalm-immutable
  *
  * phpcs:disable Generic.Files.LineLength.TooLong
  *
@@ -155,6 +155,8 @@ final class Collection implements CollectionInterface
     private $source;
 
     /**
+     * @psalm-external-mutation-free
+     *
      * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
      * @param mixed ...$parameters
      */
@@ -402,6 +404,7 @@ final class Collection implements CollectionInterface
     }
 
     /**
+     * @pure
      * @template NewTKey
      * @template NewT
      *
@@ -416,6 +419,8 @@ final class Collection implements CollectionInterface
     }
 
     /**
+     * @pure
+     *
      * @return self<int, string>
      */
     public static function fromFile(string $filepath): self
@@ -427,6 +432,8 @@ final class Collection implements CollectionInterface
     }
 
     /**
+     * @pure
+     *
      * @template NewTKey
      * @template NewT
      *
@@ -443,6 +450,8 @@ final class Collection implements CollectionInterface
     }
 
     /**
+     * @pure
+     *
      * @param resource $resource
      *
      * @return self<int, string>
@@ -459,6 +468,8 @@ final class Collection implements CollectionInterface
     }
 
     /**
+     * @pure
+     *
      * @return self<int, string>
      */
     public static function fromString(string $string, string $delimiter = ''): self

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -124,10 +124,10 @@ use loophp\collection\Contract\Operation\Wrapable;
 use loophp\collection\Contract\Operation\Zipable;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
- *
- * @psalm-immutable
  *
  * @template-extends Allable<TKey, T>
  * @template-extends Appendable<TKey, T>

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -127,6 +127,8 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template TKey
  * @template T
  *
+ * @psalm-immutable
+ *
  * @template-extends Allable<TKey, T>
  * @template-extends Appendable<TKey, T>
  * @template-extends Applyable<TKey, T>

--- a/src/Contract/Operation.php
+++ b/src/Contract/Operation.php
@@ -11,9 +11,12 @@ namespace loophp\collection\Contract;
 
 use Closure;
 
+/** @immutable */
 interface Operation
 {
+    /** @pure */
     public function __invoke(): Closure;
 
+    /** @pure */
     public static function of(): Closure;
 }

--- a/src/Contract/Operation.php
+++ b/src/Contract/Operation.php
@@ -14,9 +14,13 @@ use Closure;
 /** @immutable */
 interface Operation
 {
-    /** @pure */
+    /**
+     * @pure
+     */
     public function __invoke(): Closure;
 
-    /** @pure */
+    /**
+     * @pure
+     */
     public static function of(): Closure;
 }

--- a/src/Contract/Operation/Squashable.php
+++ b/src/Contract/Operation/Squashable.php
@@ -12,6 +12,8 @@ namespace loophp\collection\Contract\Operation;
 use loophp\collection\Contract\Collection;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */

--- a/src/Contract/Operation/Squashable.php
+++ b/src/Contract/Operation/Squashable.php
@@ -12,8 +12,6 @@ namespace loophp\collection\Contract\Operation;
 use loophp\collection\Contract\Collection;
 
 /**
- * @immutable
- *
  * @template TKey
  * @template T
  */

--- a/src/Operation/AbstractOperation.php
+++ b/src/Operation/AbstractOperation.php
@@ -12,12 +12,16 @@ namespace loophp\collection\Operation;
 use Closure;
 use loophp\collection\Contract\Operation;
 
+/**
+ * @immutable
+ */
 abstract class AbstractOperation implements Operation
 {
     final public function __construct()
     {
     }
 
+    /** @pure */
     public static function of(): Closure
     {
         return (new static())->__invoke();

--- a/src/Operation/AbstractOperation.php
+++ b/src/Operation/AbstractOperation.php
@@ -17,6 +17,7 @@ use loophp\collection\Contract\Operation;
  */
 abstract class AbstractOperation implements Operation
 {
+    /** @pure */
     final public function __construct()
     {
     }

--- a/src/Operation/AbstractOperation.php
+++ b/src/Operation/AbstractOperation.php
@@ -17,12 +17,16 @@ use loophp\collection\Contract\Operation;
  */
 abstract class AbstractOperation implements Operation
 {
-    /** @pure */
+    /**
+     * @pure
+     */
     final public function __construct()
     {
     }
 
-    /** @pure */
+    /**
+     * @pure
+     */
     public static function of(): Closure
     {
         return (new static())->__invoke();

--- a/src/Operation/Append.php
+++ b/src/Operation/Append.php
@@ -14,12 +14,16 @@ use Iterator;
 use loophp\collection\Iterator\MultipleIterableIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Append extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(Iterator<TKey, T>): Iterator<int|TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Apply.php
+++ b/src/Operation/Apply.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Apply extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>):bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Associate.php
+++ b/src/Operation/Associate.php
@@ -15,6 +15,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -23,6 +25,8 @@ use Iterator;
 final class Associate extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(TKey, TKey, T, Iterator<TKey, T>): (T|TKey) ...): Closure((callable(T, TKey, T, Iterator<TKey, T>): (T|TKey))...): Closure(Iterator<TKey, T>): Generator<TKey|T, T|TKey>
      */
     public function __invoke(): Closure

--- a/src/Operation/AsyncMap.php
+++ b/src/Operation/AsyncMap.php
@@ -27,7 +27,7 @@ if (false === function_exists('Amp\ParallelFunctions\parallel')) {
 }
 // phpcs:enable
 /**
- * Class AsyncMap.
+ * @immutable
  *
  * @template TKey
  * @template T
@@ -37,6 +37,8 @@ if (false === function_exists('Amp\ParallelFunctions\parallel')) {
 final class AsyncMap extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey): T ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Cache.php
+++ b/src/Operation/Cache.php
@@ -15,6 +15,8 @@ use loophp\collection\Iterator\PsrCacheIterator;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -23,6 +25,8 @@ use Psr\Cache\CacheItemPoolInterface;
 final class Cache extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(CacheItemPoolInterface): Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Chunk.php
+++ b/src/Operation/Chunk.php
@@ -18,12 +18,16 @@ use Iterator;
 use function count;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Chunk extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int...): Closure(Iterator<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Coalesce.php
+++ b/src/Operation/Coalesce.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Coalesce extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Collapse.php
+++ b/src/Operation/Collapse.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Collapse extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, (T|iterable<TKey, T>)>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Column.php
+++ b/src/Operation/Column.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Column extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T): Closure(Iterator<TKey, T>): Generator<int, iterable<TKey, T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Combinate.php
+++ b/src/Operation/Combinate.php
@@ -17,11 +17,16 @@ use function array_slice;
 use function count;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Combinate extends AbstractOperation
 {
+    /**
+     * @pure
+     */
     public function __invoke(): Closure
     {
         return static function (?int $length = null): Closure {

--- a/src/Operation/Combine.php
+++ b/src/Operation/Combine.php
@@ -17,12 +17,16 @@ use Iterator;
 use const E_USER_WARNING;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Combine extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<T, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Compact.php
+++ b/src/Operation/Compact.php
@@ -16,6 +16,8 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -24,6 +26,8 @@ use function in_array;
 final class Compact extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Contains.php
+++ b/src/Operation/Contains.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Contains extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T ...$values): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure

--- a/src/Operation/Current.php
+++ b/src/Operation/Current.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Current extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int $index): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Cycle.php
+++ b/src/Operation/Cycle.php
@@ -14,12 +14,16 @@ use InfiniteIterator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Cycle extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Diff.php
+++ b/src/Operation/Diff.php
@@ -16,12 +16,16 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Diff extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/DiffKeys.php
+++ b/src/Operation/DiffKeys.php
@@ -16,12 +16,16 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class DiffKeys extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(TKey...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Distinct extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @template U
      *
      * @return Closure(callable(U): Closure(U): bool): Closure(callable(T, TKey): U): Closure(Iterator<TKey, T>): Generator<TKey, T>

--- a/src/Operation/Drop.php
+++ b/src/Operation/Drop.php
@@ -14,12 +14,16 @@ use Iterator;
 use LimitIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Drop extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int...): Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/DropWhile.php
+++ b/src/Operation/DropWhile.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class DropWhile extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey): bool ...): Closure (Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Dump.php
+++ b/src/Operation/Dump.php
@@ -15,6 +15,8 @@ use Iterator;
 use Symfony\Component\VarDumper\VarDumper;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -23,6 +25,8 @@ use Symfony\Component\VarDumper\VarDumper;
 final class Dump extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(string): Closure(int): Closure(?Closure): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Duplicate.php
+++ b/src/Operation/Duplicate.php
@@ -16,12 +16,16 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Duplicate extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Every.php
+++ b/src/Operation/Every.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Every extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure

--- a/src/Operation/Explode.php
+++ b/src/Operation/Explode.php
@@ -15,12 +15,16 @@ use Iterator;
 use loophp\collection\Contract\Operation\Splitable;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Explode extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Falsy.php
+++ b/src/Operation/Falsy.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Falsy extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure

--- a/src/Operation/Filter.php
+++ b/src/Operation/Filter.php
@@ -14,6 +14,8 @@ use Closure;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Filter extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T , TKey, Iterator<TKey, T>): bool ...): Closure (Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/First.php
+++ b/src/Operation/First.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class First extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/FlatMap.php
+++ b/src/Operation/FlatMap.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class FlatMap extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @template IKey
      * @template IValue
      *

--- a/src/Operation/Flatten.php
+++ b/src/Operation/Flatten.php
@@ -15,12 +15,16 @@ use Iterator;
 use loophp\collection\Iterator\IterableIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Flatten extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure

--- a/src/Operation/Flip.php
+++ b/src/Operation/Flip.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Flip extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<T, TKey>
      */
     public function __invoke(): Closure

--- a/src/Operation/FoldLeft.php
+++ b/src/Operation/FoldLeft.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class FoldLeft extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>):(T|null)): Closure(T): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/FoldLeft1.php
+++ b/src/Operation/FoldLeft1.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class FoldLeft1 extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>):(T|null)): Closure(Iterator<TKey, T>): Generator<int|TKey, null|T>
      */
     public function __invoke(): Closure

--- a/src/Operation/FoldRight.php
+++ b/src/Operation/FoldRight.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class FoldRight extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>):(T|null)): Closure(T): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/FoldRight1.php
+++ b/src/Operation/FoldRight1.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class FoldRight1 extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>): (T|null)):Closure (Iterator<TKey, T>): Generator<int|TKey, T|null>
      */
     public function __invoke(): Closure

--- a/src/Operation/Forget.php
+++ b/src/Operation/Forget.php
@@ -16,12 +16,16 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Forget extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(TKey...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Frequency.php
+++ b/src/Operation/Frequency.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Frequency extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Get.php
+++ b/src/Operation/Get.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Get extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(TKey): Closure (T|null): Closure(Iterator<TKey, T>): Generator<TKey, T|null>
      */
     public function __invoke(): Closure

--- a/src/Operation/Group.php
+++ b/src/Operation/Group.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Group extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/GroupBy.php
+++ b/src/Operation/GroupBy.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class GroupBy extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure((null | callable(TKey, T ): (TKey | null))):Closure (Iterator<TKey, T>): Generator<int, T|list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Has.php
+++ b/src/Operation/Has.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Has extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure

--- a/src/Operation/Head.php
+++ b/src/Operation/Head.php
@@ -15,12 +15,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Head extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/IfThenElse.php
+++ b/src/Operation/IfThenElse.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class IfThenElse extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey): bool): Closure(callable(T, TKey): (T)): Closure(callable(T, TKey): (T)): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Implode.php
+++ b/src/Operation/Implode.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Implode extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(string): Closure(Iterator<TKey, T>): Generator<int, string>
      */
     public function __invoke(): Closure

--- a/src/Operation/Init.php
+++ b/src/Operation/Init.php
@@ -15,12 +15,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Init extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Inits.php
+++ b/src/Operation/Inits.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Inits extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Intersect.php
+++ b/src/Operation/Intersect.php
@@ -16,12 +16,16 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Intersect extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/IntersectKeys.php
+++ b/src/Operation/IntersectKeys.php
@@ -16,12 +16,16 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class IntersectKeys extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(TKey...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Intersperse.php
+++ b/src/Operation/Intersperse.php
@@ -15,12 +15,16 @@ use InvalidArgumentException;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Intersperse extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T): Closure(int): Closure(int): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Key.php
+++ b/src/Operation/Key.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Key extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(Iterator<TKey, T>): Generator<int, TKey>
      */
     public function __invoke(): Closure

--- a/src/Operation/Keys.php
+++ b/src/Operation/Keys.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Keys extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, TKey>
      */
     public function __invoke(): Closure

--- a/src/Operation/Last.php
+++ b/src/Operation/Last.php
@@ -15,12 +15,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Last extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Limit.php
+++ b/src/Operation/Limit.php
@@ -14,6 +14,8 @@ use Iterator;
 use LimitIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use LimitIterator;
 final class Limit extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(int): Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Lines.php
+++ b/src/Operation/Lines.php
@@ -16,12 +16,16 @@ use Iterator;
 use const PHP_EOL;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Lines extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, (T|string)>): Generator<int, string>
      */
     public function __invoke(): Closure

--- a/src/Operation/Map.php
+++ b/src/Operation/Map.php
@@ -18,6 +18,8 @@ use function count;
 use const E_USER_DEPRECATED;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -26,6 +28,8 @@ use const E_USER_DEPRECATED;
 final class Map extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/MapN.php
+++ b/src/Operation/MapN.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class MapN extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(mixed, mixed, Iterator<TKey, T>): mixed ...): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure

--- a/src/Operation/MatchOne.php
+++ b/src/Operation/MatchOne.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class MatchOne extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>): T): Closure(callable(T, TKey, Iterator<TKey, T>): bool): Closure(Iterator<TKey, T>): Generator<TKey|int, bool>
      */
     public function __invoke(): Closure

--- a/src/Operation/Matching.php
+++ b/src/Operation/Matching.php
@@ -17,6 +17,8 @@ use Iterator;
 use loophp\collection\Contract\Operation\Sortable;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -25,6 +27,8 @@ use loophp\collection\Contract\Operation\Sortable;
 final class Matching extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Criteria): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Merge.php
+++ b/src/Operation/Merge.php
@@ -14,12 +14,16 @@ use Iterator;
 use loophp\collection\Iterator\MultipleIterableIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Merge extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(iterable<TKey, T>...): Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Normalize.php
+++ b/src/Operation/Normalize.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Normalize extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Nth.php
+++ b/src/Operation/Nth.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Nth extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Nullsy.php
+++ b/src/Operation/Nullsy.php
@@ -16,6 +16,8 @@ use Iterator;
 use function in_array;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
@@ -27,6 +29,8 @@ final class Nullsy extends AbstractOperation
     public const VALUES = [null, [], 0, false, ''];
 
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure

--- a/src/Operation/Pack.php
+++ b/src/Operation/Pack.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Pack extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, array{0: TKey, 1: T}>
      */
     public function __invoke(): Closure

--- a/src/Operation/Pad.php
+++ b/src/Operation/Pad.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Pad extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(T): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Pair.php
+++ b/src/Operation/Pair.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Pair extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<T|TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Partition.php
+++ b/src/Operation/Partition.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Partition extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>):bool...): Closure(Iterator<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Permutate.php
+++ b/src/Operation/Permutate.php
@@ -14,11 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Permutate extends AbstractOperation
 {
+    /**
+     * @pure
+     */
     public function __invoke(): Closure
     {
         $getPermutations =

--- a/src/Operation/Pipe.php
+++ b/src/Operation/Pipe.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Pipe extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(...callable(Iterator<TKey, T>):Generator<TKey, T, mixed, mixed>):Closure(Iterator<TKey, T>):Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Pluck.php
+++ b/src/Operation/Pluck.php
@@ -23,6 +23,8 @@ use function is_array;
 use function is_object;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -31,6 +33,8 @@ use function is_object;
 final class Pluck extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T):Closure(T):Closure(Iterator<TKey, T>):Generator<int, T|iterable<int, T>, mixed, void>
      */
     public function __invoke(): Closure

--- a/src/Operation/Prepend.php
+++ b/src/Operation/Prepend.php
@@ -14,12 +14,16 @@ use Iterator;
 use loophp\collection\Iterator\MultipleIterableIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Prepend extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(Iterator<TKey, T>): Iterator<int|TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Product.php
+++ b/src/Operation/Product.php
@@ -16,11 +16,16 @@ use Iterator;
 use function count;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Product extends AbstractOperation
 {
+    /**
+     * @pure
+     */
     public function __invoke(): Closure
     {
         return

--- a/src/Operation/RSample.php
+++ b/src/Operation/RSample.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class RSample extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(float): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Random.php
+++ b/src/Operation/Random.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Random extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Range.php
+++ b/src/Operation/Range.php
@@ -16,6 +16,8 @@ use Iterator;
 use const INF;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -24,6 +26,8 @@ use const INF;
 final class Range extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(float  = default):Closure (float=): Closure(float=): Closure(null|Iterator<TKey, T>): Generator<int, float>
      */
     public function __invoke(): Closure

--- a/src/Operation/Reduction.php
+++ b/src/Operation/Reduction.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Reduction extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>): (T|null)):Closure (T|null): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Reverse.php
+++ b/src/Operation/Reverse.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @todo Remove the Wrap and Unwrap operations
  * @todo They are only needed when: Collection::empty()->reverse()
  * @todo Most probably that the FoldLeft operation needs an update.
@@ -24,6 +26,8 @@ use Iterator;
 final class Reverse extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T, mixed, void>
      */
     public function __invoke(): Closure

--- a/src/Operation/Scale.php
+++ b/src/Operation/Scale.php
@@ -16,6 +16,8 @@ use Iterator;
 use const INF;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -24,6 +26,8 @@ use const INF;
 final class Scale extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(float): Closure(float): Closure(float): Closure(float): Closure(float): Closure(Iterator<TKey, float|int>): Generator<TKey, float|int>
      */
     public function __invoke(): Closure

--- a/src/Operation/ScanLeft.php
+++ b/src/Operation/ScanLeft.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class ScanLeft extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>): (T|null)):Closure (T|null): Closure(Iterator<TKey, T>): Generator<int|TKey, T|null>
      */
     public function __invoke(): Closure

--- a/src/Operation/ScanLeft1.php
+++ b/src/Operation/ScanLeft1.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class ScanLeft1 extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>): (T|null)):Closure (Iterator<TKey, T>): Generator<int|TKey, T|null>
      */
     public function __invoke(): Closure

--- a/src/Operation/ScanRight.php
+++ b/src/Operation/ScanRight.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class ScanRight extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>): (T|null)):Closure (T|null): Closure(Iterator<TKey, T>): Generator<int|TKey, T|null>
      */
     public function __invoke(): Closure

--- a/src/Operation/ScanRight1.php
+++ b/src/Operation/ScanRight1.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class ScanRight1 extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>): (T|null)):Closure (Iterator<TKey, T>): Generator<int|TKey, T|null>
      */
     public function __invoke(): Closure

--- a/src/Operation/Shuffle.php
+++ b/src/Operation/Shuffle.php
@@ -14,12 +14,16 @@ use Iterator;
 use loophp\collection\Iterator\RandomIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Shuffle extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Since.php
+++ b/src/Operation/Since.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Since extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>):bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Slice.php
+++ b/src/Operation/Slice.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Slice extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(int=): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Sort.php
+++ b/src/Operation/Sort.php
@@ -17,6 +17,8 @@ use Iterator;
 use loophp\collection\Contract\Operation;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -25,6 +27,8 @@ use loophp\collection\Contract\Operation;
 final class Sort extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(callable(T|TKey, T|TKey): int): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Span.php
+++ b/src/Operation/Span.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Span extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool):Closure (Iterator<TKey, T>): Generator<int, Iterator<TKey, T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Split.php
+++ b/src/Operation/Split.php
@@ -15,6 +15,8 @@ use Iterator;
 use loophp\collection\Contract\Operation\Splitable;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -23,6 +25,8 @@ use loophp\collection\Contract\Operation\Splitable;
 final class Split extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure((callable(T, TKey): bool)...): Closure(Iterator<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Strict.php
+++ b/src/Operation/Strict.php
@@ -14,12 +14,16 @@ use Iterator;
 use loophp\collection\Iterator\TypedIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Strict extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(null|callable(mixed): string): Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Tail.php
+++ b/src/Operation/Tail.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Tail extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Tails.php
+++ b/src/Operation/Tails.php
@@ -15,12 +15,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Tails extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, list<T>, mixed, void>
      */
     public function __invoke(): Closure

--- a/src/Operation/TakeWhile.php
+++ b/src/Operation/TakeWhile.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class TakeWhile extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool):Closure (Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Times.php
+++ b/src/Operation/Times.php
@@ -15,6 +15,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -23,6 +25,8 @@ use Iterator;
 final class Times extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(null|callable(int): (int|T)): Closure(null|Iterator<TKey, T>): Generator<int, int|T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Transpose.php
+++ b/src/Operation/Transpose.php
@@ -16,12 +16,16 @@ use loophp\collection\Iterator\IterableIterator;
 use MultipleIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Transpose extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Truthy.php
+++ b/src/Operation/Truthy.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Truthy extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unfold.php
+++ b/src/Operation/Unfold.php
@@ -13,6 +13,8 @@ use Closure;
 use Generator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -21,6 +23,8 @@ use Generator;
 final class Unfold extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(T...): Closure(callable(mixed|T...): (mixed|array<TKey, T>)): Closure(): Generator<int, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unlines.php
+++ b/src/Operation/Unlines.php
@@ -16,12 +16,16 @@ use Iterator;
 use const PHP_EOL;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Unlines extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, (T|string)>): Generator<TKey, string, mixed, void>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unpack.php
+++ b/src/Operation/Unpack.php
@@ -15,6 +15,8 @@ use Iterator;
 use loophp\collection\Iterator\IterableIterator;
 
 /**
+ * @immutable
+ *
  * @template NewTKey
  * @template NewT
  *
@@ -24,6 +26,8 @@ use loophp\collection\Iterator\IterableIterator;
 final class Unpack extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unpair.php
+++ b/src/Operation/Unpair.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Unpair extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, array{TKey, T}>
      */
     public function __invoke(): Closure

--- a/src/Operation/Until.php
+++ b/src/Operation/Until.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class Until extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unwindow.php
+++ b/src/Operation/Unwindow.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Unwindow extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, list<T>>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unwords.php
+++ b/src/Operation/Unwords.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Unwords extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, (T|string)>): Generator<TKey, string, mixed, void>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unwrap.php
+++ b/src/Operation/Unwrap.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Unwrap extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure

--- a/src/Operation/Unzip.php
+++ b/src/Operation/Unzip.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Unzip extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, list<T>>): Generator<int, list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/When.php
+++ b/src/Operation/When.php
@@ -14,6 +14,8 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -22,6 +24,8 @@ use Iterator;
 final class When extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(callable(Iterator<TKey, T>): bool): Closure(callable(Iterator<TKey, T>): iterable<TKey, T>): Closure(callable(Iterator<TKey, T>): iterable<TKey, T>): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure

--- a/src/Operation/Window.php
+++ b/src/Operation/Window.php
@@ -16,12 +16,16 @@ use Iterator;
 use function array_slice;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Window extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T|list<T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Words.php
+++ b/src/Operation/Words.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Words extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<TKey, string>
      */
     public function __invoke(): Closure

--- a/src/Operation/Wrap.php
+++ b/src/Operation/Wrap.php
@@ -14,12 +14,16 @@ use Generator;
 use Iterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  */
 final class Wrap extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(Iterator<TKey, T>): Generator<int, array<TKey, T>>
      */
     public function __invoke(): Closure

--- a/src/Operation/Zip.php
+++ b/src/Operation/Zip.php
@@ -15,6 +15,8 @@ use loophp\collection\Iterator\IterableIterator;
 use MultipleIterator;
 
 /**
+ * @immutable
+ *
  * @template TKey
  * @template T
  *
@@ -23,6 +25,8 @@ use MultipleIterator;
 final class Zip extends AbstractOperation
 {
     /**
+     * @pure
+     *
      * @return Closure(iterable<TKey, T>...): Closure(Iterator<TKey, T>): Iterator<list<TKey>, list<T>>
      */
     public function __invoke(): Closure


### PR DESCRIPTION
Collection claims to make use of pure functions and immutability; this PR introduces annotations so that this can be verified via static analysis.

Note: there is still scope to improve on this and use `pure-callable` instead of `callable` in places where a pure callable should be provided: https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-pure.
