### PR TITLE
Add Collection::isEmpty Method

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -476,9 +476,12 @@ Signature: ``Collection::contains(...$values);``
     }
 
 count
-~~~~~~~~
+~~~~~
 
-Returns the number of elements in a collection
+Returns the number of elements in a collection.
+
+.. tip:: If you only want to check whether the collection is empty or not, use the ``isEmpty`` 
+         operation as it will be significant more performant in a large collection.
 
 Interface: `Countable`_
 
@@ -1170,6 +1173,26 @@ Signature: ``Collection::intersperse($element, int $every = 1, int $startAt = 0)
     foreach($collection as $item) {
         var_dump($item); // 'x', 'a', 'x', 'b', 'x', 'c'
     }
+
+isEmpty
+~~~~~~~
+
+Check if a collection has any elements inside.
+
+Interface: `IsEmptyable`_
+
+Signature: ``Collection::isEmpty();``
+
+.. code-block:: php
+
+    Collection::fromIterable(range('a', 'c'))
+        ->isEmpty(); // false
+
+    Collection::fromIterable([])
+        ->isEmpty(); // true
+
+    Collection::fromIterable([null])
+        ->isEmpty(); // false
 
 key
 ~~~
@@ -2385,6 +2408,7 @@ Signature: ``Collection::zip(iterable ...$iterables);``
 .. _Intersectable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Intersectable.php
 .. _Intersectkeysable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Intersectkeysable.php
 .. _Intersperseable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Intersperseable.php
+.. _IsEmptyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/IsEmptyable.php
 .. _Keyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Keyable.php
 .. _Keysable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Keysable.php
 .. _Lastable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Lastable.php

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -480,7 +480,7 @@ count
 
 Returns the number of elements in a collection.
 
-.. tip:: If you only want to check whether the collection is empty or not, use the ``isEmpty`` 
+.. tip:: If you only want to check whether the collection is empty or not, use the ``isEmpty``
          operation as it will be significant more performant in a large collection.
 
 Interface: `Countable`_
@@ -1183,16 +1183,8 @@ Interface: `IsEmptyable`_
 
 Signature: ``Collection::isEmpty();``
 
-.. code-block:: php
-
-    Collection::fromIterable(range('a', 'c'))
-        ->isEmpty(); // false
-
-    Collection::fromIterable([])
-        ->isEmpty(); // true
-
-    Collection::fromIterable([null])
-        ->isEmpty(); // false
+.. literalinclude:: code/operations/isEmpty.php
+  :language: php
 
 key
 ~~~

--- a/docs/pages/code/operations/isEmpty.php
+++ b/docs/pages/code/operations/isEmpty.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+Collection::fromIterable(range('a', 'c'))
+    ->isEmpty(); // false
+
+Collection::fromIterable([])
+    ->isEmpty(); // true
+
+Collection::fromIterable([null])
+    ->isEmpty(); // false

--- a/docs/pages/code/simple.php
+++ b/docs/pages/code/simple.php
@@ -11,27 +11,8 @@ include __DIR__ . '/../../../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
-$collection = Collection::range(0, 100_000_000);
+$collection = Collection::fromIterable(['A', 'B', 'C', 'D', 'E']);
 
-$times = 0;
-$for = range(1, 10);
-
-foreach ($for as $i) {
-    $start = microtime(true);
-
-    $isEmpty = $collection->count() === 0;
-
-    $end = microtime(true);
-
-    $times += $end - $start;
-}
-
-var_dump($times / count($for));
-
-
-
-
-exit;
 // Get the result as an array.
 $collection
     ->all(); // ['A', 'B', 'C', 'D', 'E']

--- a/docs/pages/code/simple.php
+++ b/docs/pages/code/simple.php
@@ -11,8 +11,27 @@ include __DIR__ . '/../../../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
-$collection = Collection::fromIterable(['A', 'B', 'C', 'D', 'E']);
+$collection = Collection::range(0, 100_000_000);
 
+$times = 0;
+$for = range(1, 10);
+
+foreach ($for as $i) {
+    $start = microtime(true);
+
+    $isEmpty = $collection->count() === 0;
+
+    $end = microtime(true);
+
+    $times += $end - $start;
+}
+
+var_dump($times / count($for));
+
+
+
+
+exit;
 // Get the result as an array.
 $collection
     ->all(); // ['A', 'B', 'C', 'D', 'E']

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1876,6 +1876,33 @@ class CollectionSpec extends ObjectBehavior
             ->during('all');
     }
 
