### PR TITLE
Add AsyncMapN Operation | Remove AsyncMap Variadic Callbacks Usage

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -351,7 +351,7 @@ Signature: ``Collection::asyncMapN(callable ...$callbacks): Collection;``
     };
 
     $collection = Collection::fromIterable(['c' => 3, 'b' => 2, 'a' => 1])
-        ->asyncMap($mapper1, $mapper2); // ['a' => 2, 'b' => 4, 'c' => 6]
+        ->asyncMapN($mapper1, $mapper2); // ['a' => 2, 'b' => 4, 'c' => 6]
 
 cache
 ~~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -299,13 +299,44 @@ Asynchronously apply one or more supplied callbacks to every item of a collectio
 
 .. warning:: This method requires `amphp/parallel-functions <https://github.com/amphp/parallel-functions>`_ to be installed.
 
-.. warning::
-        This operation is non-deterministic, we cannot ensure the order of the elements at the end. Additionally,
+.. warning:: This operation is non-deterministic, we cannot ensure the order of the elements at the end. Additionally,
         keys are preserved - use the ``Collection::normalize`` operation if you want to re-index the keys.
+
+.. warning:: An earlier version of this operation allowed usage with multiple callbacks. This behaviour
+        was removed in version ``5.0``; ``asyncMapN`` should be used instead, or,
+        alternatively, multiple successive ``asyncMap`` calls can achieve the same result.
 
 Interface: `AsyncMapable`_
 
-Signature: ``Collection::asyncMap(callable ...$callbacks): Collection;``
+Signature: ``Collection::asyncMap(callable callback): Collection;``
+
+.. code-block:: php
+
+    $mapper = static function(int $value): int {
+        sleep($value);
+
+        return $value * 2;
+    };
+
+    $collection = Collection::fromIterable(['c' => 3, 'b' => 2, 'a' => 1])
+        ->asyncMap($mapper); // ['a' => 2, 'b' => 4, 'c' => 6]
+
+asyncMapN
+~~~~~~~~~
+
+Asynchronously apply one or more supplied callbacks to every item of a collection and use the return value.
+
+.. tip:: This operation is best used when multiple callbacks need to be applied. If you only want to apply
+        a single callback, ``asyncMap`` should be prefered as it benefits from more specific type hints.
+
+.. warning:: This method requires `amphp/parallel-functions <https://github.com/amphp/parallel-functions>`_ to be installed.
+
+.. warning:: This operation is non-deterministic, we cannot ensure the order of the elements at the end. Additionally,
+        keys are preserved - use the ``Collection::normalize`` operation if you want to re-index the keys.
+
+Interface: `AsyncMapNable`_
+
+Signature: ``Collection::asyncMapN(callable ...$callbacks): Collection;``
 
 .. code-block:: php
 
@@ -2376,6 +2407,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Applyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Applyable.php
 .. _Associateable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Associateable.php
 .. _AsyncMapable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/AsyncMapable.php
+.. _AsyncMapNable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/AsyncMapNable.php
 .. _Cacheable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Cacheable.php
 .. _Chunkable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Chunkable.php
 .. _Collapseable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Collapseable.php

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -246,6 +246,21 @@ class CollectionSpec extends ObjectBehavior
 
     public function it_can_asyncMap(): void
     {
+        $callback = static function (int $v): int {
+            sleep($v);
+
+            return $v * 2;
+        };
+
+        $this->beConstructedThrough('fromIterable', [['c' => 2, 'b' => 1, 'a' => 0]]);
+
+        $this
+            ->asyncMap($callback)
+            ->shouldIterateAs(['a' => 0, 'b' => 2, 'c' => 4]);
+    }
+
+    public function it_can_asyncMapN(): void
+    {
         $callback1 = static function (int $v): int {
             sleep($v);
 
@@ -256,11 +271,11 @@ class CollectionSpec extends ObjectBehavior
             return $v * 2;
         };
 
-        $this->beConstructedThrough('fromIterable', [['c' => 3, 'b' => 2, 'a' => 1]]);
+        $this->beConstructedThrough('fromIterable', [['c' => 2, 'b' => 1, 'a' => 0]]);
 
         $this
-            ->asyncMap($callback1, $callback2)
-            ->shouldIterateAs(['a' => 2, 'b' => 4, 'c' => 6]);
+            ->asyncMapN($callback1, $callback2)
+            ->shouldIterateAs(['a' => 0, 'b' => 2, 'c' => 4]);
     }
 
     public function it_can_be_constructed_from_a_file(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -23,6 +23,7 @@ use loophp\collection\Operation\Append;
 use loophp\collection\Operation\Apply;
 use loophp\collection\Operation\Associate;
 use loophp\collection\Operation\AsyncMap;
+use loophp\collection\Operation\AsyncMapN;
 use loophp\collection\Operation\Cache;
 use loophp\collection\Operation\Chunk;
 use loophp\collection\Operation\Coalesce;
@@ -199,9 +200,14 @@ final class Collection implements CollectionInterface
         return new self(Associate::of()($callbackForKeys ?? $defaultCallback)($callbackForValues ?? $defaultCallback), $this->getIterator());
     }
 
