### PR TITLE
Refactor Scalar Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This library has been inspired by:
     needed are standard PHP variables like `int`, `string`, `callable` or
     `iterator`.
     It allows users to use those operations individually, at their own will, to
-    build up something custom. Currently, more than [**80 operations**][28] are
+    build up something custom. Currently, more than [**100 operations**][28] are
     available in this library. This library is an example of what you can do
     with all those small bricks, but nothing prevents users from using an operation
     on its own as well.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,7 +58,7 @@ Features
    the arguments needed are standard PHP variables like ``int``,
    ``string``, ``callable`` or ``iterator``. It allows users to use
    those operations individually, at their own will, to build up
-   something custom. Currently, more than :ref:`80 operations <api>`
+   something custom. Currently, more than :ref:`100 operations <api>`
    are available in this library. This library is an example of what
    you can do with all those small bricks, but nothing prevents users
    from using an operation on its own as well.

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -2072,14 +2072,10 @@ Signature: ``Collection::truthy();``
 .. code-block:: php
 
     $truthyCollection = Collection::fromIterable([2, 3, 4])
-        ->truthy(); // [true]
+        ->truthy(); // true
 
     $falsyCollection = Collection::fromIterable(['a', '', 'c', 'd'])
-        ->truthy(); // [false]
-
-    if ($falsyCollection->truthy()->current()) {
-        // do something
-    }
+        ->truthy(); // false
 
 unlines
 ~~~~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -452,8 +452,7 @@ contains
 
 Check if the collection contains one or more values.
 
-.. warning:: The `values` parameter is variadic and will be evaluated as a logical ``OR``.
-             If you're looking for a logical ``AND``, you have to make separate calls to this method.
+.. warning:: The ``values`` parameter is variadic and will be evaluated as a logical ``OR``.
 
 Interface: `Containsable`_
 
@@ -647,9 +646,7 @@ every
 
 This operation tests whether all elements in the collection pass the test implemented by the provided callback(s).
 
-.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
-             If you're looking for a logical ``AND``, you have to make multiple calls to the
-             same operation.
+.. warning:: The ``callbacks`` parameter is variadic and will be evaluated as a logical ``OR``.
 
 Interface: `Everyable`_
 
@@ -1000,8 +997,6 @@ has
 Check if the collection has values with the help of one or more callables.
 
 .. warning:: The ``callbacks`` parameter is variadic and will be evaluated as a logical ``OR``.
-             If you're looking for a logical ``AND``, you have to make multiple calls to the
-             same operation.
 
 Interface: `Hasable`_
 
@@ -1017,7 +1012,7 @@ Signature: ``Collection::has(callable ...$callbacks);``
 
     Collection::fromIterable(range('A', 'C'))
         ->has(
-            static fn ($value, $key): string => $key > 4 ? 'D' : A',
+            static fn ($value, $key): string => $key > 4 ? 'D' : 'A',
             static fn ($value, $key): string => 'Z'
         ); // true
 

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -160,7 +160,7 @@ When used as a ``Collection`` method, operations fall into three main categories
 1. Operations that return a ``scalar`` value. Currently, this includes:
    ``Contains``, ``Every``, ``Falsy``, ``Has``, ``Key``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
 
-2. Operations that return a new ``Collection`` object - this includes the majority of operations
+2. Operations that return a new ``Collection`` object - this includes the majority of operations.
 
 3. Operations that return a ``Collection`` of ``Collection`` objects. Currently, this includes: ``Partition``, ``Span``.
 

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -703,14 +703,13 @@ Signature: ``Collection::falsy();``
 .. code-block:: php
 
     $truthyCollection = Collection::fromIterable([2, 3, 4])
-        ->falsy(); // [false]
+        ->falsy(); // false
+
+    $truthyCollection = Collection::fromIterable([2, null, 4])
+        ->falsy(); // false
 
     $falsyCollection = Collection::fromIterable(['', null, 0])
-        ->falsy(); // [true]
-
-    if ($falsyCollection->falsy()->current()) {
-        // do something
-    }
+        ->falsy(); // true
 
 filter
 ~~~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -453,8 +453,7 @@ contains
 Check if the collection contains one or more values.
 
 .. warning:: The `values` parameter is variadic and will be evaluated as a logical ``OR``.
-             If you're looking for a logical ``AND``, you have to make separate calls to this method;
-             note the calls cannot be in succession because the collection will contain a boolean after the first call.
+             If you're looking for a logical ``AND``, you have to make separate calls to this method.
 
 Interface: `Containsable`_
 
@@ -463,17 +462,13 @@ Signature: ``Collection::contains(...$values);``
 .. code-block:: php
 
     $collection = Collection::fromIterable(range('a', 'c'))
-        ->contains('d'); // [false]
+        ->contains('d'); // false
 
     $collection = Collection::fromIterable(range('a', 'c'))
-        ->contains('a', 'z'); // [true]
+        ->contains('a', 'z'); // true
 
     $collection = Collection::fromIterable(['a' => 'b', 'c' => 'd'])
-        ->contains('d'); // ['c' => true]
-
-    if ($collection->contains('d')->current()) {
-        // do something
-    }
+        ->contains('d'); // true
 
 count
 ~~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -460,13 +460,13 @@ Signature: ``Collection::contains(...$values);``
 
 .. code-block:: php
 
-    $collection = Collection::fromIterable(range('a', 'c'))
+    $result = Collection::fromIterable(range('a', 'c'))
         ->contains('d'); // false
 
-    $collection = Collection::fromIterable(range('a', 'c'))
+    $result = Collection::fromIterable(range('a', 'c'))
         ->contains('a', 'z'); // true
 
-    $collection = Collection::fromIterable(['a' => 'b', 'c' => 'd'])
+    $result = Collection::fromIterable(['a' => 'b', 'c' => 'd'])
         ->contains('d'); // true
 
 count
@@ -656,14 +656,14 @@ Signature: ``Collection::every(callable ...$callbacks);``
 
     $callback = static function (int $value): bool => $value < 20;
 
-    Collection::fromIterable(range(0, 10))
+    $result = Collection::fromIterable(range(0, 10))
         ->every($callback); // true
 
-    Collection::fromIterable(range(0, 10))
+    $result = Collection::fromIterable(range(0, 10))
         ->append(21)
         ->every($callback); // false
 
-    Collection::fromIterable([])
+    $result = Collection::fromIterable([])
         ->every($callback); // true
 
 explode
@@ -694,13 +694,13 @@ Signature: ``Collection::falsy();``
 
 .. code-block:: php
 
-    $truthyCollection = Collection::fromIterable([2, 3, 4])
+    $result = Collection::fromIterable([2, 3, 4])
         ->falsy(); // false
 
