### PR TITLE
Update `Reverse` operation - optimize and remove todos.

### DIFF
--- a/src/Operation/Reverse.php
+++ b/src/Operation/Reverse.php
@@ -12,7 +12,6 @@ namespace loophp\collection\Operation;
 use Closure;
 use Generator;
 use Iterator;
-use loophp\fpt\Reduce;
 
 /**
  * @immutable

--- a/src/Operation/Reverse.php
+++ b/src/Operation/Reverse.php
@@ -12,13 +12,10 @@ namespace loophp\collection\Operation;
 use Closure;
 use Generator;
 use Iterator;
+use loophp\fpt\Reduce;
 
 /**
  * @immutable
- *
- * @todo Remove the Wrap and Unwrap operations
- * @todo They are only needed when: Collection::empty()->reverse()
- * @todo Most probably that the FoldLeft operation needs an update.
  *
  * @template TKey
  * @template T
@@ -44,9 +41,8 @@ final class Reverse extends AbstractOperation
         /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
         $pipe = Pipe::of()(
             Pack::of(),
-            Wrap::of(),
-            FoldLeft::of()($callback)([]),
-            Flatten::of()(1),
+            Reduction::of()($callback)([]),
+            Last::of(),
             Unpack::of(),
         );
 

--- a/tests/static-analysis/reverse.php
+++ b/tests/static-analysis/reverse.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function reverse_checkList(CollectionInterface $collection): void
+{
+}
+
+reverse_checkList(Collection::fromIterable(range(0, 5))->reverse());


### PR DESCRIPTION
This PR:

* [x] Fix Reverse operation - optimize and get rid of todos finally !
* [x] Add static analysis tests 

This can use the new Reduce operation (#139) if that PR is merged before.