-    public function asyncMap(callable ...$callbacks): CollectionInterface
+    public function asyncMap(callable $callback): CollectionInterface
     {
-        return new self(AsyncMap::of()(...$callbacks), $this->getIterator());
+        return new self(AsyncMap::of()($callback), $this->getIterator());
+    }
+
+    public function asyncMapN(callable ...$callbacks): CollectionInterface
+    {
+        return new self(AsyncMapN::of()(...$callbacks), $this->getIterator());
     }
 
     public function cache(?CacheItemPoolInterface $cache = null): CollectionInterface

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -18,6 +18,7 @@ use loophp\collection\Contract\Operation\Appendable;
 use loophp\collection\Contract\Operation\Applyable;
 use loophp\collection\Contract\Operation\Associateable;
 use loophp\collection\Contract\Operation\AsyncMapable;
+use loophp\collection\Contract\Operation\AsyncMapNable;
 use loophp\collection\Contract\Operation\Cacheable;
 use loophp\collection\Contract\Operation\Chunkable;
 use loophp\collection\Contract\Operation\Coalesceable;
@@ -136,6 +137,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Applyable<TKey, T>
  * @template-extends Associateable<TKey, T>
  * @template-extends AsyncMapable<TKey, T>
+ * @template-extends AsyncMapNable<TKey, T>
  * @template-extends Cacheable<TKey, T>
  * @template-extends Chunkable<TKey, T>
  * @template-extends Coalesceable<TKey, T>
@@ -247,6 +249,7 @@ interface Collection extends
     Applyable,
     Associateable,
     AsyncMapable,
+    AsyncMapNable,
     Cacheable,
     Chunkable,
     Coalesceable,

--- a/src/Contract/Operation/AsyncMapNable.php
+++ b/src/Contract/Operation/AsyncMapNable.php
@@ -22,7 +22,7 @@ interface AsyncMapNable
      *
      * @param callable(mixed, mixed): mixed ...$callbacks
      *