-    $truthyCollection = Collection::fromIterable([2, null, 4])
+    $result = Collection::fromIterable([2, null, 4])
         ->falsy(); // false
 
-    $falsyCollection = Collection::fromIterable(['', null, 0])
+    $result = Collection::fromIterable(['', null, 0])
         ->falsy(); // true
 
 filter
@@ -1004,13 +1004,13 @@ Signature: ``Collection::has(callable ...$callbacks);``
 
 .. code-block:: php
 
-    Collection::fromIterable(range('A', 'C'))
+    $result = Collection::fromIterable(range('A', 'C'))
         ->has(static fn (): string => 'B'); // true
 
-    Collection::fromIterable(range('A', 'C'))
+    $result = Collection::fromIterable(range('A', 'C'))
         ->has(static fn (): string => 'D'); // false
 
-    Collection::fromIterable(range('A', 'C'))
+    $result = Collection::fromIterable(range('A', 'C'))
         ->has(
             static fn ($value, $key): string => $key > 4 ? 'D' : 'A',
             static fn ($value, $key): string => 'Z'
@@ -1411,10 +1411,10 @@ Signature: ``Collection::nullsy();``
 
 .. code-block:: php
 
-    $nullsy = Collection::fromIterable([null, false])
+    $result = Collection::fromIterable([null, false])
         ->nullsy(); // true
 
-    $nonNullsy = Collection::fromIterable(['a', null, 'c'])
+    $result = Collection::fromIterable(['a', null, 'c'])
         ->nullsy(); // false
 
 pack
@@ -2061,10 +2061,10 @@ Signature: ``Collection::truthy();``
 
 .. code-block:: php
 
-    $truthyCollection = Collection::fromIterable([2, 3, 4])
+    $result = Collection::fromIterable([2, 3, 4])
         ->truthy(); // true
 
-    $falsyCollection = Collection::fromIterable(['a', '', 'c', 'd'])
+    $result = Collection::fromIterable(['a', '', 'c', 'd'])
         ->truthy(); // false
 
 unlines

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1002,9 +1002,9 @@ Signature: ``Collection::groupBy(?callable $callback = null);``
 has
 ~~~
 
-Check if the collection has values.
+Check if the collection has values with the help of one or more callables.
 
-.. warning:: The `callbacks` parameter is variadic and will be evaluated as a logical ``OR``.
+.. warning:: The ``callbacks`` parameter is variadic and will be evaluated as a logical ``OR``.
              If you're looking for a logical ``AND``, you have to make multiple calls to the
              same operation.
 
@@ -1015,16 +1015,16 @@ Signature: ``Collection::has(callable ...$callbacks);``
 .. code-block:: php
 
     Collection::fromIterable(range('A', 'C'))
-        ->has(static fn (): string => 'B'); // [1 => true]
+        ->has(static fn (): string => 'B'); // true
 
     Collection::fromIterable(range('A', 'C'))
-        ->has(static fn (): string => 'D'); // [0 => false]
+        ->has(static fn (): string => 'D'); // false
 
     Collection::fromIterable(range('A', 'C'))
         ->has(
-            static fn ($value, $key, Iterator $iterator): string => 'A',
-            static fn ($value, $key, Iterator $iterator): string => 'Z'
-        ); // [true]
+            static fn ($value, $key): string => $key > 4 ? 'D' : A',
+            static fn ($value, $key): string => 'Z'
+        ); // true
 
 head
 ~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -157,7 +157,7 @@ or through the ``Collection`` object.
 When used separately, operations typically return a PHP `Generator`_ or an `Iterator`_.
 When used as a ``Collection`` method, operations fall into a few main categories based on the return type:
 
-1. Operations that return a ``boolean`` value: ``Contains``, ``Every``, ``Falsy``, ``Has``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
+1. Operations that return a ``boolean`` or ``scalar`` value: ``Contains``, ``Count``, ``Every``, ``Falsy``, ``Has``, ``IsEmpty``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
 
 2. Operations that return a ``Collection`` of ``Collection`` objects: ``Partition``, ``Span``.
 
@@ -169,7 +169,7 @@ When used as a ``Collection`` method, operations fall into a few main categories
         which allow using any type as a key as opposed to ``array``, which only allows ``int|string`` keys.
 
 .. note:: Earlier versions of the package had most operations returning a new ``Collection`` object.
-        This was changed based on convenience and ease of use; typical usage of operations which return `scalar` values
+        This was changed based on convenience and ease of use; typical usage of operations which return ``boolean`` values
         would involve immediately retrieving the value inside, whereas for most other operations further transformations
         are likely to be applied.
 

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -657,22 +657,17 @@ Signature: ``Collection::every(callable ...$callbacks);``
 
 .. code-block:: php
 
-    $callback = static function ($value): bool {
-        return $value < 20;
-    };
+    $callback = static function (int $value): bool => $value < 20;
 
     Collection::fromIterable(range(0, 10))
-        ->every($callback)
-        ->current(); // true
+        ->every($callback); // true
 
     Collection::fromIterable(range(0, 10))
         ->append(21)
-        ->every($callback)
-        ->current(); // false
+        ->every($callback); // false
 
     Collection::fromIterable([])
-        ->every($callback)
-        ->current(); // true
+        ->every($callback); // true
 
 explode
 ~~~~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1421,15 +1421,11 @@ Signature: ``Collection::nullsy();``
 
 .. code-block:: php
 
-    $nullsy = Collection::fromIterable([null, null])
-        ->nullsy(); // [true]
+    $nullsy = Collection::fromIterable([null, false])
+        ->nullsy(); // true
 
     $nonNullsy = Collection::fromIterable(['a', null, 'c'])
-        ->nullsy(); // [false]
-
-    if ($falsyCollection->nullsy()->current()) {
-        // do something
-    }
+        ->nullsy(); // false
 
 pack
 ~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1309,15 +1309,15 @@ Signature: ``Collection::mapN(callable ...$callbacks);``
 match
 ~~~~~
 
-Check if the collection match a ``user callback``.
+Check if the collection matches a given ``user callback``.
 
-You must provide a callback that will get the ``key``, the ``current value``, and the ``iterator`` as parameters.
+You must provide a callback that can get the ``key``, the ``current value``, and the ``iterator`` as parameters.
 
 When no matcher callback is provided, the user callback must return ``true`` (the
 default value of the ``matcher callback``) in order to stop.
 
-The returned value of the operation is ``true`` when the callback match at least one element
-of the collection. ``false`` otherwise.
+The returned value of the operation is ``true`` when the callback matches at least one element
+of the collection, ``false`` otherwise.
 
 If you want to match the ``user callback`` against another value (other than ``true``), you must
 provide your own ``matcher callback`` as a second argument, and it must return a ``boolean``.

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -155,17 +155,18 @@ or through the ``Collection`` object.
   :language: php
 
 When used separately, operations typically return a PHP `Generator`_ or an `Iterator`_.
