### PR TITLE
refactor: Reduce the use of the spread operators and variadic parameters

### DIFF
--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -384,15 +384,15 @@ class CollectionSpec extends ObjectBehavior
 
     public function it_can_be_constructed_with_a_callable(): void
     {
-        $test1 = $this::fromCallable(static fn (int $a, int $b): Generator => yield from range($a, $b), ...[1, 5]);
+        $test1 = $this::fromCallable(static fn (int $a, int $b): Generator => yield from range($a, $b), [1, 5]);
         $test1->shouldImplement(Collection::class);
         $test1->getIterator()->shouldIterateAs([1, 2, 3, 4, 5]);
 
-        $test2 = $this::fromCallable(static fn (int $a, int $b): array => range($a, $b), 1, 5);
+        $test2 = $this::fromCallable(static fn (int $a, int $b): array => range($a, $b), [1, 5]);
         $test2->shouldImplement(Collection::class);
         $test2->getIterator()->shouldIterateAs([1, 2, 3, 4, 5]);
 
-        $test3 = $this::fromCallable(static fn (int $a, int $b): ArrayIterator => new ArrayIterator(range($a, $b)), 1, 5);
+        $test3 = $this::fromCallable(static fn (int $a, int $b): ArrayIterator => new ArrayIterator(range($a, $b)), [1, 5]);
         $test3->shouldImplement(Collection::class);
         $test3->getIterator()->shouldIterateAs([1, 2, 3, 4, 5]);
 
@@ -448,7 +448,7 @@ class CollectionSpec extends ObjectBehavior
             }
         };
 
-        $this::fromCallable($fibonacci, 0, 1)
+        $this::fromCallable($fibonacci, [0, 1])
             ->limit(10)
             ->shouldIterateAs([0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
     }

--- a/spec/loophp/collection/Iterator/ClosureIteratorSpec.php
+++ b/spec/loophp/collection/Iterator/ClosureIteratorSpec.php
@@ -23,7 +23,7 @@ class ClosureIteratorSpec extends ObjectBehavior
 
     public function it_can_return_a_string_key(): void
     {
-        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, self::MAP_DATA);
+        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, [self::MAP_DATA]);
 
         $this->key()->shouldBe('foo');
         $this->next();
@@ -32,7 +32,7 @@ class ClosureIteratorSpec extends ObjectBehavior
 
     public function it_can_return_an_int_key(): void
     {
-        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, self::LIST_DATA);
+        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, [self::LIST_DATA]);
 
         $this->key()->shouldBe(0);
         $this->next();
@@ -41,14 +41,14 @@ class ClosureIteratorSpec extends ObjectBehavior
 
     public function it_can_return_inner_iterator(): void
     {
-        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, self::LIST_DATA);
+        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, [self::LIST_DATA]);
 
         $this->getInnerIterator()->shouldIterateAs(self::LIST_DATA);
     }
 
     public function it_can_rewind(): void
     {
-        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, ['foo']);
+        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, [['foo']]);
 
         $this->current()->shouldBe('foo');
 
