### PR TITLE
Update `Filter` operation.

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -717,22 +717,18 @@ Signature: ``Collection::falsy();``
 filter
 ~~~~~~
 
-Filter collection items based on one or more callbacks. Multiple callbacks will be treated as a logical ``AND``.
+Filter collection items based on one or more callbacks.
+
+.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
+             If you're looking for a logical ``AND``, you have to make multiple calls to the
+             same operation.
 
 Interface: `Filterable`_
 
 Signature: ``Collection::filter(callable ...$callbacks);``
 
-.. code-block:: php
-
-    $divisibleBy3 = static fn($value): bool => 0 === $value % 3;
-    $divisibleBy6 = static fn($value): bool => 0 === $value % 6;
-
-    $collection = Collection::fromIterable(range(1, 10))
-        ->filter($divisibleBy3); // [3, 6, 9]
-
-    $collection = Collection::fromIterable(range(1, 10))
-        ->filter($divisibleBy3, $divisibleBy6); // [6]
+.. literalinclude:: code/operations/filter.php
+  :language: php
 
 first
 ~~~~~
@@ -773,13 +769,13 @@ Signature: ``Collection::flatMap(callable $callback);``
 
 .. code-block:: php
 
-    $square = static fn (int $val): int => $val ** 2;  
+    $square = static fn (int $val): int => $val ** 2;
     $squareArray = static fn (int $val): array => [$val ** 2];
     $squareCollection = static fn (int $val): Collection => Collection::fromIterable([$val ** 2]);
 
     $collection = Collection::fromIterable(range(1, 3))
         ->flatMap($squareArray); // [1, 4, 9]
-    
+
     $collection = Collection::fromIterable(range(1, 3))
         ->flatMap($squareCollection); // [1, 4, 9]
 

--- a/docs/pages/code/operations/filter.php
+++ b/docs/pages/code/operations/filter.php
@@ -13,8 +13,8 @@ include __DIR__ . '/../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
-$divisibleBy3 = static fn($value): bool => 0 === $value % 3;
-$divisibleBy5 = static fn($value): bool => 0 === $value % 5;
+$divisibleBy3 = static fn ($value): bool => 0 === $value % 3;
+$divisibleBy5 = static fn ($value): bool => 0 === $value % 5;
 
 $collection = Collection::fromIterable(range(1, 10))
     ->filter($divisibleBy3); // [3, 6, 9]

--- a/docs/pages/code/operations/filter.php
+++ b/docs/pages/code/operations/filter.php
@@ -13,11 +13,15 @@ include __DIR__ . '/../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
+$divisibleBy2 = static fn ($value): bool => 0 === $value % 2;
 $divisibleBy3 = static fn ($value): bool => 0 === $value % 3;
-$divisibleBy5 = static fn ($value): bool => 0 === $value % 5;
 
 $collection = Collection::fromIterable(range(1, 10))
     ->filter($divisibleBy3); // [3, 6, 9]
 
 $collection = Collection::fromIterable(range(1, 10))
-    ->filter($divisibleBy3, $divisibleBy5); // [3, 5, 6, 0, 10]
+    ->filter($divisibleBy2, $divisibleBy3); // [2, 3, 4, 6, 8, 9, 10]
+
+$collection = Collection::fromIterable(range(1, 10))
+    ->filter($divisibleBy2)
+    ->filter($divisibleBy3); // [6]

--- a/docs/pages/code/operations/filter.php
+++ b/docs/pages/code/operations/filter.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+include __DIR__ . '/../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+$divisibleBy3 = static fn($value): bool => 0 === $value % 3;
+$divisibleBy5 = static fn($value): bool => 0 === $value % 5;
+
+$collection = Collection::fromIterable(range(1, 10))
+    ->filter($divisibleBy3); // [3, 6, 9]
+
+$collection = Collection::fromIterable(range(1, 10))
+    ->filter($divisibleBy3, $divisibleBy5); // [3, 5, 6, 0, 10]

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1131,6 +1131,11 @@ class CollectionSpec extends ObjectBehavior
             )
             ->shouldIterateAs([0 => 'a', 3 => 'd']);
 
+        $this::fromIterable(range(0, 10))
+            ->filter(static fn (int $value): bool => $value % 2 === 0)
+            ->filter(static fn (int $value): bool => $value % 3 === 0)
+            ->shouldIterateAs([0 => 0, 6 => 6]);
+
         $this::fromIterable([true, false, 0, '', null])
             ->filter()
             ->shouldIterateAs([true]);

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1124,16 +1124,12 @@ class CollectionSpec extends ObjectBehavior
             ->filter($callableWithKey)
             ->shouldIterateAs([6 => 6, 8 => 8, 10 => 10]);
 
-        $this::fromIterable(['afooe', 'fooe', 'allo', 'llo'])
+        $this::fromIterable(['a', 'b', 'c', 'd'])
             ->filter(
-                static function ($value) {
-                    return 0 === mb_strpos($value, 'a');
-                },
-                static function ($value) {
-                    return mb_strlen($value) - 1 === mb_strpos($value, 'o');
-                }
+                static fn (string $value): bool => 'a' === $value,
+                static fn (string $value): bool => 'd' === $value
             )
-            ->shouldIterateAs([2 => 'allo']);
+            ->shouldIterateAs([0 => 'a', 3 => 'd']);
 
         $this::fromIterable([true, false, 0, '', null])
             ->filter()


### PR DESCRIPTION
All the operations having variadic arguments evaluates as logical `OR`, the filter operation should also follow that rule.

**BREAKING CHANGE: yes**

This PR

* [x] Update the Filter operation
* [x] Has updated documentation
* [x] Has updated tests

Related to #123 and #125 