-When used as a ``Collection`` method, operations fall into three main categories based on the return type:
+When used as a ``Collection`` method, operations fall into a few main categories based on the return type:
 
-1. Operations that return a ``scalar`` value. Currently, this includes:
-   ``Contains``, ``Every``, ``Falsy``, ``Has``, ``Key``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
+1. Operations that return a ``boolean`` value: ``Contains``, ``Every``, ``Falsy``, ``Has``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
 
-2. Operations that return a new ``Collection`` object - this includes the majority of operations.
+2. Operations that return a ``Collection`` of ``Collection`` objects: ``Partition``, ``Span``.
 
-3. Operations that return a ``Collection`` of ``Collection`` objects. Currently, this includes: ``Partition``, ``Span``.
+3. Operations that return keys/values from the collection: ``All``, ``Current``, ``Get``, ``Key``.
 
-A couple other operations do not fall neatly in any of the above categories: ``all``, ``current``, ``get``.
-These methods will retrieve items of the collection/iterable directly.
+4. Operations that return a new ``Collection`` object: all other operations.
+
+.. note:: The ``Key`` operation can return any value because ``Collection`` leverages PHP Generators, 
+        which allow using any type as a key as opposed to ``array``, which only allows ``int|string`` keys.
 
 .. note:: Earlier versions of the package had most operations returning a new ``Collection`` object.
         This was changed based on convenience and ease of use; typical usage of operations which return `scalar` values

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -31,7 +31,7 @@ Create a collection from a callable.
     $collection = Collection::fromCallable($callback);
 
 fromFile
-~~~~~~~~~~~~
+~~~~~~~~
 
 Create a collection from a file.
 
@@ -145,7 +145,32 @@ Another example
 Methods (operations)
 --------------------
 
-.. note:: Operations always returns a new collection object, with the exception of ``all``, ``count``, ``current``, ``key``.
+Background
+~~~~~~~~~~
+
+Operations are pure functions which can be used to manipulate an iterator, either directly
+or through the ``Collection`` object.
+
+.. literalinclude:: code/operations/background.php
+  :language: php
+
+When used separately, operations typically return a PHP `Generator`_ or an `Iterator`_.
+When used as a ``Collection`` method, operations fall into three main categories based on the return type:
+
+1. Operations that return a ``scalar`` value. Currently, this includes:
+   ``Contains``, ``Every``, ``Falsy``, ``Has``, ``Key``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
+
+2. Operations that return a new ``Collection`` object - this includes the majority of operations
+
+3. Operations that return a ``Collection`` of ``Collection`` objects. Currently, this includes: ``Partition``, ``Span``.
+
+A couple other operations do not fall neatly in any of the above categories: ``all``, ``current``, ``get``.
+These methods will retrieve items of the collection/iterable directly.
+
+.. note:: Earlier versions of the package had most operations returning a new ``Collection`` object.
+        This was changed based on convenience and ease of use; typical usage of operations which return `scalar` values
+        would involve immediately retrieving the value inside, whereas for most other operations further transformations
+        are likely to be applied.
 
 all
 ~~~
@@ -2342,7 +2367,6 @@ Signature: ``Collection::zip(iterable ...$iterables);``
         ->limit(100)
         ->unwrap(); // [0, 1, 2, 3 ... 196, 197, 198, 199]
 
-.. _Doctrine Collections: https://github.com/doctrine/collections
 .. _Allable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Allable.php
 .. _Appendable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Appendable.php
 .. _Applyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Applyable.php
@@ -2357,9 +2381,7 @@ Signature: ``Collection::zip(iterable ...$iterables);``
 .. _Compactable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Compactable.php
 .. _Coalesceable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Coalesceable.php
 .. _Containsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Containsable.php
-.. _Countable: https://www.php.net/manual/en/class.countable.php
 .. _Currentable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Currentable.php
-.. _Criteria: https://www.doctrine-project.org/projects/doctrine-collections/en/1.6/index.html#matching
 .. _Cycleable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Cycleable.php
 .. _Diffable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Diffable.php
 .. _Diffkeysable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Diffkeysable.php
@@ -2453,7 +2475,13 @@ Signature: ``Collection::zip(iterable ...$iterables);``
 .. _Wordsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Wordsable.php
 .. _Wrapable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Wrapable.php
 .. _Zipable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Zipable.php
+
 .. _array_flip(): https://php.net/array_flip
+.. _Countable: https://www.php.net/manual/en/class.countable.php
+.. _Criteria: https://www.doctrine-project.org/projects/doctrine-collections/en/1.6/index.html#matching
+.. _Doctrine Collections: https://github.com/doctrine/collections
+.. _Generator: https://www.php.net/manual/en/language.generators.overview.php
+.. _Iterator: https://www.php.net/manual/en/class.iterator.php
 .. _symfony/var-dumper: https://packagist.org/packages/symfony/var-dumper
 .. _Traversable: https://www.php.net/manual/en/class.traversable.php
 .. _TypedIterator: https://github.com/loophp/collection/blob/master/src/Iterator/TypedIterator.php

--- a/docs/pages/code/operations/background.php
+++ b/docs/pages/code/operations/background.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use ArrayIterator;
+use loophp\collection\Collection;
+use loophp\collection\Operation\Filter;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$input = [1, 2, 3, 4];
+$even = static fn (int $value): bool => $value % 2 === 0;
+
+// Standalone usage
+$filtered = Filter::of()($even)(new ArrayIterator($input));
+
+print_r(iterator_to_array($filtered)); // [2, 4]
+
+// Usage via Collection object
+$filtered = Collection::fromIterable($input)->filter($even);
+
+print_r($filtered->all()); // [2, 4]

--- a/docs/pages/code/operations/match.php
+++ b/docs/pages/code/operations/match.php
@@ -13,23 +13,15 @@ use loophp\collection\Collection;
 
 include __DIR__ . '/../../../../vendor/autoload.php';
 
-// Example 1
-$matcher = static function (int $value): bool {
-    return 10 > $value;
-};
+// Example 1 -> match found
+$result = Collection::fromIterable(range(1, 100))
+    ->match(static fn (int $value): bool => 10 > $value); // true
 
-$collection = Collection::fromIterable(range(1, 100))
-    ->match($matcher); // true
+// Example 2 -> match not found
+$result = Collection::fromIterable(range(1, 100))
+    ->match(static fn (int $value): bool => 314 < $value); // false
 