-     * @return Collection<TKey, T>
+     * @return Collection<mixed, mixed>
      */
     public function asyncMapN(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/AsyncMapNable.php
+++ b/src/Contract/Operation/AsyncMapNable.php
@@ -9,21 +9,20 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
  * @template TKey
  * @template T
  */
-interface MapNable
+interface AsyncMapNable
 {
     /**
-     * Apply one or more callbacks to every item of a collection and use the return value.
+     * Asynchronously apply callbacks to every item of a collection and use the return value.
      *
-     * @param callable(mixed, mixed, Iterator<TKey, T>): mixed ...$callbacks
+     * @param callable(mixed, mixed): mixed ...$callbacks
      *
-     * @return Collection<mixed, mixed>
+     * @return Collection<TKey, T>
      */
-    public function mapN(callable ...$callbacks): Collection;
+    public function asyncMapN(callable ...$callbacks): Collection;
 }

--- a/src/Contract/Operation/AsyncMapable.php
+++ b/src/Contract/Operation/AsyncMapable.php
@@ -18,9 +18,13 @@ use loophp\collection\Contract\Collection;
 interface AsyncMapable
 {
     /**
-     * Asynchronously apply callbacks to a collection.
+     * Asynchronously apply a single callback to every item of a collection and use the return value.
      *
-     * @return Collection<TKey, T>
+     * @template V
+     *
+     * @param callable(T, TKey): V $callback
+     *
+     * @return Collection<TKey, V>
      */
-    public function asyncMap(callable ...$callbacks): Collection;
+    public function asyncMap(callable $callback): Collection;
 }

--- a/src/Operation/AsyncMapN.php
+++ b/src/Operation/AsyncMapN.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Amp\Sync\LocalSemaphore;
+use Closure;
+use Exception;
+use Generator;
+use Iterator;
+
+use function Amp\Iterator\fromIterable;
+use function Amp\ParallelFunctions\parallel;
+use function Amp\Promise\wait;
+use function Amp\Sync\ConcurrentIterator\map;
+use function function_exists;
+
+// phpcs:disable
+if (false === function_exists('Amp\ParallelFunctions\parallel')) {
+    throw new Exception('You need amphp/parallel-functions to get this operation working.');
+}
+// phpcs:enable
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ */
+final class AsyncMapN extends AbstractOperation
+{
+    /**
+     * @pure
+     *
+     * @return Closure(callable(mixed, mixed): mixed ...): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
+     */
+    public function __invoke(): Closure
+    {
+        return
+            /**
+             * @param callable(mixed, mixed): mixed ...$callbacks
+             */
+            static fn (callable ...$callbacks): Closure =>
+                /**
+                 * @param Iterator<TKey, T> $iterator
+                 *
+                 * @return Generator<mixed, mixed>
+                 */
+                static function (Iterator $iterator) use ($callbacks): Generator {
+                    $callbackFactory =
+                        /**
+                         * @param mixed $key
+                         *
+                         * @return Closure(mixed, callable(mixed, mixed): mixed): mixed
+                         */
+                        static fn ($key): Closure =>
+                            /**
+                             * @param mixed $carry
+                             * @param callable(mixed, mixed): mixed $callback
+                             *
+                             * @return mixed
+                             */
+                            static fn ($carry, callable $callback) => $callback($carry, $key);
+
+                    $callback =
+                        /**
+                         * @param array{0: mixed, 1: mixed} $value
+                         *
+                         * @return array{0: mixed, 1: mixed}
+                         */
+                        static function (array $value) use ($callbacks, $callbackFactory): array {
+                            [$key, $value] = $value;
+
+                            return [$key, array_reduce($callbacks, $callbackFactory($key), $value)];
+                        };
+
+                    $iter = map(fromIterable(Pack::of()($iterator)), new LocalSemaphore(32), parallel($callback));
+
+                    while (wait($iter->advance())) {
+                        /** @var array{0: mixed, 1: mixed} $item */
+                        $item = $iter->getCurrent();
+
+                        yield $item[0] => $item[1];
+                    }
+                };
+    }
+}

--- a/src/Operation/AsyncMapN.php
+++ b/src/Operation/AsyncMapN.php
@@ -75,11 +75,7 @@ final class AsyncMapN extends AbstractOperation
                          *
                          * @return array{0: mixed, 1: mixed}
                          */
-                        static function (array $value) use ($callbacks, $callbackFactory): array {
-                            [$key, $value] = $value;
-
-                            return [$key, array_reduce($callbacks, $callbackFactory($key), $value)];
-                        };
+                        static fn (array $value): array => [$value[0], array_reduce($callbacks, $callbackFactory($value[0]), $value[1])];
 
                     $iter = map(fromIterable(Pack::of()($iterator)), new LocalSemaphore(32), parallel($callback));
 

--- a/src/Operation/Map.php
+++ b/src/Operation/Map.php
@@ -26,19 +26,21 @@ final class Map extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>): T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @template V
+     *
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>): V): Closure(Iterator<TKey, T>): Generator<TKey, V>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T, TKey, Iterator<TKey, T>): T $callback
+             * @param callable(T, TKey, Iterator<TKey, T>): V $callback
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
-                 * @return Generator<TKey, T>
+                 * @return Generator<TKey, V>
                  */
                 static function (Iterator $iterator) use ($callback): Generator {
                     foreach ($iterator as $key => $value) {

--- a/tests/static-analysis/asyncMap.php
+++ b/tests/static-analysis/asyncMap.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function asyncMap_checkListInt(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function asyncMap_checkListString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function asyncMap_checkasyncMapString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, stdClass> $collection
+ */
+function asyncMap_checkasyncMapClass(CollectionInterface $collection): void
+{
+}
+
+$square = static fn (int $val): int => $val ** 2;
+$toString = static fn (int $val): string => (string) $val;
+$appendBar = static fn (string $val): string => $val . 'bar';
+$toClass = static function (string $val): stdClass {
+    $class = new stdClass();
+    $class->val = $val;
+
+    return $class;
+};
+
+asyncMap_checkListInt(Collection::fromIterable([1, 2, 3])->asyncMap($square));
+asyncMap_checkListInt(Collection::fromIterable([1, 2, 3])->asyncMap($square)->asyncMap($square));
+
+asyncMap_checkasyncMapClass(Collection::fromIterable(['foo' => 'bar', 'bar' => 'baz'])->asyncMap($toClass));
+
+// This should work but static analysers restrict the return type
+// E.g: `numeric&string` or `non-empty-string`
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+asyncMap_checkListString(Collection::fromIterable([1, 2, 3])->asyncMap($toString));
+/** @psalm-suppress InvalidArgument */
+asyncMap_checkasyncMapString(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->asyncMap($appendBar));
+/** @psalm-suppress InvalidArgument */
+asyncMap_checkListString(Collection::fromIterable(['foo', 'bar'])->asyncMap($appendBar));
+/** @psalm-suppress InvalidArgument */
+asyncMap_checkListString(Collection::fromIterable([1, 2, 3])->asyncMap($square)->asyncMap($toString)->asyncMap($appendBar));
+
+// VALID failures due to usage with wrong types
+
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+asyncMap_checkListInt(Collection::fromIterable(['foo' => 'bar'])->asyncMap($square));
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+asyncMap_checkasyncMapString(Collection::fromIterable([1, 2, 3])->asyncMap($appendBar));

--- a/tests/static-analysis/asyncMapN.php
+++ b/tests/static-analysis/asyncMapN.php
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function asyncMapN_checkListInt(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function asyncMapN_checkListString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function asyncMapN_checkMapString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, stdClass> $collection
+ */
+function asyncMapN_checkMapClass(CollectionInterface $collection): void
+{
+}
+
+$square = static fn (int $val): int => $val ** 2;
+$toString = static fn (int $val): string => (string) $val;
+$appendBar = static fn (string $val): string => $val . 'bar';
+$toClass = static function (string $val): stdClass {
+    $class = new stdClass();
+    $class->val = $val;
+
+    return $class;
+};
+
+asyncMapN_checkListInt(Collection::fromIterable([1, 2, 3])->asyncMapN($square));
+asyncMapN_checkListString(Collection::fromIterable([1, 2, 3])->asyncMapN($square, $toString));
+
+asyncMapN_checkMapString(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->asyncMapN($appendBar));
+asyncMapN_checkMapClass(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->asyncMapN($appendBar, $toClass));
+
+// Below are INVALID but are allowed by static analysis due to `mixed` usage in `asyncMapN`.
+// This is necessary in order to allow the flexibility that `asyncMapN` requires with multiple callbacks.
+
+asyncMapN_checkListInt(Collection::fromIterable(['foo' => 'bar'])->asyncMapN($square));
+asyncMapN_checkListString(Collection::fromIterable(['foo' => 'bar'])->asyncMapN($square, $toString));
+
+asyncMapN_checkMapString(Collection::fromIterable([1, 2, 3])->asyncMapN($appendBar));
+asyncMapN_checkMapClass(Collection::fromIterable([1, 2, 3])->asyncMapN($appendBar, $toClass));


### PR DESCRIPTION
This PR:

* [x] Adds the `AsyncMapN` Operation - similar to `MapN`
* [x] Modifies `AsyncMap` to only accept a single callback
* [x] It breaks backward compatibility
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation

Related to https://github.com/loophp/collection/discussions/135.