### PR TITLE
Add All Operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -159,17 +159,8 @@ Interface: `Allable`_
 
 Signature: ``Collection::all();``
 
-.. code-block:: php
-
-        $generator = static function (): Generator {
-            yield 0 => 'a';
-            yield 1 => 'b';
-            yield 0 => 'c';
-            yield 2 => 'd';
-        };
-
-        Collection::fromIterable($generator())
-            ->all(); // [0 => 'c', 1 => 'b', 2 => 'd']
+.. literalinclude:: code/operations/all.php
+  :language: php
 
 append
 ~~~~~~

--- a/docs/pages/code/operations/all.php
+++ b/docs/pages/code/operations/all.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use ArrayIterator;
+use Generator;
+use loophp\collection\Collection;
+use loophp\collection\Operation\All;
+use loophp\collection\Operation\Filter;
+use loophp\collection\Operation\Pipe;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+// Example 1 -> usage with Collection
+$generator = static function (): Generator {
+    yield 0 => 'a';
+
+    yield 1 => 'b';
+
+    yield 0 => 'c';
+
+    yield 2 => 'd';
+};
+
+$collection = Collection::fromIterable($generator());
+print_r($collection->all()); // [0 => 'c', 1 => 'b', 2 => 'd']
+
+// Example 2 -> standalone usage
+$even = static fn (int $value): bool => $value % 2 === 0;
+
+$piped = Pipe::of()(Filter::of()($even), All::of())(new ArrayIterator([1, 2, 3, 4]));
+print_r($piped); // [2, 4]

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -27,6 +27,7 @@ use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\ObjectBehavior;
 use stdClass;
+use TypeError;
 use function gettype;
 use const E_USER_DEPRECATED;
 use const INF;