-// Example 2
-$matcher = static function (int $value): bool {
-    return 314 < $value;
-};
-
-$collection = Collection::fromIterable(range(1, 100))
-    ->match($matcher); // false
-
-// Example 3
+// Example 3 -> match found
 $input = [
     'Ningbo (CN)',
     'California (US)',
@@ -39,5 +31,9 @@ $input = [
 
 $pattern = '/\(EU\)$/';
 
-$collection = Collection::fromIterable($input)
+$result = Collection::fromIterable($input)
     ->match(static fn (string $value): bool => (bool) preg_match($pattern, $value)); // true
+
+// Example 4 -> custom matcher
+$result = Collection::fromIterable(range(1, 10))
+    ->match(static fn (int $value): bool => 5 !== $value, static fn (): bool => false); // true

--- a/docs/pages/installation.rst
+++ b/docs/pages/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-The easiest way to install it is through Composer_
+The easiest way to install it is through Composer_:
 
 .. code-block:: bash
 

--- a/docs/pages/requirements.rst
+++ b/docs/pages/requirements.rst
@@ -4,7 +4,7 @@ Requirements
 PHP
 ---
 
-PHP greater than 7.4 is required, including 8.0
+PHP greater than 7.4 is required, including 8.0.
 
 Dependencies
 ------------

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1584,60 +1584,38 @@ class CollectionSpec extends ObjectBehavior
         $input = range('A', 'C');
 
         $this::fromIterable($input)
-            ->has(
-                static function ($value, $key) {
-                    return 'A';
-                }
-            )
-            ->shouldIterateAs([true]);
+            ->has(static fn () => 'A')
+            ->shouldBe(true);
 
         $this::fromIterable($input)
-            ->has(
-                static function ($value, $key) {
-                    return 'Z';
-                }
-            )
-            ->shouldIterateAs([false]);
+            ->has(static fn () => 'Z')
+            ->shouldBe(false);
 
         $input = ['b', 1, 'foo', 'bar'];
 
         $this::fromIterable($input)
-            ->has(
-                static function ($value, $key) {
-                    return 'foo';
-                }
-            )
-            ->shouldIterateAs([2 => true]);
+            ->has(static fn () => 'foo')
+            ->shouldBe(true);
 
         $this::fromIterable($input)
-            ->has(
-                static function ($value, $key) {
-                    return 'unknown';
-                }
-            )
-            ->shouldIterateAs([false]);
+            ->has(static fn () => 'unknown')
+            ->shouldBe(false);
 
         $this::empty()
-            ->has(
-                static function ($value, $key) {
-                    return $value;
-                }
-            )
-            ->shouldIterateAs([false]);
+            ->has(static fn ($value) => $value)
+            ->shouldBe(false);
 
         $this::fromIterable($input)
-            ->has(
-                static fn () => 1,
-                static fn () => 'bar'
-            )
-            ->shouldIterateAs([1 => true]);
+            ->has(static fn () => 1, static fn () => 'bar')
+            ->shouldBe(true);
 
         $this::fromIterable($input)
-            ->has(
-                static fn () => 'coin',
-                static fn () => 'bar'
-            )
-            ->shouldIterateAs([3 => true]);
+            ->has(static fn () => 'coin', static fn () => 'bar')
+            ->shouldBe(true);
+
+        $this::fromIterable($input)
+            ->has(static fn ($value, $key) => 5 < $key ? 'bar' : 'coin')
+            ->shouldBe(false);
     }
 
     public function it_can_head(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1090,15 +1090,19 @@ class CollectionSpec extends ObjectBehavior
     {
         $this::fromIterable([false, false, false])
             ->falsy()
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable([false, true, false])
             ->falsy()
-            ->shouldIterateAs([1 => false]);
+            ->shouldBe(false);
+
+        $this::fromIterable([1, 2, null])
+            ->falsy()
+            ->shouldBe(false);
 
         $this::fromIterable([0, [], ''])
             ->falsy()
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
     }
 
     public function it_can_filter(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1989,27 +1989,16 @@ class CollectionSpec extends ObjectBehavior
         $input = range(1, 10);
 
         $this::fromIterable($input)
-            ->match(
-                static function (int $value): bool {
-                    return 7 === $value;
-                }
-            )
-            ->shouldIterateAs([6 => true]);
+            ->match(static fn (int $value): bool => 7 === $value)
+            ->shouldBe(true);
 
         $this::fromIterable($input)
-            ->match(
-                static function (int $value): bool {
-                    return 17 === $value;
-                }
-            )
-            ->shouldIterateAs([0 => false]);
+            ->match(static fn (int $value): bool => 17 === $value)
+            ->shouldBe(false);
 
         $this::fromIterable($input)
-            ->match(
-                static fn (int $value): bool => 5 !== $value,
-                static fn (): bool => false
-            )
-            ->shouldIterateAs([4 => true]);
+            ->match(static fn (int $value): bool => 5 !== $value, static fn (): bool => false)
+            ->shouldBe(true);
     }
 
     public function it_can_matching(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -3123,19 +3123,19 @@ class CollectionSpec extends ObjectBehavior
     {
         $this::fromIterable([true, true, true])
             ->truthy()
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable([true, false, true])
             ->truthy()
-            ->shouldIterateAs([1 => false]);
+            ->shouldBe(false);
 
         $this::fromIterable([1, 2, 3])
             ->truthy()
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable([1, 2, 3, 0])
             ->truthy()
-            ->shouldIterateAs([3 => false]);
+            ->shouldBe(false);
     }
 
     public function it_can_unfold(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -21,6 +21,7 @@ use JsonSerializable;
 use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 use loophp\collection\Contract\Operation;
+use loophp\collection\Iterator\ClosureIterator;
 use loophp\collection\Operation\AbstractOperation;
 use OutOfBoundsException;
 use PhpSpec\Exception\Example\FailureException;
@@ -984,57 +985,42 @@ class CollectionSpec extends ObjectBehavior
     public function it_can_every(): void
     {
         $input = range(0, 10);
-
-        $callback = static function ($value): bool {
-            return 20 > $value;
-        };
+        $callback = static fn ($value): bool => 20 > $value;
 
         $this::fromIterable($input)
             ->every($callback)
-            ->shouldIterateAs([0 => true]);
+            ->shouldBe(true);
 
         $this::empty()
             ->every($callback)
-            ->shouldIterateAs([0 => true]);
+            ->shouldBe(true);
 
         $this::fromIterable($input)
-            ->every(
-                static function ($value, $key, Iterator $iterator): bool {
-                    return is_numeric($key);
-                }
-            )
-            ->shouldIterateAs([0 => true]);
+            ->every(static fn ($value, $key): bool => is_numeric($key))
+            ->shouldBe(true);
 
         $this::fromIterable($input)
-            ->every(
-                static function ($value, $key, Iterator $iterator): bool {
-                    return $iterator instanceof Iterator;
-                }
-            )
-            ->shouldIterateAs([0 => true]);
+            ->every(static fn ($value, $key, Iterator $iterator): bool => $iterator instanceof ClosureIterator)
+            ->shouldBe(true);
 
         $callback1 = static fn ($value, $key): bool => 20 > $value;
         $this::fromIterable($input)
             ->every($callback1)
-            ->shouldIterateAs([0 => true]);
+            ->shouldBe(true);
 
         $callback2 = static fn ($value, $key): bool => 50 < $value;
         $this::fromIterable($input)
             ->every($callback2)
-            ->shouldIterateAs([0 => false]);
+            ->shouldBe(false);
 
         $this::fromIterable($input)
             ->every($callback2, $callback1)
-            ->shouldIterateAs([0 => true]);
+            ->shouldBe(true);
 
         // Validate a date
-        $date = '2021-04-09xxx';
-
-        $this::fromString($date, '-')
+        $this::fromString('2021-04-09xxx', '-')
             ->every(static fn (string $value): bool => is_numeric($value))
-            ->shouldIterateAs([
-                2 => false,
-            ]);
+            ->shouldBe(false);
     }
 
     public function it_can_explode(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -652,23 +652,23 @@ class CollectionSpec extends ObjectBehavior
     {
         $this::fromIterable(range('A', 'C'))
             ->contains('A')
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable(range('A', 'C'))
             ->contains('unknown')
-            ->shouldIterateAs([false]);
+            ->shouldBe(false);
 
         $this::fromIterable(range('A', 'C'))
             ->contains('C', 'A')
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable(range('A', 'C'))
             ->contains('C', 'unknown', 'A')
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable(['a' => 'b', 'c' => 'd'])
             ->contains('d')
-            ->shouldIterateAs(['c' => true]);
+            ->shouldBe(true);
     }
 
     public function it_can_convert_use_a_string_as_parameter(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -2169,19 +2169,19 @@ class CollectionSpec extends ObjectBehavior
     {
         $this::fromIterable([null, null, null])
             ->nullsy()
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable([null, 0, null])
             ->nullsy()
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable([null, [], 0, false, ''])
             ->nullsy()
-            ->shouldIterateAs([true]);
+            ->shouldBe(true);
 
         $this::fromIterable([null, [], 0, false, '', 'foo'])
             ->nullsy()
-            ->shouldIterateAs([5 => false]);
+            ->shouldBe(false);
     }
 
     public function it_can_pack(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -509,9 +509,9 @@ final class Collection implements CollectionInterface
         return new self(GroupBy::of()($callable), $this->getIterator());
     }
 
-    public function has(callable ...$callbacks): CollectionInterface
+    public function has(callable ...$callbacks): bool
     {
-        return new self(Has::of()(...$callbacks), $this->getIterator());
+        return (new self(Has::of()(...$callbacks), $this->getIterator()))->getIterator()->current();
     }
 
     public function head(): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -610,9 +610,11 @@ final class Collection implements CollectionInterface
         return new self(MapN::of()(...$callbacks), $this->getIterator());
     }
 
-    public function match(callable $callback, ?callable $matcher = null): CollectionInterface
+    public function match(callable $callback, ?callable $matcher = null): bool
     {
-        return new self(MatchOne::of()($matcher ?? static fn (): bool => true)($callback), $this->getIterator());
+        return (new self(MatchOne::of()($matcher ?? static fn (): bool => true)($callback), $this->getIterator()))
+            ->getIterator()
+            ->current();
     }
 
     public function matching(Criteria $criteria): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -822,9 +822,9 @@ final class Collection implements CollectionInterface
         return new self(Transpose::of(), $this->getIterator());
     }
 
-    public function truthy(): CollectionInterface
+    public function truthy(): bool
     {
-        return new self(Truthy::of(), $this->getIterator());
+        return (new self(Truthy::of(), $this->getIterator()))->getIterator()->current();
     }
 
     public static function unfold(callable $callback, ...$parameters): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -344,9 +344,9 @@ final class Collection implements CollectionInterface
         return new self(Explode::of()(...$explodes), $this->getIterator());
     }
 
-    public function falsy(): CollectionInterface
+    public function falsy(): bool
     {
-        return new self(Falsy::of(), $this->getIterator());
+        return (new self(Falsy::of(), $this->getIterator()))->getIterator()->current();
     }
 
     public function filter(callable ...$callbacks): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -242,9 +242,9 @@ final class Collection implements CollectionInterface
         return new self(Compact::of()(...$values), $this->getIterator());
     }
 
-    public function contains(...$values): CollectionInterface
+    public function contains(...$values): bool
     {
-        return new self(Contains::of()(...$values), $this->getIterator());
+        return (new self(Contains::of()(...$values), $this->getIterator()))->getIterator()->current();
     }
 
     public function count(): int

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -635,9 +635,9 @@ final class Collection implements CollectionInterface
         return new self(Nth::of()($step)($offset), $this->getIterator());
     }
 
-    public function nullsy(): CollectionInterface
+    public function nullsy(): bool
     {
-        return new self(Nullsy::of(), $this->getIterator());
+        return (new self(Nullsy::of(), $this->getIterator()))->getIterator()->current();
     }
 
     public function pack(): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -334,9 +334,9 @@ final class Collection implements CollectionInterface
         return self::fromIterable($emptyArray);
     }
 
