### PR TITLE
Show partition failure

### DIFF
--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -23,6 +23,7 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 use loophp\collection\Contract\Operation;
 use loophp\collection\Iterator\ClosureIterator;
 use loophp\collection\Operation\AbstractOperation;
+use loophp\collection\Operation\Pipe;
 use OutOfBoundsException;
 use PhpSpec\Exception\Example\FailureException;
 use PhpSpec\Exception\Example\MatcherException;
@@ -58,6 +59,22 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable($duplicateKeyGen())
             ->all()
             ->shouldIterateAs(['a' => 3, 'b' => 2]);
+    }
+
+    public function it_fails_to_work_with_generator(): void
+    {
+        $gen = static fn (): Generator => yield from [1, 2, 3];
+
+        $this->beConstructedThrough('fromIterable', [$gen()]);
+        $this->shouldHaveCount(3);
+        $this->shouldIterateAs([1, 2, 3]);
+    }
+
+    public function it_works_with_iterator(): void
+    {
+        $this->beConstructedThrough('fromIterable', [new ArrayIterator([1, 2, 3])]);
+        $this->shouldHaveCount(3);
+        $this->shouldIterateAs([1, 2, 3]);
     }
 
     public function it_can_append(): void
@@ -2264,7 +2281,7 @@ class CollectionSpec extends ObjectBehavior
 
         $subject = $this::fromIterable($input)->partition($isGreaterThan(5));
         $subject->shouldHaveCount(2);
-        $subject->first()->shouldBeAnInstanceOf(CollectionInterface::class);
+        $subject->first()->current()->shouldBeAnInstanceOf(CollectionInterface::class);
         $subject->last()->shouldBeAnInstanceOf(CollectionInterface::class);
 
         $this::fromIterable($input)

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -2133,16 +2133,6 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs($generator());
     }
 
-    public function it_reproduces_partition_issue(): void
-    {
-        $collection = $this::fromIterable([1, 2, 3, 4, 5]);
-
-        [$even, $odd] = $collection->partition(static fn (int $value): bool => $value % 2 === 0)->all();
-
-        $even->shouldHaveCount(2);
-        $even->shouldIterateAs([1 => 2, 3 => 4]);
-    }
-
     public function it_can_normalize(): void
     {
         $this::fromIterable(['a' => 10, 'b' => 100, 'c' => 1000])
@@ -3876,6 +3866,31 @@ class CollectionSpec extends ObjectBehavior
     public function it_is_initializable(): void
     {
         $this->shouldHaveType(Collection::class);
+    }
+
+    public function it_reproduces_partition_issue(): void
+    {
+        $collection = $this::fromIterable([1, 2, 3, 4, 5]);
+
+        [$even, $odd] = $collection->partition(static fn (int $value): bool => $value % 2 === 0)->all();
+
+        $even->shouldHaveCount(2);
+        $even->shouldIterateAs([1 => 2, 3 => 4]);
+    }
+
+    public function it_reproduces_partition_issue_using_first_last(): void
+    {
+        $collection = $this::fromIterable([1, 2, 3, 4, 5]);
+
+        $partitioned = $collection->partition(static fn (int $value): bool => $value % 2 === 0);
+        $even = $partitioned->first()->current();
+
+        $even->shouldHaveCount(2);
+        $even->shouldIterateAs([1 => 2, 3 => 4]);
+
+        $odd = $partitioned->last()->current();
+        $odd->shouldHaveCount(3);
+        $odd->shouldIterateAs([0 => 1, 2 => 3, 4 => 5]);
     }
 
     public function let(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -2133,6 +2133,16 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs($generator());
     }
 
+    public function it_reproduces_partition_issue(): void
+    {
+        $collection = $this::fromIterable([1, 2, 3, 4, 5]);
+
+        [$even, $odd] = $collection->partition(static fn (int $value): bool => $value % 2 === 0)->all();
+
+        $even->shouldHaveCount(2);
+        $even->shouldIterateAs([1 => 2, 3 => 4]);
+    }
+
     public function it_can_normalize(): void
     {
         $this::fromIterable(['a' => 10, 'b' => 100, 'c' => 1000])

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -11,6 +11,7 @@ namespace loophp\collection;
 
 use Closure;
 use Doctrine\Common\Collections\Criteria;
+use Generator;
 use Iterator;
 use loophp\collection\Contract\Collection as CollectionInterface;
 use loophp\collection\Contract\Operation;
@@ -670,7 +671,7 @@ final class Collection implements CollectionInterface
         return new self(
             Pipe::of()(
                 Partition::of()(...$callbacks),
-                Map::of()(static fn (Iterator $iterator): CollectionInterface => self::fromIterable($iterator))
+                Map::of()(static fn (Generator $generator): CollectionInterface => self::fromIterable(iterator_to_array($generator)))
             ),
             $this->getIterator()
         );

--- a/src/Operation/Partition.php
+++ b/src/Operation/Partition.php
@@ -42,7 +42,7 @@ final class Partition extends AbstractOperation
                  *
                  * @return Generator<int, Iterator<TKey, T>>
                  */
-                static function (Iterator $iterator) use ($callbacks): Iterator {
+                static function (Iterator $iterator) use ($callbacks): Generator {
                     /** @var Iterator<TKey, T> $filter */
                     $filter = Filter::of()(...$callbacks)($iterator);
                     /** @var Iterator<TKey, T> $reject */


### PR DESCRIPTION
I noticed an issue trying to use the new `partition` method from **master**. I am not sure exactly what's causing it, but I wrote a test to showcase -> whenever we run `count` on one of the results from the partition operation it causes this fatal error:

`Fatal error: Generator passed to yield from was aborted without proper return and is unable to continue`

In the other project where I was trying to use this I dumped the collection before-after the `count`:

### Before
```PHP
loophp\collection\Collection^ {#5180
  -parameters: array:1 [
    0 => Generator {#5177
      executing: {
        ./vendor/loophp/collection/src/Operation/Filter.php:46 { …}
      }
      closed: false
    }
  ]
  -source: Closure(iterable $iterable): Iterator^ {#5148
    returnType: "Iterator"
    class: "loophp\collection\Collection"
  }
}
```

### After
```PHP
loophp\collection\Collection^ {#5180
  -parameters: array:1 [
    0 => Generator {#5177
      closed: true
    }
  ]
  -source: Closure(iterable $iterable): Iterator^ {#5148
    returnType: "Iterator"
    class: "loophp\collection\Collection"
  }
}
```

Based on this it looks like the generator appears closed