### PR TITLE
Span: Add Variadic Callback Support

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1936,7 +1936,7 @@ span
 ~~~~
 
 Partition the collection into two subgroups where the first element is the longest
-prefix (*possibly empty*) of elements that satisfy the callback and the second element
+prefix (*possibly empty*) of elements that satisfy the callback(s) and the second element
 is the remainder.
 
 The raw ``Span`` operation returns a generator yielding two iterators.
@@ -1949,7 +1949,7 @@ resulting iterators will be converted and mapped into ``Collection`` objects.
 
 Interface: `Spanable`_
 
-Signature: ``Collection::span(callable $callback): Collection;``
+Signature: ``Collection::span(callable ...$callbacks): Collection;``
 
 .. literalinclude:: code/operations/span.php
   :language: php

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -2910,9 +2910,15 @@ class CollectionSpec extends ObjectBehavior
         $subject->shouldHaveCount(2);
         $subject->first()->shouldBeAnInstanceOf(CollectionInterface::class);
         $subject->last()->shouldBeAnInstanceOf(CollectionInterface::class);
-
         $subject->first()->current()->shouldIterateAs([1, 2, 3]);
         $subject->last()->current()->shouldIterateAs([3 => 4, 4 => 5, 5 => 6, 6 => 7, 7 => 8, 8 => 9, 9 => 10]);
+
+        $subject = $this::fromIterable($input)->span(static fn (int $x): bool => 4 > $x, static fn (int $x): bool => $x % 2 === 0);
+        $subject->shouldHaveCount(2);
+        $subject->first()->shouldBeAnInstanceOf(CollectionInterface::class);
+        $subject->last()->shouldBeAnInstanceOf(CollectionInterface::class);
+        $subject->first()->current()->shouldIterateAs([1, 2, 3, 4]);
+        $subject->last()->current()->shouldIterateAs([4 => 5, 5 => 6, 6 => 7, 7 => 8, 8 => 9, 9 => 10]);
     }
 
     public function it_can_split(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -775,11 +775,11 @@ final class Collection implements CollectionInterface
         return new self(Sort::of()($type)($callback), $this->getIterator());
     }
 
-    public function span(callable $callback): CollectionInterface
+    public function span(callable ...$callbacks): CollectionInterface
     {
         return new self(
             Pipe::of()(
-                Span::of()($callback),
+                Span::of()(...$callbacks),
                 Map::of()(static fn (Iterator $iterator): CollectionInterface => self::fromIterable($iterator))
             ),
             $this->getIterator()

--- a/src/Contract/Operation/Spanable.php
+++ b/src/Contract/Operation/Spanable.php
@@ -19,9 +19,9 @@ use loophp\collection\Contract\Collection;
 interface Spanable
 {
     /**
-     * @param callable(T, TKey, Iterator<TKey, T>): bool $callback
+     * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
      *
      * @return Collection<int, Collection<TKey, T>>
      */
-    public function span(callable $callback): Collection;
+    public function span(callable ...$callbacks): Collection;
 }

--- a/src/Operation/Span.php
+++ b/src/Operation/Span.php
@@ -32,21 +32,21 @@ final class Span extends AbstractOperation
     {
         return
             /**
-             * @param callable(T, TKey, Iterator<TKey, T>): bool $callback
+             * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
              *
              * @return Closure(Iterator<TKey, T>): Generator<int, Iterator<TKey, T>>
              */
-            static fn (callable $callback): Closure =>
+            static fn (callable ...$callbacks): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
                  * @return Generator<int, Iterator<TKey, T>>
                  */
-                static function (Iterator $iterator) use ($callback): Generator {
+                static function (Iterator $iterator) use ($callbacks): Generator {
                     /** @var Iterator<TKey, T> $takeWhile */
-                    $takeWhile = TakeWhile::of()($callback)($iterator);
+                    $takeWhile = TakeWhile::of()(...$callbacks)($iterator);
                     /** @var Iterator<TKey, T> $dropWhile */
-                    $dropWhile = DropWhile::of()($callback)($iterator);
+                    $dropWhile = DropWhile::of()(...$callbacks)($iterator);
 
                     return yield from [$takeWhile, $dropWhile];
                 };

--- a/src/Operation/TakeWhile.php
+++ b/src/Operation/TakeWhile.php
@@ -33,7 +33,7 @@ final class TakeWhile extends AbstractOperation
     {
         return
             /**
-             * @param callable(T, TKey, Iterator<TKey, T>):bool $callback
+             * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
              *
              * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
              */

--- a/tests/static-analysis/span.php
+++ b/tests/static-analysis/span.php
@@ -38,10 +38,14 @@ function span_checkMapString(CollectionInterface $collection): void
 }
 
 $intValueCallback = static fn (int $value): bool => $value % 2 === 0;
+$intSecondCallback = static fn (int $value): bool => 3 > $value;
 $stringValueCallback = static fn (string $value): bool => 'bar' === $value;
+$stringSecondCallback = static fn (string $value): bool => 'foo' === $value;
 
 span_checkListCollectionInt(Collection::fromIterable([2, 3, 4])->span($intValueCallback));
+span_checkListCollectionInt(Collection::fromIterable([2, 3, 4])->span($intValueCallback, $intSecondCallback));
 span_checkMapCollectionString(Collection::fromIterable(['foo' => 'bar', 'bar' => 'foo'])->span($stringValueCallback));
+span_checkMapCollectionString(Collection::fromIterable(['foo' => 'bar', 'bar' => 'foo'])->span($stringValueCallback, $stringSecondCallback));
 
 [$left, $right] = Collection::fromIterable([2, 3, 4])->span($intValueCallback)->all();
 span_checkListInt($left);


### PR DESCRIPTION
This PR:

* [x] Adds variadic callbacks support to the existing `Span` operation
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation
* [x] Part of v5 preparations