-    public function every(callable ...$callbacks): CollectionInterface
+    public function every(callable ...$callbacks): bool
     {
-        return new self(Every::of()(static fn (): bool => false)(...$callbacks), $this->getIterator());
+        return (new self(Every::of()(static fn (): bool => false)(...$callbacks), $this->getIterator()))->getIterator()->current();
     }
 
     public function explode(...$explodes): CollectionInterface

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -156,7 +156,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Duplicateable<TKey, T>
  * @template-extends Everyable<TKey, T>
  * @template-extends Explodeable<TKey, T>
- * @template-extends Falsyable<int, bool>
+ * @template-extends Falsyable<TKey, T>
  * @template-extends Filterable<TKey, T>
  * @template-extends Firstable<TKey, T>
  * @template-extends FlatMapable<TKey, T>

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -193,7 +193,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Mergeable<TKey, T>
  * @template-extends Normalizeable<TKey, T>
  * @template-extends Nthable<TKey, T>
- * @template-extends Nullsyable<int, bool>
+ * @template-extends Nullsyable<TKey, T>
  * @template-extends Packable<TKey, T>
  * @template-extends Padable<TKey, T>
  * @template-extends Pairable<TKey, T>

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -225,7 +225,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Tailsable<TKey, T>
  * @template-extends TakeWhileable<TKey, T>
  * @template-extends Transposeable<TKey, T>
- * @template-extends Truthyable<int, bool>
+ * @template-extends Truthyable<TKey, T>
  * @template-extends Unlinesable<TKey, T>
  * @template-extends Unpackable<TKey, T>
  * @template-extends Unpairable<TKey, T>