@@ -63,7 +63,7 @@ class ClosureIteratorSpec extends ObjectBehavior
 
     public function it_is_initializable_from_callable_with_array(): void
     {
-        $this->beConstructedWith(static fn (array $iterable): array => $iterable, self::LIST_DATA);
+        $this->beConstructedWith(static fn (array $iterable): array => $iterable, [self::LIST_DATA]);
 
         $this->shouldHaveType(ClosureIterator::class);
 
@@ -75,7 +75,7 @@ class ClosureIteratorSpec extends ObjectBehavior
     {
         $data = ['foo' => 1, 2];
 
-        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, $data);
+        $this->beConstructedWith(static fn (array $iterable): Generator => yield from $iterable, [$data]);
 
         $this->shouldHaveType(ClosureIterator::class);
 
@@ -85,7 +85,7 @@ class ClosureIteratorSpec extends ObjectBehavior
 
     public function it_is_initializable_from_callable_with_iterator(): void
     {
-        $this->beConstructedWith(static fn (array $iterable): Iterator => new ArrayIterator($iterable), self::MAP_DATA);
+        $this->beConstructedWith(static fn (array $iterable): Iterator => new ArrayIterator($iterable), [self::MAP_DATA]);
 
         $this->shouldHaveType(ClosureIterator::class);
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -149,9 +149,9 @@ use const PHP_INT_MIN;
 final class Collection implements CollectionInterface
 {
     /**
-     * @var list<mixed>
+     * @var iterable<mixed>
      */
-    private array $parameters;
+    private iterable $parameters;
 
     /**
      * @var callable(mixed ...$parameters): iterable<TKey, T>
@@ -162,9 +162,9 @@ final class Collection implements CollectionInterface
      * @psalm-external-mutation-free
      *
      * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
-     * @param mixed ...$parameters
+     * @param iterable<array-key, mixed> $parameters
      */
-    public function __construct(callable $callable, ...$parameters)
+    public function __construct(callable $callable, iterable $parameters = [])
     {
         $this->source = $callable;
         $this->parameters = $parameters;
@@ -177,12 +177,12 @@ final class Collection implements CollectionInterface
 
     public function append(...$items): CollectionInterface
     {
-        return new self(Append::of()(...$items), $this->getIterator());
+        return new self(Append::of()(...$items), [$this->getIterator()]);
     }
 
     public function apply(callable ...$callbacks): CollectionInterface
     {
-        return new self(Apply::of()(...$callbacks), $this->getIterator());
+        return new self(Apply::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function associate(
@@ -197,62 +197,62 @@ final class Collection implements CollectionInterface
              */
             static fn ($carry) => $carry;
 
-        return new self(Associate::of()($callbackForKeys ?? $defaultCallback)($callbackForValues ?? $defaultCallback), $this->getIterator());
+        return new self(Associate::of()($callbackForKeys ?? $defaultCallback)($callbackForValues ?? $defaultCallback), [$this->getIterator()]);
     }
 
     public function asyncMap(callable $callback): CollectionInterface
     {
-        return new self(AsyncMap::of()($callback), $this->getIterator());
+        return new self(AsyncMap::of()($callback), [$this->getIterator()]);
     }
 
     public function asyncMapN(callable ...$callbacks): CollectionInterface
     {
-        return new self(AsyncMapN::of()(...$callbacks), $this->getIterator());
+        return new self(AsyncMapN::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function cache(?CacheItemPoolInterface $cache = null): CollectionInterface
     {
-        return new self(Cache::of()($cache ?? new ArrayAdapter()), $this->getIterator());
+        return new self(Cache::of()($cache ?? new ArrayAdapter()), [$this->getIterator()]);
     }
 
     public function chunk(int ...$sizes): CollectionInterface
     {
-        return new self(Chunk::of()(...$sizes), $this->getIterator());
+        return new self(Chunk::of()(...$sizes), [$this->getIterator()]);
     }
 
     public function coalesce(): CollectionInterface
     {
-        return new self(Coalesce::of(), $this->getIterator());
+        return new self(Coalesce::of(), [$this->getIterator()]);
     }
 
     public function collapse(): CollectionInterface
     {
-        return new self(Collapse::of(), $this->getIterator());
+        return new self(Collapse::of(), [$this->getIterator()]);
     }
 
     public function column($column): CollectionInterface
     {
-        return new self(Column::of()($column), $this->getIterator());
+        return new self(Column::of()($column), [$this->getIterator()]);
     }
 
     public function combinate(?int $length = null): CollectionInterface
     {
-        return new self(Combinate::of()($length), $this->getIterator());
+        return new self(Combinate::of()($length), [$this->getIterator()]);
     }
 
     public function combine(...$keys): CollectionInterface
     {
-        return new self(Combine::of()(...$keys), $this->getIterator());
+        return new self(Combine::of()(...$keys), [$this->getIterator()]);
     }
 
     public function compact(...$values): CollectionInterface
     {
-        return new self(Compact::of()(...$values), $this->getIterator());
+        return new self(Compact::of()(...$values), [$this->getIterator()]);
     }
 
     public function contains(...$values): bool
     {
-        return (new self(Contains::of()(...$values), $this->getIterator()))->getIterator()->current();
+        return (new self(Contains::of()(...$values), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function count(): int
@@ -262,22 +262,22 @@ final class Collection implements CollectionInterface
 
     public function current(int $index = 0)
     {
-        return (new self(Current::of()($index), $this->getIterator()))->getIterator()->current();
+        return (new self(Current::of()($index), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function cycle(): CollectionInterface
     {
-        return new self(Cycle::of(), $this->getIterator());
+        return new self(Cycle::of(), [$this->getIterator()]);
     }
 
     public function diff(...$values): CollectionInterface
     {
-        return new self(Diff::of()(...$values), $this->getIterator());
+        return new self(Diff::of()(...$values), [$this->getIterator()]);
     }
 
     public function diffKeys(...$values): CollectionInterface
     {
-        return new self(DiffKeys::of()(...$values), $this->getIterator());
+        return new self(DiffKeys::of()(...$values), [$this->getIterator()]);
     }
 
     public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): CollectionInterface
@@ -303,27 +303,27 @@ final class Collection implements CollectionInterface
                  */
                 static fn ($right): bool => $left === $right;
 
-        return new self(Distinct::of()($comparatorCallback)($accessorCallback), $this->getIterator());
+        return new self(Distinct::of()($comparatorCallback)($accessorCallback), [$this->getIterator()]);
     }
 
     public function drop(int ...$counts): CollectionInterface
     {
-        return new self(Drop::of()(...$counts), $this->getIterator());
+        return new self(Drop::of()(...$counts), [$this->getIterator()]);
     }
 
     public function dropWhile(callable ...$callbacks): CollectionInterface
     {
-        return new self(DropWhile::of()(...$callbacks), $this->getIterator());
+        return new self(DropWhile::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function dump(string $name = '', int $size = 1, ?Closure $closure = null): CollectionInterface
     {
-        return new self(Dump::of()($name)($size)($closure), $this->getIterator());
+        return new self(Dump::of()($name)($size)($closure), [$this->getIterator()]);
     }
 
     public function duplicate(): CollectionInterface
     {
-        return new self(Duplicate::of(), $this->getIterator());
+        return new self(Duplicate::of(), [$this->getIterator()]);
     }
 
     /**
@@ -344,72 +344,72 @@ final class Collection implements CollectionInterface
 
     public function every(callable ...$callbacks): bool
     {
-        return (new self(Every::of()(static fn (): bool => false)(...$callbacks), $this->getIterator()))->getIterator()->current();
+        return (new self(Every::of()(static fn (): bool => false)(...$callbacks), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function explode(...$explodes): CollectionInterface
     {
-        return new self(Explode::of()(...$explodes), $this->getIterator());
+        return new self(Explode::of()(...$explodes), [$this->getIterator()]);
     }
 
     public function falsy(): bool
     {
-        return (new self(Falsy::of(), $this->getIterator()))->getIterator()->current();
+        return (new self(Falsy::of(), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function filter(callable ...$callbacks): CollectionInterface
     {
-        return new self(Filter::of()(...$callbacks), $this->getIterator());
+        return new self(Filter::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function first(): CollectionInterface
     {
-        return new self(First::of(), $this->getIterator());
+        return new self(First::of(), [$this->getIterator()]);
     }
 
     public function flatMap(callable $callback): CollectionInterface
     {
-        return new self(FlatMap::of()($callback), $this->getIterator());
+        return new self(FlatMap::of()($callback), [$this->getIterator()]);
     }
 
     public function flatten(int $depth = PHP_INT_MAX): CollectionInterface
     {
-        return new self(Flatten::of()($depth), $this->getIterator());
+        return new self(Flatten::of()($depth), [$this->getIterator()]);
     }
 
     public function flip(): CollectionInterface
     {
-        return new self(Flip::of(), $this->getIterator());
+        return new self(Flip::of(), [$this->getIterator()]);
     }
 
     public function foldLeft(callable $callback, $initial = null): CollectionInterface
     {
-        return new self(FoldLeft::of()($callback)($initial), $this->getIterator());
+        return new self(FoldLeft::of()($callback)($initial), [$this->getIterator()]);
     }
 
     public function foldLeft1(callable $callback): CollectionInterface
     {
-        return new self(FoldLeft1::of()($callback), $this->getIterator());
+        return new self(FoldLeft1::of()($callback), [$this->getIterator()]);
     }
 
     public function foldRight(callable $callback, $initial = null): CollectionInterface
     {
-        return new self(Foldright::of()($callback)($initial), $this->getIterator());
+        return new self(Foldright::of()($callback)($initial), [$this->getIterator()]);
     }
 
     public function foldRight1(callable $callback): CollectionInterface
     {
-        return new self(FoldRight1::of()($callback), $this->getIterator());
+        return new self(FoldRight1::of()($callback), [$this->getIterator()]);
     }
 
     public function forget(...$keys): CollectionInterface
     {
-        return new self(Forget::of()(...$keys), $this->getIterator());
+        return new self(Forget::of()(...$keys), [$this->getIterator()]);
     }
 
     public function frequency(): CollectionInterface
     {
-        return new self(Frequency::of(), $this->getIterator());
+        return new self(Frequency::of(), [$this->getIterator()]);
     }
 
     /**
@@ -418,13 +418,13 @@ final class Collection implements CollectionInterface
      * @template NewT
      *
      * @param callable(mixed ...$parameters): iterable<NewTKey, NewT> $callable
-     * @param mixed ...$parameters
+     * @param iterable<mixed> $parameters
      *
      * @return self<NewTKey, NewT>
      */
-    public static function fromCallable(callable $callable, ...$parameters): self
+    public static function fromCallable(callable $callable, iterable $parameters = []): self
     {
-        return new self($callable, ...$parameters);
+        return new self($callable, $parameters);
     }
 
     /**
@@ -436,7 +436,7 @@ final class Collection implements CollectionInterface
     {
         return new self(
             static fn (string $filepath): Iterator => new ResourceIterator(fopen($filepath, 'rb'), true),
-            $filepath
+            [$filepath]
         );
     }
 
@@ -454,7 +454,7 @@ final class Collection implements CollectionInterface
     {
         return new self(
             static fn (iterable $iterable): Iterator => new IterableIterator($iterable),
-            $iterable
+            [$iterable]
         );
     }
 
@@ -472,7 +472,7 @@ final class Collection implements CollectionInterface
              * @param resource $resource
              */
             static fn ($resource): Iterator => new ResourceIterator($resource),
-            $resource
+            [$resource]
         );
     }
 
@@ -485,8 +485,7 @@ final class Collection implements CollectionInterface
     {
         return new self(
             static fn (string $string, string $delimiter): Iterator => new StringIterator($string, $delimiter),
-            $string,
-            $delimiter
+            [$string, $delimiter]
         );
     }
 
@@ -496,7 +495,7 @@ final class Collection implements CollectionInterface
      */
     public function get($key, $default = null): CollectionInterface
     {
-        return new self(Get::of()($key)($default), $this->getIterator());
+        return new self(Get::of()($key)($default), [$this->getIterator()]);
     }
 
     /**
@@ -504,27 +503,27 @@ final class Collection implements CollectionInterface
      */
     public function getIterator(): Iterator
     {
-        return new ClosureIterator($this->source, ...$this->parameters);
+        return new ClosureIterator($this->source, $this->parameters);
     }
 
     public function group(): CollectionInterface
     {
-        return new self(Group::of(), $this->getIterator());
+        return new self(Group::of(), [$this->getIterator()]);
     }
 
     public function groupBy(?callable $callable = null): CollectionInterface
     {
-        return new self(GroupBy::of()($callable), $this->getIterator());
+        return new self(GroupBy::of()($callable), [$this->getIterator()]);
     }
 
     public function has(callable ...$callbacks): bool
     {
-        return (new self(Has::of()(...$callbacks), $this->getIterator()))->getIterator()->current();
+        return (new self(Has::of()(...$callbacks), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function head(): CollectionInterface
     {
-        return new self(Head::of(), $this->getIterator());
+        return new self(Head::of(), [$this->getIterator()]);
     }
 
     public function ifThenElse(callable $condition, callable $then, ?callable $else = null): CollectionInterface
@@ -537,37 +536,37 @@ final class Collection implements CollectionInterface
              */
             static fn ($value) => $value;
 
-        return new self(IfThenElse::of()($condition)($then)($else ?? $identity), $this->getIterator());
+        return new self(IfThenElse::of()($condition)($then)($else ?? $identity), [$this->getIterator()]);
     }
 
     public function implode(string $glue = ''): CollectionInterface
     {
-        return new self(Implode::of()($glue), $this->getIterator());
+        return new self(Implode::of()($glue), [$this->getIterator()]);
     }
 
     public function init(): CollectionInterface
     {
-        return new self(Init::of(), $this->getIterator());
+        return new self(Init::of(), [$this->getIterator()]);
     }
 
     public function inits(): CollectionInterface
     {
-        return new self(Inits::of(), $this->getIterator());
+        return new self(Inits::of(), [$this->getIterator()]);
     }
 
     public function intersect(...$values): CollectionInterface
     {
-        return new self(Intersect::of()(...$values), $this->getIterator());
+        return new self(Intersect::of()(...$values), [$this->getIterator()]);
     }
 
     public function intersectKeys(...$keys): CollectionInterface
     {
-        return new self(IntersectKeys::of()(...$keys), $this->getIterator());
+        return new self(IntersectKeys::of()(...$keys), [$this->getIterator()]);
     }
 
     public function intersperse($element, int $every = 1, int $startAt = 0): CollectionInterface
     {
-        return new self(Intersperse::of()($element)($every)($startAt), $this->getIterator());
+        return new self(Intersperse::of()($element)($every)($startAt), [$this->getIterator()]);
     }
 
     public function isEmpty(): bool
@@ -585,84 +584,84 @@ final class Collection implements CollectionInterface
 
     public function key(int $index = 0)
     {
-        return (new self(Key::of()($index), $this->getIterator()))->getIterator()->current();
+        return (new self(Key::of()($index), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function keys(): CollectionInterface
     {
-        return new self(Keys::of(), $this->getIterator());
+        return new self(Keys::of(), [$this->getIterator()]);
     }
 
     public function last(): CollectionInterface
     {
-        return new self(Last::of(), $this->getIterator());
+        return new self(Last::of(), [$this->getIterator()]);
     }
 
     public function limit(int $count = -1, int $offset = 0): CollectionInterface
     {
-        return new self(Limit::of()($count)($offset), $this->getIterator());
+        return new self(Limit::of()($count)($offset), [$this->getIterator()]);
     }
 
     public function lines(): CollectionInterface
     {
-        return new self(Lines::of(), $this->getIterator());
+        return new self(Lines::of(), [$this->getIterator()]);
     }
 
     public function map(callable $callback): CollectionInterface
     {
-        return new self(Map::of()($callback), $this->getIterator());
+        return new self(Map::of()($callback), [$this->getIterator()]);
     }
 
     public function mapN(callable ...$callbacks): CollectionInterface
     {
-        return new self(MapN::of()(...$callbacks), $this->getIterator());
+        return new self(MapN::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function match(callable $callback, ?callable $matcher = null): bool
     {
-        return (new self(MatchOne::of()($matcher ?? static fn (): bool => true)($callback), $this->getIterator()))
+        return (new self(MatchOne::of()($matcher ?? static fn (): bool => true)($callback), [$this->getIterator()]))
             ->getIterator()
             ->current();
     }
 
     public function matching(Criteria $criteria): CollectionInterface
     {
-        return new self(Matching::of()($criteria), $this->getIterator());
+        return new self(Matching::of()($criteria), [$this->getIterator()]);
     }
 
     public function merge(iterable ...$sources): CollectionInterface
     {
-        return new self(Merge::of()(...$sources), $this->getIterator());
+        return new self(Merge::of()(...$sources), [$this->getIterator()]);
     }
 
     public function normalize(): CollectionInterface
     {
-        return new self(Normalize::of(), $this->getIterator());
+        return new self(Normalize::of(), [$this->getIterator()]);
     }
 
     public function nth(int $step, int $offset = 0): CollectionInterface
     {
-        return new self(Nth::of()($step)($offset), $this->getIterator());
+        return new self(Nth::of()($step)($offset), [$this->getIterator()]);
     }
 
     public function nullsy(): bool
     {
-        return (new self(Nullsy::of(), $this->getIterator()))->getIterator()->current();
+        return (new self(Nullsy::of(), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function pack(): CollectionInterface
     {
-        return new self(Pack::of(), $this->getIterator());
+        return new self(Pack::of(), [$this->getIterator()]);
     }
 
     public function pad(int $size, $value): CollectionInterface
     {
-        return new self(Pad::of()($size)($value), $this->getIterator());
+        return new self(Pad::of()($size)($value), [$this->getIterator()]);
     }
 
     public function pair(): CollectionInterface
     {
-        return new self(Pair::of(), $this->getIterator());
+        return new self(Pair::of(), [$this->getIterator()]);
     }
 
     public function partition(callable ...$callbacks): CollectionInterface
@@ -672,38 +671,38 @@ final class Collection implements CollectionInterface
                 Partition::of()(...$callbacks),
                 Map::of()(static fn (Iterator $iterator): CollectionInterface => self::fromIterable($iterator))
             ),
-            $this->getIterator()
+            [$this->getIterator()]
         );
     }
 
     public function permutate(): CollectionInterface
     {
-        return new self(Permutate::of(), $this->getIterator());
+        return new self(Permutate::of(), [$this->getIterator()]);
     }
 
     public function pipe(callable ...$callbacks): CollectionInterface
     {
-        return new self(Pipe::of()(...$callbacks), $this->getIterator());
+        return new self(Pipe::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function pluck($pluck, $default = null): CollectionInterface
     {
-        return new self(Pluck::of()($pluck)($default), $this->getIterator());
+        return new self(Pluck::of()($pluck)($default), [$this->getIterator()]);
     }
 
     public function prepend(...$items): CollectionInterface
     {
-        return new self(Prepend::of()(...$items), $this->getIterator());
+        return new self(Prepend::of()(...$items), [$this->getIterator()]);
     }
 
     public function product(iterable ...$iterables): CollectionInterface
     {
-        return new self(Product::of()(...$iterables), $this->getIterator());
+        return new self(Product::of()(...$iterables), [$this->getIterator()]);
     }
 
     public function random(int $size = 1, ?int $seed = null): CollectionInterface
     {
-        return new self(Random::of()($seed ?? random_int(PHP_INT_MIN, PHP_INT_MAX))($size), $this->getIterator());
+        return new self(Random::of()($seed ?? random_int(PHP_INT_MIN, PHP_INT_MAX))($size), [$this->getIterator()]);
     }
 
     public static function range(float $start = 0.0, float $end = INF, float $step = 1.0): CollectionInterface
@@ -713,22 +712,22 @@ final class Collection implements CollectionInterface
 
     public function reduction(callable $callback, $initial = null): CollectionInterface
     {
-        return new self(Reduction::of()($callback)($initial), $this->getIterator());
+        return new self(Reduction::of()($callback)($initial), [$this->getIterator()]);
     }
 
     public function reject(callable ...$callbacks): CollectionInterface
     {
-        return new self(Reject::of()(...$callbacks), $this->getIterator());
+        return new self(Reject::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function reverse(): CollectionInterface
     {
-        return new self(Reverse::of(), $this->getIterator());
+        return new self(Reverse::of(), [$this->getIterator()]);
     }
 
     public function rsample(float $probability): CollectionInterface
     {
-        return new self(RSample::of()($probability), $this->getIterator());
+        return new self(RSample::of()($probability), [$this->getIterator()]);
     }
 
     public function scale(
@@ -738,47 +737,47 @@ final class Collection implements CollectionInterface
         float $wantedUpperBound = 1.0,
         float $base = 0.0
     ): CollectionInterface {
-        return new self(Scale::of()($lowerBound)($upperBound)($wantedLowerBound)($wantedUpperBound)($base), $this->getIterator());
+        return new self(Scale::of()($lowerBound)($upperBound)($wantedLowerBound)($wantedUpperBound)($base), [$this->getIterator()]);
     }
 
     public function scanLeft(callable $callback, $initial = null): CollectionInterface
     {
-        return new self(ScanLeft::of()($callback)($initial), $this->getIterator());
+        return new self(ScanLeft::of()($callback)($initial), [$this->getIterator()]);
     }
 
     public function scanLeft1(callable $callback): CollectionInterface
     {
-        return new self(ScanLeft1::of()($callback), $this->getIterator());
+        return new self(ScanLeft1::of()($callback), [$this->getIterator()]);
     }
 
     public function scanRight(callable $callback, $initial = null): CollectionInterface
     {
-        return new self(ScanRight::of()($callback)($initial), $this->getIterator());
+        return new self(ScanRight::of()($callback)($initial), [$this->getIterator()]);
     }
 
     public function scanRight1(callable $callback): CollectionInterface
     {
-        return new self(ScanRight1::of()($callback), $this->getIterator());
+        return new self(ScanRight1::of()($callback), [$this->getIterator()]);
     }
 
     public function shuffle(?int $seed = null): CollectionInterface
     {
-        return new self(Shuffle::of()($seed ?? random_int(PHP_INT_MIN, PHP_INT_MAX)), $this->getIterator());
+        return new self(Shuffle::of()($seed ?? random_int(PHP_INT_MIN, PHP_INT_MAX)), [$this->getIterator()]);
     }
 
     public function since(callable ...$callbacks): CollectionInterface
     {
-        return new self(Since::of()(...$callbacks), $this->getIterator());
+        return new self(Since::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function slice(int $offset, int $length = -1): CollectionInterface
     {
-        return new self(Slice::of()($offset)($length), $this->getIterator());
+        return new self(Slice::of()($offset)($length), [$this->getIterator()]);
     }
 
     public function sort(int $type = Operation\Sortable::BY_VALUES, ?callable $callback = null): CollectionInterface
     {
-        return new self(Sort::of()($type)($callback), $this->getIterator());
+        return new self(Sort::of()($type)($callback), [$this->getIterator()]);
     }
 
     public function span(callable ...$callbacks): CollectionInterface
@@ -788,13 +787,13 @@ final class Collection implements CollectionInterface
                 Span::of()(...$callbacks),
                 Map::of()(static fn (Iterator $iterator): CollectionInterface => self::fromIterable($iterator))
             ),
-            $this->getIterator()
+            [$this->getIterator()]
         );
     }
 
     public function split(int $type = Operation\Splitable::BEFORE, callable ...$callbacks): CollectionInterface
     {
-        return new self(Split::of()($type)(...$callbacks), $this->getIterator());
+        return new self(Split::of()($type)(...$callbacks), [$this->getIterator()]);
     }
 
     public function squash(): CollectionInterface
@@ -804,22 +803,22 @@ final class Collection implements CollectionInterface
 
     public function strict(?callable $callback = null): CollectionInterface
     {
-        return new self(Strict::of()($callback), $this->getIterator());
+        return new self(Strict::of()($callback), [$this->getIterator()]);
     }
 
     public function tail(): CollectionInterface
     {
-        return new self(Tail::of(), $this->getIterator());
+        return new self(Tail::of(), [$this->getIterator()]);
     }
 
     public function tails(): CollectionInterface
     {
-        return new self(Tails::of(), $this->getIterator());
+        return new self(Tails::of(), [$this->getIterator()]);
     }
 
     public function takeWhile(callable ...$callbacks): CollectionInterface
     {
-        return new self(TakeWhile::of()(...$callbacks), $this->getIterator());
+        return new self(TakeWhile::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public static function times(int $number = 0, ?callable $callback = null): CollectionInterface
@@ -829,12 +828,12 @@ final class Collection implements CollectionInterface
 
     public function transpose(): CollectionInterface
     {
-        return new self(Transpose::of(), $this->getIterator());
+        return new self(Transpose::of(), [$this->getIterator()]);
     }
 
     public function truthy(): bool
     {
-        return (new self(Truthy::of(), $this->getIterator()))->getIterator()->current();
+        return (new self(Truthy::of(), [$this->getIterator()]))->getIterator()->current();
     }
 
     public static function unfold(callable $callback, ...$parameters): CollectionInterface
@@ -844,42 +843,42 @@ final class Collection implements CollectionInterface
 
     public function unlines(): CollectionInterface
     {
-        return new self(Unlines::of(), $this->getIterator());
+        return new self(Unlines::of(), [$this->getIterator()]);
     }
 
     public function unpack(): CollectionInterface
     {
-        return new self(Unpack::of(), $this->getIterator());
+        return new self(Unpack::of(), [$this->getIterator()]);
     }
 
     public function unpair(): CollectionInterface
     {
-        return new self(Unpair::of(), $this->getIterator());
+        return new self(Unpair::of(), [$this->getIterator()]);
     }
 
     public function until(callable ...$callbacks): CollectionInterface
     {
-        return new self(Until::of()(...$callbacks), $this->getIterator());
+        return new self(Until::of()(...$callbacks), [$this->getIterator()]);
     }
 
     public function unwindow(): CollectionInterface
     {
-        return new self(Unwindow::of(), $this->getIterator());
+        return new self(Unwindow::of(), [$this->getIterator()]);
     }
 
     public function unwords(): CollectionInterface
     {
-        return new self(Unwords::of(), $this->getIterator());
+        return new self(Unwords::of(), [$this->getIterator()]);
     }
 
     public function unwrap(): CollectionInterface
     {
-        return new self(Unwrap::of(), $this->getIterator());
+        return new self(Unwrap::of(), [$this->getIterator()]);
     }
 
     public function unzip(): CollectionInterface
     {
-        return new self(Unzip::of(), $this->getIterator());
+        return new self(Unzip::of(), [$this->getIterator()]);
     }
 
     public function when(callable $predicate, callable $whenTrue, ?callable $whenFalse = null): CollectionInterface
@@ -892,26 +891,26 @@ final class Collection implements CollectionInterface
              */
             static fn (Iterator $collection): iterable => $collection;
 
-        return new self(When::of()($predicate)($whenTrue)($whenFalse), $this->getIterator());
+        return new self(When::of()($predicate)($whenTrue)($whenFalse), [$this->getIterator()]);
     }
 
     public function window(int $size): CollectionInterface
     {
-        return new self(Window::of()($size), $this->getIterator());
+        return new self(Window::of()($size), [$this->getIterator()]);
     }
 
     public function words(): CollectionInterface
     {
-        return new self(Words::of(), $this->getIterator());
+        return new self(Words::of(), [$this->getIterator()]);
     }
 
     public function wrap(): CollectionInterface
     {
-        return new self(Wrap::of(), $this->getIterator());
+        return new self(Wrap::of(), [$this->getIterator()]);
     }
 
     public function zip(iterable ...$iterables): CollectionInterface
     {
-        return new self(Zip::of()(...$iterables), $this->getIterator());
+        return new self(Zip::of()(...$iterables), [$this->getIterator()]);
     }
 }

--- a/src/Iterator/ClosureIterator.php
+++ b/src/Iterator/ClosureIterator.php
@@ -27,15 +27,15 @@ final class ClosureIterator extends ProxyIterator
     private $callable;
 
     /**
-     * @var list<mixed>
+     * @var iterable<int, mixed>
      */
-    private $parameters;
+    private iterable $parameters;
 
     /**
      * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
-     * @param mixed ...$parameters
+     * @param iterable<mixed> $parameters
      */
-    public function __construct(callable $callable, ...$parameters)
+    public function __construct(callable $callable, iterable $parameters)
     {
         $this->callable = $callable;
         $this->parameters = $parameters;

--- a/src/Iterator/IterableIterator.php
+++ b/src/Iterator/IterableIterator.php
@@ -28,7 +28,7 @@ final class IterableIterator extends ProxyIterator
     {
         $this->iterator = new ClosureIterator(
             static fn (iterable $iterable): Generator => yield from $iterable,
-            $iterable
+            [$iterable]
         );
     }
 }

--- a/src/Iterator/TypedIterator.php
+++ b/src/Iterator/TypedIterator.php
@@ -81,7 +81,7 @@ final class TypedIterator extends ProxyIterator
                     yield $key => $value;
                 }
             },
-            $iterator
+            [$iterator]
         );
     }
 }

--- a/tests/static-analysis/fromCallable.php
+++ b/tests/static-analysis/fromCallable.php
@@ -138,8 +138,8 @@ fromCallable_checkList(Collection::fromCallable($arrayList));
 fromCallable_checkMap(Collection::fromCallable($arrayMap));
 fromCallable_checkMixed(Collection::fromCallable($arrayMixed));
 
-fromCallable_checkList(Collection::fromCallable($arrayIteratorList, 1, 3));
-fromCallable_checkMap(Collection::fromCallable($arrayIteratorMap, 1));
+fromCallable_checkList(Collection::fromCallable($arrayIteratorList, [1, 3]));
+fromCallable_checkMap(Collection::fromCallable($arrayIteratorMap, [1]));
 fromCallable_checkMixed(Collection::fromCallable($arrayIteratorMixed));
 
 fromCallable_checkList(Collection::fromCallable([$classWithMethod, 'getValues']));


### PR DESCRIPTION
This PR:

* [x] Reduce the amount of spread operators and variadic parameters (perf improvement)
* [x] Thanks to this, in the future it will be possible to pass more than 2 parameters to `Collection` and|or `ClosureIterator`.
* [x] It breaks backward compatibility: The constructor of `Collection` and `ClosureIterator` has been altered.
* [x] All tests has been updated 