+    public function it_can_isEmpty(): void
+    {
+        $gen = static fn (): Generator => yield from [];
+
+        $this::fromIterable([])->isEmpty()->shouldBe(true);
+        $this::fromIterable($gen())->isEmpty()->shouldBe(true);
+        $this::empty()->isEmpty()->shouldBe(true);
+
+        $this::fromIterable([null])->isEmpty()->shouldBe(false);
+        $this::fromIterable([[]])->isEmpty()->shouldBe(false);
+        $this::fromIterable([1, 2, 3])->isEmpty()->shouldBe(false);
+
+        $withValues = $this::fromIterable([1, 2, 3]);
+
+        foreach ($withValues as $value) {
+            // iterating once through it
+        }
+        $withValues->isEmpty()->shouldBe(false);
+
+        $withoutValues = $this::fromIterable([]);
+
+        foreach ($withoutValues as $value) {
+            // iterating once through it
+        }
+        $withoutValues->isEmpty()->shouldBe(true);
+    }
+
     public function it_can_key(): void
     {
         $input = array_combine(
@@ -2561,7 +2588,7 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs([5.0, 8.01, 11.02, 12.78, 14.03, 15.0]);
     }
 
-    public function it_can_scanleft(): void
+    public function it_can_scanLeft(): void
     {
         $callback = static function ($carry, $value) {
             return $carry / $value;
@@ -2586,7 +2613,7 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs([0 => 3]);
     }
 
-    public function it_can_scanleft1(): void
+    public function it_can_scanLeft1(): void
     {
         $callback = static function ($carry, $value) {
             return $carry / $value;
@@ -2601,7 +2628,7 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs([12]);
     }
 
-    public function it_can_scanright(): void
+    public function it_can_scanRight(): void
     {
         $callback = static function ($carry, $value) {
             return $value / $carry;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -562,6 +562,11 @@ final class Collection implements CollectionInterface
         return new self(Intersperse::of()($element)($every)($startAt), $this->getIterator());
     }
 
+    public function isEmpty(): bool
+    {
+        return !$this->getIterator()->valid();
+    }
+
     /**
      * @return array<mixed>
      */

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -62,6 +62,7 @@ use loophp\collection\Contract\Operation\Initsable;
 use loophp\collection\Contract\Operation\Intersectable;
 use loophp\collection\Contract\Operation\Intersectkeysable;
 use loophp\collection\Contract\Operation\Intersperseable;
+use loophp\collection\Contract\Operation\IsEmptyable;
 use loophp\collection\Contract\Operation\Keyable;
 use loophp\collection\Contract\Operation\Keysable;
 use loophp\collection\Contract\Operation\Lastable;
@@ -179,6 +180,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Intersectable<TKey, T>
  * @template-extends Intersectkeysable<TKey, T>
  * @template-extends Intersperseable<TKey, T>
+ * @template-extends IsEmptyable<TKey, T>
  * @template-extends Keyable<TKey, T>
  * @template-extends Keysable<TKey, T>
  * @template-extends Lastable<TKey, T>
@@ -290,6 +292,7 @@ interface Collection extends
     Intersectable,
     Intersectkeysable,
     Intersperseable,
+    IsEmptyable,
     IteratorAggregate,
     JsonSerializable,
     Keyable,

--- a/src/Contract/Operation/IsEmptyable.php
+++ b/src/Contract/Operation/IsEmptyable.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface IsEmptyable
+{
+    /**
+     * Check if the collection contains any elements.
+     */
+    public function isEmpty(): bool;
+}

--- a/tests/static-analysis/isEmpty.php
+++ b/tests/static-analysis/isEmpty.php
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+function isEmpty_check(bool $value): void
+{
+}
+
+isEmpty_check(Collection::fromIterable([1, 2, 3])->isEmpty());


### PR DESCRIPTION
### Overview
This PR adds the `isEmpty` method and `IsEmptyable` interface.

**Why is this needed when we have `Collection::count`?**

### 1. Convenience
Typical use case:
```PHP
$collection = Collection::fromIterable([1, 2, 3]);
$filteredCollection = $collection->filter(...);

if (!$filteredCollection->isEmpty()) {
    // do something
}

// compared to

if (0 !== $filteredCollection->count()) {
    // do something
}
```

Other popular PHP collection libraries also have this, so people are used to it:
**Doctrine**: https://www.doctrine-project.org/projects/doctrine-collections/en/1.6/index.html#isempty
**Laravel**: https://laravel.com/docs/8.x/collections#method-isempty
**Knapsack**: https://dusankasan.github.io/Knapsack/#Operations-isEmpty

Other languages have this:
**Java**: https://docs.oracle.com/javase/8/docs/api/java/util/Collection.html#isEmpty--
**C++**: https://www.cplusplus.com/reference/vector/vector/empty/
**Haskell**: http://zvon.org/other/haskell/Outputprelude/null_f.html

### 2. Performance
This is a big one. Simple benchmark using `microtime` and `Collection::range(0, 100_000_000)`:

```PHP
$isEmpty = 0 === $collection->count();
// vs
$isEmpty = $collection->isEmpty();
```

Ran it 100,000 times for `isEmpty()`, only 10 times for `count`, and here's why (average time for _a single run_):

 `isEmpty` -> **5.575289726257324E-6 seconds** (basically instant because it's in constant time)
 `count` -> **13.571631002426148 seconds** (this runs in O(N))

### Checklist

- [x] Tests
- [x] Static analysis check
- [x] Documentation