--- a/src/Contract/Operation/Containsable.php
+++ b/src/Contract/Operation/Containsable.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use loophp\collection\Contract\Collection;
-
 /**
  * @template TKey
  * @template T
@@ -19,8 +17,6 @@ interface Containsable
 {
     /**
      * @param T ...$values
-     *
-     * @return Collection<TKey, bool>
      */
-    public function contains(...$values): Collection;
+    public function contains(...$values): bool;
 }

--- a/src/Contract/Operation/Everyable.php
+++ b/src/Contract/Operation/Everyable.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Contract\Operation;
 
 use Iterator;
-use loophp\collection\Contract\Collection;
 
 /**
  * @template TKey
@@ -20,8 +19,6 @@ interface Everyable
 {
     /**
      * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
-     *
-     * @return Collection<TKey, bool>
      */
-    public function every(callable ...$callbacks): Collection;
+    public function every(callable ...$callbacks): bool;
 }

--- a/src/Contract/Operation/Falsyable.php
+++ b/src/Contract/Operation/Falsyable.php
@@ -9,16 +9,11 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use loophp\collection\Contract\Collection;
-
 /**
  * @template TKey
  * @template T
  */
 interface Falsyable
 {
-    /**
-     * @return Collection<int, bool>
-     */
-    public function falsy(): Collection;
+    public function falsy(): bool;
 }

--- a/src/Contract/Operation/Hasable.php
+++ b/src/Contract/Operation/Hasable.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Contract\Operation;
 
 use Iterator;
-use loophp\collection\Contract\Collection;
 
 /**
  * @template TKey
@@ -20,8 +19,6 @@ interface Hasable
 {
     /**
      * @param callable(T, TKey, Iterator<TKey, T>): T ...$callbacks
-     *
-     * @return Collection<TKey, bool>
      */
-    public function has(callable ...$callbacks): Collection;
+    public function has(callable ...$callbacks): bool;
 }

--- a/src/Contract/Operation/Matchable.php
+++ b/src/Contract/Operation/Matchable.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Contract\Operation;
 
 use Iterator;
-use loophp\collection\Contract\Collection;
 
 /**
  * @template TKey
@@ -20,9 +19,7 @@ interface Matchable
 {
     /**
      * @param callable(T, TKey, Iterator<TKey, T>): bool $callback
-     * @param null|callable(T, TKey, Iterator<TKey, T>): T $matcher
-     *
-     * @return Collection<int, bool>
+     * @param null|callable(T, TKey, Iterator<TKey, T>): bool $matcher
      */
-    public function match(callable $callback, ?callable $matcher = null): Collection;
+    public function match(callable $callback, ?callable $matcher = null): bool;
 }

--- a/src/Contract/Operation/Nullsyable.php
+++ b/src/Contract/Operation/Nullsyable.php
@@ -9,16 +9,11 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use loophp\collection\Contract\Collection;
-
 /**
  * @template TKey
  * @template T
  */
 interface Nullsyable
 {
-    /**
-     * @return Collection<int, bool>
-     */
-    public function nullsy(): Collection;
+    public function nullsy(): bool;
 }

--- a/src/Contract/Operation/Truthyable.php
+++ b/src/Contract/Operation/Truthyable.php
@@ -9,16 +9,11 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use loophp\collection\Contract\Collection;
-
 /**
  * @template TKey
  * @template T
  */
 interface Truthyable
 {
-    /**
-     * @return Collection<int, bool>
-     */
-    public function truthy(): Collection;
+    public function truthy(): bool;
 }

--- a/src/Operation/Falsy.php
+++ b/src/Operation/Falsy.php
@@ -28,22 +28,10 @@ final class Falsy extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $matchCallback =
-            /**
-             * @param T $value
-             */
-            static fn ($value): bool => (bool) $value;
-
-        $mapCallback =
-            /**
-             * @param T $value
-             */
-            static fn ($value): bool => !(bool) $value;
-
         /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
         $pipe = Pipe::of()(
-            MatchOne::of()(static fn (): bool => true)($matchCallback),
-            Map::of()($mapCallback),
+            MatchOne::of()(static fn (): bool => true)(static fn ($value): bool => (bool) $value),
+            Map::of()(static fn ($value): bool => !(bool) $value),
         );
 
         // Point free style.

--- a/src/Operation/MatchOne.php
+++ b/src/Operation/MatchOne.php
@@ -27,22 +27,22 @@ final class MatchOne extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T): Closure(callable(T, TKey, Iterator<TKey, T>): bool): Closure(Iterator<TKey, T>): Generator<TKey|int, bool>
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T, TKey, Iterator<TKey, T>): T $matcher
+             * @param callable(T, TKey, Iterator<TKey, T>): bool ...$matchers
              *
