### PR TITLE
Update `Map` to only take a single callback

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1279,14 +1279,14 @@ map
 Apply a single callback to every item of a collection and use the return value.
 
 .. warning:: An earlier version of this operation allowed usage with multiple callbacks. This behaviour
-        is deprecated and will be removed in a future major version; ``mapN`` should be used instead, or,
+        was removed in version ``5.0``; ``mapN`` should be used instead, or,
         alternatively, multiple successive ``map`` calls can achieve the same result.
 
 .. warning:: Keys are preserved, use the ``Collection::normalize`` operation if you want to re-index the keys.
 
 Interface: `Mapable`_
 
-Signature: ``Collection::map(callable ...$callbacks);``
+Signature: ``Collection::map(callable $callbacks);``
 
 .. code-block:: php
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -600,9 +600,9 @@ final class Collection implements CollectionInterface
         return new self(Lines::of(), $this->getIterator());
     }
 
-    public function map(callable ...$callbacks): CollectionInterface
+    public function map(callable $callback): CollectionInterface
     {
-        return new self(Map::of()(...$callbacks), $this->getIterator());
+        return new self(Map::of()($callback), $this->getIterator());
     }
 
     public function mapN(callable ...$callbacks): CollectionInterface

--- a/src/Contract/Operation/Mapable.php
+++ b/src/Contract/Operation/Mapable.php
@@ -19,15 +19,13 @@ use loophp\collection\Contract\Collection;
 interface Mapable
 {
     /**
-     * Apply one or more callbacks to a collection and use the return value.
-     * Usage with multiple callbacks is deprecated and will be removed in a future major version.
-     * Use mapN instead for multiple callbacks.
+     * Apply a single callback to every item of a collection and use the return value.
      *
      * @template V
      *
-     * @param callable(T, TKey, Iterator<TKey, T>): V ...$callbacks
+     * @param callable(T, TKey, Iterator<TKey, T>): V $callback
      *
      * @return Collection<TKey, V>
      */
-    public function map(callable ...$callbacks): Collection;
+    public function map(callable $callback): Collection;
 }

--- a/src/Operation/Map.php
+++ b/src/Operation/Map.php
@@ -13,10 +13,6 @@ use Closure;
 use Generator;
 use Iterator;
 
-use function count;
-
-use const E_USER_DEPRECATED;
-
 /**
  * @immutable
  *
@@ -30,45 +26,23 @@ final class Map extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T, TKey, Iterator<TKey, T>): T ...$callbacks
+             * @param callable(T, TKey, Iterator<TKey, T>): T $callback
              */
-            static fn (callable ...$callbacks): Closure =>
+            static fn (callable $callback): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
                  * @return Generator<TKey, T>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
-                    if (count($callbacks) > 1) {
-                        @trigger_error(
-                            'Using `Map` with multiple callbacks is deprecated, and will be removed in a future major version; use `MapN` instead.',
-                            E_USER_DEPRECATED
-                        );
-                    }
-
-                    $callbackFactory =
-                        /**
-                         * @param TKey $key
-                         *
-                         * @return Closure(T, callable(T, TKey, Iterator<TKey, T>): T): T
-                         */
-                        static fn ($key): Closure =>
-                            /**
-                             * @param T $carry
-                             * @param callable(T, TKey, Iterator<TKey, T>): T $callback
-                             *
-                             * @return T
-                             */
-                            static fn ($carry, callable $callback) => $callback($carry, $key, $iterator);
-
+                static function (Iterator $iterator) use ($callback): Generator {
                     foreach ($iterator as $key => $value) {
-                        yield $key => array_reduce($callbacks, $callbackFactory($key), $value);
+                        yield $key => $callback($value, $key, $iterator);
                     }
                 };
     }

--- a/tests/static-analysis/map.php
+++ b/tests/static-analysis/map.php
@@ -68,17 +68,4 @@ map_checkListString(Collection::fromIterable([1, 2, 3])->map($square)->map($toSt
 /** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
 map_checkListInt(Collection::fromIterable(['foo' => 'bar'])->map($square));
 /** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
-map_checkListString(Collection::fromIterable(['foo' => 'bar'])->map($square, $toString));
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
 map_checkMapString(Collection::fromIterable([1, 2, 3])->map($appendBar));
-/** @psalm-suppress InvalidArgument, InvalidScalarArgument @phpstan-ignore-next-line */
-map_checkMapClass(Collection::fromIterable([1, 2, 3])->map($appendBar, $toClass));
-
-// VALID failures due to usage with multiple callbacks, which cannot be properly typed
-// `mapN` should be used instead for these use cases, which is more lenient due to `mixed` type hints
-
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
-map_checkListString(Collection::fromIterable([1, 2, 3])->map($square, $toString));
-
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-map_checkMapClass(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->map($appendBar, $toClass));


### PR DESCRIPTION
This PR:

* [x] Updates `Map` to only take a single callback
* [x] It breaks backward compatibility
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation

Follows https://github.com/loophp/collection/pull/112.
Related to https://github.com/loophp/collection/pull/77.