### PR TITLE
Link to `stable` docs instead of `latest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ For more detailed changelogs, please check [the release changelogs][45].
 [9]: https://www.php.net/array-filter
 [10]: https://www.php.net/array-reduce
 [17]: https://www.php.net/manual/en/class.splobjectstorage.php
-[18]: https://loophp-collection.readthedocs.io/en/latest/pages/usage.html#working-with-keys-and-values
+[18]: https://loophp-collection.readthedocs.io/en/stable/pages/usage.html#working-with-keys-and-values
 [19]: https://github.com/illuminate/support
 [20]: https://github.com/DusanKasan/Knapsack
 [21]: https://github.com/mtdowling/transducers.php
@@ -234,8 +234,8 @@ For more detailed changelogs, please check [the release changelogs][45].
 [24]: https://github.com/nikic/iter
 [27]: http://danieltao.com/lazy.js/
 [33]: https://loophp-collection.rtfd.io
-[28]: https://loophp-collection.readthedocs.io/en/latest/pages/api.html
-[32]: https://loophp-collection.readthedocs.io/en/latest/pages/usage.html
+[28]: https://loophp-collection.readthedocs.io/en/stable/pages/api.html
+[32]: https://loophp-collection.readthedocs.io/en/stable/pages/usage.html
 [34]: https://github.com/loophp/collection/issues
 [2]: https://github.com/loophp/collection/actions
 [35]: http://www.phpspec.net/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ This library could be a valid replacement for `\SplObjectStorage`_ but with much
 This way of working opens up new perspectives and another way of handling data, in a more functional way.
 
 And last but not least, collection keys are preserved throughout most operations; while it might lead to some confusion at first,
-please carefully read `this example`_ for the full explanation and benefits.
+please carefully read :ref:`this example <Working with keys and values>` for the full explanation and benefits.
 
 This library has been inspired by:
 
@@ -151,7 +151,6 @@ For more detailed changelogs, please check `the release changelogs`_.
 .. _Haskell: https://www.haskell.org/
 .. _new Collection object: https://github.com/loophp/collection/blob/master/src/Collection.php
 .. _SplObjectStorage: https://www.php.net/manual/en/class.splobjectstorage.php
-.. _this example: https://loophp-collection.readthedocs.io/en/stable/pages/usage.html#working-with-keys-and-values
 .. _Lazy.js: http://danieltao.com/lazy.js/
 .. _Laravel Support Package: https://github.com/illuminate/support
 .. _pure: https://en.wikipedia.org/wiki/Pure_function

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,7 +151,7 @@ For more detailed changelogs, please check `the release changelogs`_.
 .. _Haskell: https://www.haskell.org/
 .. _new Collection object: https://github.com/loophp/collection/blob/master/src/Collection.php
 .. _SplObjectStorage: https://www.php.net/manual/en/class.splobjectstorage.php
-.. _this example: https://loophp-collection.readthedocs.io/en/latest/pages/usage.html#working-with-keys-and-values
+.. _this example: https://loophp-collection.readthedocs.io/en/stable/pages/usage.html#working-with-keys-and-values
 .. _Lazy.js: http://danieltao.com/lazy.js/
 .. _Laravel Support Package: https://github.com/illuminate/support
 .. _pure: https://en.wikipedia.org/wiki/Pure_function


### PR DESCRIPTION
This PR updates the links in the README to link to the `stable` version of the docs (last release), instead of `latest` (what's in `master`).