-             * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool): Closure(Iterator<TKey, T>): Generator<TKey|int, bool>
+             * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, bool>
              */
             static function (callable ...$matchers): Closure {
                 return
                     /**
                      * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
                      *
-                     * @return Closure(Iterator<TKey, T>): Generator<TKey|int, bool>
+                     * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
                      */
                     static function (callable ...$callbacks) use ($matchers): Closure {
                         $callbackReducer =
@@ -79,7 +79,7 @@ final class MatchOne extends AbstractOperation
                                      */
                                     static fn ($value, $key, Iterator $iterator): bool => $reducer1($value, $key, $iterator) === $reducer2($value, $key, $iterator);
 
-                        /** @var Closure(Iterator<TKey, T>): Generator<TKey|int, bool> $pipe */
+                        /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
                         $pipe = Pipe::of()(
                             Map::of()($mapCallback($callbackReducer($callbacks))($callbackReducer($matchers))),
                             DropWhile::of()(static fn (bool $value): bool => false === $value),

--- a/src/Operation/Nullsy.php
+++ b/src/Operation/Nullsy.php
@@ -35,15 +35,9 @@ final class Nullsy extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $mapCallback =
-            /**
-             * @param T $value
-             */
-            static fn ($value): bool => in_array($value, self::VALUES, true);
-
         /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
         $pipe = Pipe::of()(
-            MatchOne::of()(static fn (): bool => false)($mapCallback),
+            MatchOne::of()(static fn (): bool => false)(static fn ($value): bool => in_array($value, self::VALUES, true)),
             Map::of()(static fn ($value): bool => !$value),
         );
 

--- a/src/Operation/Nullsy.php
+++ b/src/Operation/Nullsy.php
@@ -20,6 +20,8 @@ use function in_array;
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class Nullsy extends AbstractOperation
 {

--- a/src/Operation/Truthy.php
+++ b/src/Operation/Truthy.php
@@ -28,16 +28,10 @@ final class Truthy extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $callback =
-            /**
-             * @param T $value
-             */
-            static fn ($value): bool => !(bool) $value;
-
         /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
         $pipe = Pipe::of()(
-            MatchOne::of()(static fn (): bool => true)($callback),
-            Map::of()($callback),
+            MatchOne::of()(static fn (): bool => true)(static fn ($value): bool => !(bool) $value),
+            Map::of()(static fn ($value): bool => !(bool) $value),
         );
 
         // Point free style.

--- a/src/Utils/CallbacksArrayReducer.php
+++ b/src/Utils/CallbacksArrayReducer.php
@@ -27,7 +27,7 @@ final class CallbacksArrayReducer
      *
      * @return Closure(list<callable(T, TKey, Iterator<TKey, T>): bool>, T, TKey, Iterator<TKey, T>): bool
      */
-    public static function or()
+    public static function or(): Closure
     {
         return
             /**

--- a/tests/static-analysis/contains.php
+++ b/tests/static-analysis/contains.php
@@ -10,38 +10,18 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
-/**
- * @param CollectionInterface<int, bool> $collection
- */
-function contains_checkList(CollectionInterface $collection): void
-{
-}
-/**
- * @param CollectionInterface<string, bool> $collection
- */
-function contains_checkMap(CollectionInterface $collection): void
-{
-}
-function contains_checkBool(bool $value): void
+function contains_check(bool $value): void
 {
 }
 
-contains_checkList(Collection::fromIterable([1, 2, 3])->contains(2));
-contains_checkList(Collection::fromIterable(range(1, 3))->contains(2, 4));
+contains_check(Collection::fromIterable([1, 2, 3])->contains(2));
+contains_check(Collection::fromIterable(range(1, 3))->contains(2, 4));
 
-contains_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar'));
+contains_check(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar'));
 /** @psalm-suppress InvalidArgument -> Psalm is smart and knows that 'abc' cannot be in there */
-contains_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar', 'abc'));
+contains_check(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar', 'abc'));
 
-// VALID failures below -> `current` can return `NULL` if the collection is empty
-
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-contains_checkBool(Collection::fromIterable([1, 2, 3])->contains(2)->current());
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-contains_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->contains('bar')->current());
-
-// explicit check is needed for PHPStan because the value is of type `bool|null`
-if (true === Collection::fromIterable([1, 2, 3])->contains(2)->current()) {
+if (Collection::fromIterable([1, 2, 3])->contains(2)) {
+    // do something
 }

--- a/tests/static-analysis/every.php
+++ b/tests/static-analysis/every.php
@@ -10,21 +10,8 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
-/**
- * @param CollectionInterface<int, bool> $collection
- */
-function every_checkList(CollectionInterface $collection): void
-{
-}
-/**
- * @param CollectionInterface<string, bool> $collection
- */
-function every_checkMap(CollectionInterface $collection): void
-{
-}
-function every_checkBool(bool $value): void
+function every_check(bool $value): void
 {
 }
 
@@ -33,19 +20,12 @@ $negative = static fn (int $val): bool => 0 > $val;
 $bar = static fn (string $val): bool => 'bar' === $val;
 $long = static fn (string $val): bool => mb_strlen($val) > 3;
 
-every_checkList(Collection::fromIterable([1, 2, 3])->every($even));
-every_checkList(Collection::fromIterable([-1, 2, -3])->every($even, $negative));
+every_check(Collection::fromIterable([1, 2, 3])->every($even));
+every_check(Collection::fromIterable([-1, 2, -3])->every($even, $negative));
 
-every_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->every($bar));
-every_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'looooooooong'])->every($bar, $long));
+every_check(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->every($bar));
+every_check(Collection::fromIterable(['foo' => 'bar', 'baz' => 'looooooooong'])->every($bar, $long));
 
-// VALID failures below -> `current` can return `NULL` if the collection is empty
-
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-every_checkBool(Collection::fromIterable([1, 2, 3])->every($even)->current());
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-every_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->every($bar)->current());
-
-// explicit check is needed for PHPStan because the value is of type `bool|null`
-if (true === Collection::fromIterable([1, 2, 3])->every($even)->current()) {
+if (Collection::fromIterable([1, 2, 3])->every($even)) {
+    // do something
 }

--- a/tests/static-analysis/falsy.php
+++ b/tests/static-analysis/falsy.php
@@ -10,35 +10,15 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
-/**
- * @param CollectionInterface<int, bool> $collection
- */
-function falsy_checkList(CollectionInterface $collection): void
-{
-}
-function falsy_checkBool(bool $value): void
+function falsy_check(bool $value): void
 {
 }
 
-falsy_checkList(Collection::fromIterable([1, 2, 3])->falsy());
-falsy_checkList(Collection::fromIterable([1, 2, 3])->falsy()->falsy());
-falsy_checkList(Collection::fromIterable([null, ''])->falsy());
-falsy_checkList(Collection::fromIterable(['foo' => 'bar'])->falsy());
+falsy_check(Collection::fromIterable([1, 2, 3])->falsy());
+falsy_check(Collection::fromIterable([null, ''])->falsy());
+falsy_check(Collection::fromIterable(['foo' => 'bar'])->falsy());
 
-// This retrieval method doesn't cause static analysis complaints
-// but is not always reliable because of that.
-falsy_checkBool(Collection::fromIterable([1, 2, 3])->falsy()->all()[0]);
-falsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->falsy()->all()[2]);
-
-// VALID failures below -> `current` can return `NULL` if the collection is empty
-
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-falsy_checkBool(Collection::fromIterable([1, 2, 3])->falsy()->current());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-falsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->falsy()->current());
-
-// explicit check is needed for PHPStan because the value is of type `bool|null`
-if (true === Collection::fromIterable([1, 2, 3])->falsy()->current()) {
+if (!Collection::fromIterable([1, 2, 3])->falsy()) {
+    // do something
 }

--- a/tests/static-analysis/has.php
+++ b/tests/static-analysis/has.php
@@ -10,21 +10,8 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
-/**
- * @param CollectionInterface<int, bool> $collection
- */
-function has_checkList(CollectionInterface $collection): void
-{
-}
-/**
- * @param CollectionInterface<string, bool> $collection
- */
-function has_checkMap(CollectionInterface $collection): void
-{
-}
-function has_checkBool(bool $value): void
+function has_check(bool $value): void
 {
 }
 
@@ -39,38 +26,24 @@ $letterB = static fn (): string => 'b';
 $capital = static fn (string $value): string => strtoupper($value);
 $withStringKey = static fn (string $value, string $key): string => 'foo' === $key ? 'f' : 'b';
 
-has_checkList(Collection::fromIterable([1, 2, 3])->has($number2));
-has_checkList(Collection::fromIterable(range(1, 3))->has($number2, $number2));
-has_checkList(Collection::fromIterable([1, 2, 3])->has($withKey));
+has_check(Collection::fromIterable([1, 2, 3])->has($number2));
+has_check(Collection::fromIterable(range(1, 3))->has($number2, $number2));
+has_check(Collection::fromIterable([1, 2, 3])->has($withKey));
 
-has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF));
-has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF, $letterB));
-has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($withStringKey));
+has_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF));
+has_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF, $letterB));
+has_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($withStringKey));
 
 // These are valid and should work, however Psalm restricts the values that the callable
 // is allowed to return to the values contained in the collection
 
 /** @psalm-suppress ArgumentTypeCoercion */