@@ -34,6 +35,45 @@ use const PHP_EOL;
 
 class CollectionSpec extends ObjectBehavior
 {
+    public function it_can_all(): void
+    {
+        $this::fromIterable([1, 2, 3])
+            ->all()
+            ->shouldIterateAs([1, 2, 3]);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->all()
+            ->shouldIterateAs(['foo' => 'f', 'bar' => 'b']);
+
+        $duplicateKeyGen = static function (): Generator {
+            yield 'a' => 1;
+
+            yield 'b' => 2;
+
+            yield 'a' => 3;
+        };
+
+        $this::fromIterable($duplicateKeyGen())
+            ->shouldIterateAs($duplicateKeyGen());
+
+        $this::fromIterable($duplicateKeyGen())
+            ->all()
+            ->shouldIterateAs(['a' => 3, 'b' => 2]);
+
+        $nonArrayKeyGen = static function (): Generator {
+            yield ['a'] => 1;
+
+            yield ['b'] => 2;
+        };
+
+        $this::fromIterable($nonArrayKeyGen())
+            ->shouldIterateAs($nonArrayKeyGen());
+
+        $this::fromIterable($nonArrayKeyGen())
+            ->shouldThrow(TypeError::class)
+            ->during('all');
+    }
+
     public function it_can_append(): void
     {
         $generator = static function (): Generator {

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -27,7 +27,6 @@ use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\ObjectBehavior;
 use stdClass;
-use TypeError;
 use function gettype;
 use const E_USER_DEPRECATED;
 use const INF;

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -59,19 +59,6 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable($duplicateKeyGen())
             ->all()
             ->shouldIterateAs(['a' => 3, 'b' => 2]);
-
-        $nonArrayKeyGen = static function (): Generator {
-            yield ['a'] => 1;
-
-            yield ['b'] => 2;
-        };
-
-        $this::fromIterable($nonArrayKeyGen())
-            ->shouldIterateAs($nonArrayKeyGen());
-
-        $this::fromIterable($nonArrayKeyGen())
-            ->shouldThrow(TypeError::class)
-            ->during('all');
     }
 
     public function it_can_append(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -18,6 +18,7 @@ use loophp\collection\Iterator\ClosureIterator;
 use loophp\collection\Iterator\IterableIterator;
 use loophp\collection\Iterator\ResourceIterator;
 use loophp\collection\Iterator\StringIterator;
+use loophp\collection\Operation\All;
 use loophp\collection\Operation\Append;
 use loophp\collection\Operation\Apply;
 use loophp\collection\Operation\Associate;
@@ -169,7 +170,7 @@ final class Collection implements CollectionInterface
 
     public function all(): array
     {
-        return iterator_to_array($this->getIterator());
+        return All::of()($this->getIterator());
     }
 
     public function append(...$items): CollectionInterface

--- a/src/Contract/Operation/Pipeable.php
+++ b/src/Contract/Operation/Pipeable.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Generator;
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -20,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Pipeable
 {
     /**
-     * @param callable(Iterator<TKey, T>): Generator<TKey, T> ...$callbacks
+     * @param callable(iterable<TKey, T>): iterable<TKey, T> ...$callbacks
      *
      * @return Collection<TKey, T>
      */

--- a/src/Operation/All.php
+++ b/src/Operation/All.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Iterator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class All extends AbstractOperation
+{
+    /**
+     * @pure
+     *
+     * @return Closure(Iterator<TKey, T>): array<TKey, T>
+     */
+    public function __invoke(): Closure
+    {
+        return static fn (Iterator $iterator): array => iterator_to_array($iterator);
+    }
+}

--- a/src/Operation/Pipe.php
+++ b/src/Operation/Pipe.php
@@ -10,8 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,31 +24,31 @@ final class Pipe extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(...callable(Iterator<TKey, T>):Generator<TKey, T, mixed, mixed>):Closure(Iterator<TKey, T>):Iterator<TKey, T>
+     * @return Closure(callable(iterable<TKey, T>): iterable<TKey, T> ...): Closure(iterable<TKey, T>): iterable<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(Iterator<TKey, T>): Generator<TKey, T> ...$operations
+             * @param callable(iterable<TKey, T>): iterable<TKey, T> ...$operations
              *
-             * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
+             * @return Closure(iterable<TKey, T>): iterable<TKey, T>
              */
             static fn (callable ...$operations): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterator
                  *
-                 * @return Iterator<TKey, T>
+                 * @return iterable<TKey, T>
                  */
-                static function (Iterator $iterator) use ($operations): Iterator {
+                static function (iterable $iterator) use ($operations): iterable {
                     $callback =
                         /**
-                         * @param Iterator<TKey, T> $iterator
-                         * @param callable(Iterator<TKey, T>): Iterator<TKey, T> $callable
+                         * @param iterable<TKey, T> $iterator
+                         * @param callable(iterable<TKey, T>): iterable<TKey, T> $callable
                          *
-                         * @return Iterator<TKey, T>
+                         * @return iterable<TKey, T>
                          */
-                        static fn (Iterator $iterator, callable $callable): Iterator => $callable($iterator);
+                        static fn (iterable $iterator, callable $callable): iterable => $callable($iterator);
 
                     return array_reduce($operations, $callback, $iterator);
                 };

--- a/tests/static-analysis/all.php
+++ b/tests/static-analysis/all.php
@@ -10,9 +10,6 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Operation\All;
-use loophp\collection\Operation\Filter;
-use loophp\collection\Operation\Pipe;
 
 /**
  * @param array<int, int> $array
@@ -32,14 +29,6 @@ function all_checkMap(array $array): void
 function all_checkMixed(array $array): void
 {
 }
-
-$input = [1, 2, 3, 4];
-$even = static fn (int $value): bool => $value % 2 === 0;
-
-// Standalone usage
-$piped = Pipe::of()(Filter::of()($even), All::of())((new ArrayIterator($input)));
-
-print_r($piped);
 
 all_checkList(Collection::empty()->all());
 all_checkMap(Collection::empty()->all());

--- a/tests/static-analysis/all.php
+++ b/tests/static-analysis/all.php
@@ -10,6 +10,9 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
+use loophp\collection\Operation\All;
+use loophp\collection\Operation\Filter;
+use loophp\collection\Operation\Pipe;
 
 /**
  * @param array<int, int> $array
@@ -29,6 +32,14 @@ function all_checkMap(array $array): void
 function all_checkMixed(array $array): void
 {
 }
+
+$input = [1, 2, 3, 4];
+$even = static fn (int $value): bool => $value % 2 === 0;
+
+// Standalone usage
+$piped = Pipe::of()(Filter::of()($even), All::of())((new ArrayIterator($input)));
+
+print_r($piped);
 
 all_checkList(Collection::empty()->all());
 all_checkMap(Collection::empty()->all());


### PR DESCRIPTION
This PR:

* [x] Adds an `All` operation
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation

Even though this is a simple one, it's good to have it in an operation so that users that want to use the operations separately can benefit from it and don't have to use `iterator_to_array` all the time.