-has_checkList(Collection::fromIterable([1, 2, 3])->has($square));
+has_check(Collection::fromIterable([1, 2, 3])->has($square));
 /** @psalm-suppress InvalidArgument */
-has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterZ));
+has_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterZ));
 /** @psalm-suppress ArgumentTypeCoercion */
-has_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($capital));
+has_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($capital));
 
-// This retrieval method doesn't cause static analysis complaints
-// but is not always reliable because of that.
-has_checkBool(Collection::fromIterable([1, 2, 3])->has($number2)->all()[0]);
-has_checkBool(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF)->all()['foo']);
-/** @psalm-suppress InvalidArrayOffset -> in this case Psalm can tell that the key won't exist */
-has_checkBool(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF)->all()['randomKey']);
-
-// VALID failures below -> `current` can return `NULL` if the collection is empty
-
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-has_checkBool(Collection::fromIterable([1, 2, 3])->has($number2)->current());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-has_checkBool(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->has($letterF)->current());
-
-// explicit check is needed for PHPStan because the value is of type `bool|null`
-if (true === Collection::fromIterable([1, 2, 3])->has($number2)->current()) {
+if (Collection::fromIterable([1, 2, 3])->has($number2)) {
+    // do something
 }

--- a/tests/static-analysis/match.php
+++ b/tests/static-analysis/match.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+function match_check(bool $value): void
+{
+}
+
+$even = static fn (int $val): bool => $val % 2 === 0;
+$negative = static fn (int $val): bool => 0 > $val;
+$bar = static fn (string $val): bool => 'bar' === $val;
+$long = static fn (string $val): bool => mb_strlen($val) > 3;
+
+match_check(Collection::fromIterable([1, 2, 3])->match($even));
+match_check(Collection::fromIterable([1, 2, 3])->match($even, $negative));
+match_check(Collection::fromIterable([-1, -2, -3])->match($even, static fn (): bool => false));
+
+match_check(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->match($bar));
+match_check(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->match($bar, static fn (): bool => false));
+match_check(Collection::fromIterable(['foo' => 'bar', 'baz' => 'looooooooong'])->match($bar, $long));
+
+if (Collection::fromIterable([1, 2, 3])->match($even)) {
+    // do something
+}

--- a/tests/static-analysis/nullsy.php
+++ b/tests/static-analysis/nullsy.php
@@ -10,35 +10,15 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
-/**
- * @param CollectionInterface<int, bool> $collection
- */
-function nullsy_checkList(CollectionInterface $collection): void
-{
-}
-function nullsy_checkBool(bool $value): void
+function nullsy_check(bool $value): void
 {
 }
 
-nullsy_checkList(Collection::fromIterable([1, 2, 3])->nullsy());
-nullsy_checkList(Collection::fromIterable([1, 2, 3])->nullsy()->nullsy());
-nullsy_checkList(Collection::fromIterable([null, ''])->nullsy());
-nullsy_checkList(Collection::fromIterable(['foo' => 'bar'])->nullsy());
+nullsy_check(Collection::fromIterable([1, 2, 3])->nullsy());
+nullsy_check(Collection::fromIterable([null, ''])->nullsy());
+nullsy_check(Collection::fromIterable(['foo' => 'bar'])->nullsy());
 
-// This retrieval method doesn't cause static analysis complaints
-// but is not always reliable because of that.
-nullsy_checkBool(Collection::fromIterable([1, 2, 3])->nullsy()->all()[0]);
-nullsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->nullsy()->all()[2]);
-
-// VALID failures below -> `current` can return `NULL` if the collection is empty
-
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-nullsy_checkBool(Collection::fromIterable([1, 2, 3])->nullsy()->current());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-nullsy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->nullsy()->current());
-
-// explicit check is needed for PHPStan because the value is of type `bool|null`
-if (true === Collection::fromIterable([1, 2, 3])->nullsy()->current()) {
+if (Collection::fromIterable([1, 2, 3])->nullsy()) {
+    // do something
 }

--- a/tests/static-analysis/truthy.php
+++ b/tests/static-analysis/truthy.php
@@ -10,35 +10,15 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
-/**
- * @param CollectionInterface<int, bool> $collection
- */
-function truthy_checkList(CollectionInterface $collection): void
-{
-}
-function truthy_checkBool(bool $value): void
+function truthy_check(bool $value): void
 {
 }
 
-truthy_checkList(Collection::fromIterable([1, 2, 3])->truthy());
-truthy_checkList(Collection::fromIterable([1, 2, 3])->truthy()->truthy());
-truthy_checkList(Collection::fromIterable([null, ''])->truthy());
-truthy_checkList(Collection::fromIterable(['foo' => 'bar'])->truthy());
+truthy_check(Collection::fromIterable([1, 2, 3])->truthy());
+truthy_check(Collection::fromIterable([null, ''])->truthy());
+truthy_check(Collection::fromIterable(['foo' => 'bar'])->truthy());
 
-// This retrieval method doesn't cause static analysis complaints
-// but is not always reliable because of that.
-truthy_checkBool(Collection::fromIterable([1, 2, 3])->truthy()->all()[0]);
-truthy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->truthy()->all()[2]);
-
-// VALID failures below -> `current` can return `NULL` if the collection is empty
-
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-truthy_checkBool(Collection::fromIterable([1, 2, 3])->truthy()->current());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
-truthy_checkBool(Collection::fromIterable(['foo' => 'bar', 'baz' => 'taz'])->truthy()->current());
-
-// explicit check is needed for PHPStan because the value is of type `bool|null`
-if (true === Collection::fromIterable([1, 2, 3])->truthy()->current()) {
+if (Collection::fromIterable([1, 2, 3])->truthy()) {
+    // do something
 }


### PR DESCRIPTION
This PR refactors Collection Operations which currently return a single scalar value inside a collection, returning the scalar directly.

* [x] Contains 
* [x] Every
* [x] Falsy
* [x] Has 
* [x] Match + static analysis check & type fixes
* [x] Nullsy
* [x] Truthy

Related to https://github.com/loophp/collection/discussions/107.
