### PR TITLE
Add `Equals` Operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -708,6 +708,26 @@ Signature: ``Collection::duplicate(): Collection;``
             ->distinct()
             ->normalize() // [0 => 'a', 1 => 'c']
 
+equals
+~~~~~~
+
+Compare two collections for equality. Collections are considered *equal* if:
+
+* they have the same number of elements;
+* they contain the same elements, regardless of the order they appear in or their keys.
+
+Elements will be compared using strict equality (``===``).
+
+.. tip:: This operation enables comparing ``Collection`` objects in PHPUnit tests using
+    the dedicated `assertObjectEquals`_ assertion. 
+
+Interface: `Equalsable`_
+
+Signature: ``Collection::equals(Collection $other): bool;``
+
+.. literalinclude:: code/operations/equals.php
+  :language: php
+
 every
 ~~~~~
 
@@ -2433,6 +2453,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _DropWhileable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/DropWhileable.php
 .. _Dumpable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Dumpable.php
 .. _Duplicateable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Duplicateable.php
+.. _Equalsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Equalsable.php
 .. _Everyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Everyable.php
 .. _Explodeable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Explodeable.php
 .. _Falsyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Falsyable.php
@@ -2520,6 +2541,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Zipable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Zipable.php
 
 .. _array_flip(): https://php.net/array_flip
+.. _assertObjectEquals: https://phpunit.readthedocs.io/en/9.5/assertions.html#assertobjectequals
 .. _Countable: https://www.php.net/manual/en/class.countable.php
 .. _Criteria: https://www.doctrine-project.org/projects/doctrine-collections/en/1.6/index.html#matching
 .. _Doctrine Collections: https://github.com/doctrine/collections

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -176,7 +176,7 @@ or through the ``Collection`` object.
 When used separately, operations typically return a PHP `Generator`_ or an `Iterator`_.
 When used as a ``Collection`` method, operations fall into a few main categories based on the return type:
 
-1. Operations that return a ``boolean`` or ``scalar`` value: ``Contains``, ``Count``, ``Every``, ``Falsy``, ``Has``, ``IsEmpty``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
+1. Operations that return a ``boolean`` or ``scalar`` value: ``Contains``, ``Count``, ``Equals``, ``Every``, ``Falsy``, ``Has``, ``IsEmpty``, ``Match`` (or ``MatchOne``), ``Nullsy``, ``Truthy``.
 
 2. Operations that return a ``Collection`` of ``Collection`` objects: ``Partition``, ``Span``.
 
@@ -334,7 +334,7 @@ asyncMapN
 Asynchronously apply one or more supplied callbacks to every item of a collection and use the return value.
 
 .. tip:: This operation is best used when multiple callbacks need to be applied. If you only want to apply
-        a single callback, ``asyncMap`` should be prefered as it benefits from more specific type hints.
+        a single callback, ``asyncMap`` should be preferred as it benefits from more specific type hints.
 
 .. warning:: This method requires `amphp/parallel-functions <https://github.com/amphp/parallel-functions>`_ to be installed.
 
@@ -722,8 +722,9 @@ Elements will be compared using strict equality (``===``).
     the dedicated `assertObjectEquals`_ assertion. 
 
 .. warning:: Because this operation *needs to traverse both collections* to determine if
-    the same elements are contained within them, a performance cost is incurred. It is not
-    recommended to use this for potentially large collections.
+    the same elements are contained within them, a performance cost is incurred. Even though
+    the operation will stop as soon as it encounters an element of one collection that cannot
+    be found in the other, it is not recommended to use this for potentially large collections.
 
 Interface: `Equalsable`_
 

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -721,6 +721,10 @@ Elements will be compared using strict equality (``===``).
 .. tip:: This operation enables comparing ``Collection`` objects in PHPUnit tests using
     the dedicated `assertObjectEquals`_ assertion. 
 
+.. warning:: Because this operation *needs to traverse both collections* to determine if
+    the same elements are contained within them, a performance cost is incurred. It is not
+    recommended to use this for potentially large collections.
+
 Interface: `Equalsable`_
 
 Signature: ``Collection::equals(Collection $other): bool;``

--- a/docs/pages/code/operations/equals.php
+++ b/docs/pages/code/operations/equals.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+Collection::fromIterable([1, 2, 3])
+    ->equals(Collection::fromIterable([1, 2, 3])); // true
+
+Collection::fromIterable([1, 2, 3])
+    ->equals(Collection::fromIterable([3, 1, 2])); // true
+
+Collection::fromIterable([1, 2, 3])
+    ->equals(Collection::fromIterable([1, 2])); // false
+
+Collection::fromIterable([1, 2, 3])
+    ->equals(Collection::fromIterable([1, 2, 4])); // false
+
+Collection::fromIterable(['foo' => 'f'])
+    ->equals(Collection::fromIterable(['foo' => 'f'])); // true
+
+Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])
+    ->equals(Collection::fromIterable(['foo' => 'f', 'baz' => 'b'])); // true
+
+$a = (object) ['id' => 'a'];
+$a2 = (object) ['id' => 'a'];
+
+Collection::fromIterable([$a])
+    ->equals(Collection::fromIterable([$a])); // true
+
+Collection::fromIterable([$a])
+    ->equals(Collection::fromIterable([$a2])); // false

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1045,6 +1045,82 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs($result());
     }
 
+    public function it_can_equals(): void
+    {
+        $a = (object) ['id' => 'a'];
+        $a2 = (object) ['id' => 'a'];
+        $b = (object) ['id' => 'b'];
+
+        // empty variations
+        $this::empty()
+            ->equals(Collection::empty())
+            ->shouldBe(true);
+
+        $this::empty()
+            ->equals(Collection::fromIterable([1]))
+            ->shouldBe(false);
+
+        $this::fromIterable([1])
+            ->equals(Collection::empty())
+            ->shouldBe(false);
+
+        // same elements, same order
+        $this::fromIterable([1, 2, 3])
+            ->equals(Collection::fromIterable([1, 2, 3]))
+            ->shouldBe(true);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+            ->shouldBe(true);
+
+        $this::fromIterable([$a, $b])
+            ->equals(Collection::fromIterable([$a, $b]))
+            ->shouldBe(true);
+
+        // same elements, different order
+        $this::fromIterable([1, 2, 3])
+            ->equals(Collection::fromIterable([3, 1, 2]))
+            ->shouldBe(true);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->equals(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
+            ->shouldBe(true);
+
+        $this::fromIterable([$a, $b])
+            ->equals(Collection::fromIterable([$b, $a]))
+            ->shouldBe(true);
+
+        // same lengths, with one element different
+        $this::fromIterable([1, 2, 3])
+            ->equals(Collection::fromIterable([1, 2, 4]))
+            ->shouldBe(false);
+
+        // different lengths, missing elements
+        $this::fromIterable([1, 2, 3])
+            ->equals(Collection::fromIterable([1, 2]))
+            ->shouldBe(false);
+
+        // different lengths, extra elements in first
+        $this::fromIterable([1, 2, 3, 4])
+            ->equals(Collection::fromIterable([1, 2, 3]))
+            ->shouldBe(false);
+
+        // different lengths, extra elements in second
+        $this::fromIterable([1, 2, 3])
+            ->equals(Collection::fromIterable([1, 2, 3, 4]))
+            ->shouldBe(false);
+
+        // objects, different instances and contents
+        $this::fromIterable([$a])
+            ->equals(Collection::fromIterable([$b]))
+            ->shouldBe(false);
+
+        // objects, different instances but same contents
+        $this::fromIterable([$a])
+            ->equals(Collection::fromIterable([$a2]))
+            ->shouldBe(false);
+    }
+
     public function it_can_every(): void
     {
         $input = range(0, 10);

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -35,6 +35,8 @@ use const PHP_VERSION_ID;
 
 class CollectionSpec extends ObjectBehavior
 {
+    private const PHP_8 = 80_000;
+
     public function it_can_all(): void
     {
         $this::fromIterable([1, 2, 3])
@@ -799,7 +801,7 @@ class CollectionSpec extends ObjectBehavior
             ->diff('F', 'b')
             ->shouldIterateAs(['foo' => 'f']);
 
-        if (PHP_VERSION_ID >= 80000) {
+        if (PHP_VERSION_ID >= self::PHP_8) {
             $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
                 ->diff(...Collection::fromIterable(['foo' => 'f']))
                 ->shouldIterateAs(['bar' => 'b']);
@@ -1069,10 +1071,6 @@ class CollectionSpec extends ObjectBehavior
             ->equals(Collection::fromIterable([1, 2, 3]))
             ->shouldBe(true);
 
-        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-            ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
-            ->shouldBe(true);
-
         $this::fromIterable([$a, $b])
             ->equals(Collection::fromIterable([$a, $b]))
             ->shouldBe(true);
@@ -1080,10 +1078,6 @@ class CollectionSpec extends ObjectBehavior
         // same elements, different order
         $this::fromIterable([1, 2, 3])
             ->equals(Collection::fromIterable([3, 1, 2]))
-            ->shouldBe(true);
-
-        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-            ->equals(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
             ->shouldBe(true);
 
         $this::fromIterable([$a, $b])
@@ -1109,16 +1103,39 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable([1, 2, 3])
             ->equals(Collection::fromIterable([1, 2, 3, 4]))
             ->shouldBe(false);
+//
+//        // objects, different instances and contents
+//        $this::fromIterable([$a])
+//            ->equals(Collection::fromIterable([$b]))
+//            ->shouldBe(false);
+//
+//        // objects, different instances but same contents
+//        $this::fromIterable([$a])
+//            ->equals(Collection::fromIterable([$a2]))
+//            ->shouldBe(false);
 
-        // objects, different instances and contents
-        $this::fromIterable([$a])
-            ->equals(Collection::fromIterable([$b]))
-            ->shouldBe(false);
-
-        // objects, different instances but same contents
-        $this::fromIterable([$a])
-            ->equals(Collection::fromIterable([$a2]))
-            ->shouldBe(false);
+//        // only in PHP 8 due to unpacking iterable with string keys
+//        if (PHP_VERSION_ID >= 80000) {
+//            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+//                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+//                ->shouldBe(true);
+//
+//            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+//                ->equals(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
+//                ->shouldBe(true);
+//
+//            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+//                ->equals(Collection::fromIterable(['bar' => 'b']))
+//                ->shouldBe(false);
+//
+//            $this::fromIterable(['foo' => 'f'])
+//                ->equals(Collection::fromIterable(['bar' => 'b']))
+//                ->shouldBe(false);
+//
+//            $this::fromIterable(['foo' => 'f'])
+//                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+//                ->shouldBe(false);
+//        }
     }
 
     public function it_can_every(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1103,39 +1103,39 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable([1, 2, 3])
             ->equals(Collection::fromIterable([1, 2, 3, 4]))
             ->shouldBe(false);
-//
-//        // objects, different instances and contents
-//        $this::fromIterable([$a])
-//            ->equals(Collection::fromIterable([$b]))
-//            ->shouldBe(false);
-//
-//        // objects, different instances but same contents
-//        $this::fromIterable([$a])
-//            ->equals(Collection::fromIterable([$a2]))
-//            ->shouldBe(false);
 
-//        // only in PHP 8 due to unpacking iterable with string keys
-//        if (PHP_VERSION_ID >= 80000) {
-//            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-//                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
-//                ->shouldBe(true);
-//
-//            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-//                ->equals(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
-//                ->shouldBe(true);
-//
-//            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-//                ->equals(Collection::fromIterable(['bar' => 'b']))
-//                ->shouldBe(false);
-//
-//            $this::fromIterable(['foo' => 'f'])
-//                ->equals(Collection::fromIterable(['bar' => 'b']))
-//                ->shouldBe(false);
-//
-//            $this::fromIterable(['foo' => 'f'])
-//                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
-//                ->shouldBe(false);
-//        }
+        // objects, different instances and contents
+        $this::fromIterable([$a])
+            ->equals(Collection::fromIterable([$b]))
+            ->shouldBe(false);
+
+        // objects, different instances but same contents
+        $this::fromIterable([$a])
+            ->equals(Collection::fromIterable([$a2]))
+            ->shouldBe(false);
+
+        // only in PHP 8 due to unpacking iterable with string keys
+        if (PHP_VERSION_ID >= 80000) {
+            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+                ->shouldBe(true);
+
+            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+                ->equals(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
+                ->shouldBe(true);
+
+            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+                ->equals(Collection::fromIterable(['bar' => 'b']))
+                ->shouldBe(false);
+
+            $this::fromIterable(['foo' => 'f'])
+                ->equals(Collection::fromIterable(['bar' => 'b']))
+                ->shouldBe(false);
+
+            $this::fromIterable(['foo' => 'f'])
+                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+                ->shouldBe(false);
+        }
     }
 
     public function it_can_every(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -31,6 +31,7 @@ use stdClass;
 use function gettype;
 use const INF;
 use const PHP_EOL;
+use const PHP_VERSION_ID;
 
 class CollectionSpec extends ObjectBehavior
 {
@@ -785,6 +786,28 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable(range(1, 5))
             ->diff()
             ->shouldIterateAs(range(1, 5));
+
+        $this::fromIterable(range(1, 5))
+            ->diff(...Collection::fromIterable(range(2, 5)))
+            ->shouldIterateAs([0 => 1]);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->diff(...Collection::fromIterable(['f']))
+            ->shouldIterateAs(['bar' => 'b']);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->diff('F', 'b')
+            ->shouldIterateAs(['foo' => 'f']);
+
+        if (PHP_VERSION_ID >= 80000) {
+            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+                ->diff(...Collection::fromIterable(['foo' => 'f']))
+                ->shouldIterateAs(['bar' => 'b']);
+
+            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+                ->diff(...['foo' => 'F', 'bar' => 'b'])
+                ->shouldIterateAs(['foo' => 'f']);
+        }
     }
 
     public function it_can_diffKeys(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -43,6 +43,7 @@ use loophp\collection\Operation\Drop;
 use loophp\collection\Operation\DropWhile;
 use loophp\collection\Operation\Dump;
 use loophp\collection\Operation\Duplicate;
+use loophp\collection\Operation\Equals;
 use loophp\collection\Operation\Every;
 use loophp\collection\Operation\Explode;
 use loophp\collection\Operation\Falsy;
@@ -343,6 +344,11 @@ final class Collection implements CollectionInterface
         return self::fromIterable($emptyArray);
     }
 
+    public function equals(CollectionInterface $other): bool
+    {
+        return (new self(Equals::of()($other), [$this->getIterator()]))->getIterator()->current();
+    }
+
     public function every(callable ...$callbacks): bool
     {
         return (new self(Every::of()(static fn (): bool => false)(...$callbacks), [$this->getIterator()]))->getIterator()->current();
@@ -572,7 +578,7 @@ final class Collection implements CollectionInterface
 
     public function isEmpty(): bool
     {
-        return IsEmpty::of()($this->getIterator());
+        return (new self(IsEmpty::of(), [$this->getIterator()]))->getIterator()->current();
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -346,7 +346,7 @@ final class Collection implements CollectionInterface
 
     public function equals(CollectionInterface $other): bool
     {
-        return (new self(Equals::of()($other), [$this->getIterator()]))->getIterator()->current();
+        return (new self(Equals::of()($other->getIterator()), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function every(callable ...$callbacks): bool

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -37,6 +37,7 @@ use loophp\collection\Contract\Operation\Dropable;
 use loophp\collection\Contract\Operation\DropWhileable;
 use loophp\collection\Contract\Operation\Dumpable;
 use loophp\collection\Contract\Operation\Duplicateable;
+use loophp\collection\Contract\Operation\Equalsable;
 use loophp\collection\Contract\Operation\Everyable;
 use loophp\collection\Contract\Operation\Explodeable;
 use loophp\collection\Contract\Operation\Falsyable;
@@ -156,6 +157,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends DropWhileable<TKey, T>
  * @template-extends Dumpable<TKey, T>
  * @template-extends Duplicateable<TKey, T>
+ * @template-extends Equalsable<TKey, T>
  * @template-extends Everyable<TKey, T>
  * @template-extends Explodeable<TKey, T>
  * @template-extends Falsyable<TKey, T>
@@ -269,6 +271,7 @@ interface Collection extends
     DropWhileable,
     Dumpable,
     Duplicateable,
+    Equalsable,
     Everyable,
     Explodeable,
     Falsyable,

--- a/src/Contract/Operation/Diffable.php
+++ b/src/Contract/Operation/Diffable.php
@@ -18,7 +18,7 @@ use loophp\collection\Contract\Collection;
 interface Diffable
 {
     /**
-     * @param mixed ...$values
+     * @param T ...$values
      *
      * @return Collection<TKey, T>
      */

--- a/src/Contract/Operation/Equalsable.php
+++ b/src/Contract/Operation/Equalsable.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Equalsable
+{
+    /**
+     * Check if the collection equals another iterable.
+     *
+     * @param Collection<TKey, T> $other
+     */
+    public function equals(Collection $other): bool;
+}

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -40,8 +40,22 @@ final class Equals extends AbstractOperation
                  *
                  * @return Generator<int, bool>
                  */
-                return static fn (Iterator $self): Generator => yield (iterator_count($other) === iterator_count($self))
-                        && yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($self);
+                return static function (Iterator $self) use ($other): Generator {
+                    $sameCount = true;
+
+                    do {
+                        if ($self->valid() !== $other->valid()) {
+                            $sameCount = false;
+
+                            break;
+                        }
+
+                        $self->next();
+                        $other->next();
+                    } while ($self->valid() || $other->valid());
+
+                    yield $sameCount && yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($self);
+                };
             };
     }
 }

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -41,16 +41,18 @@ final class Equals extends AbstractOperation
                  * @return Generator<int, bool>
                  */
                 return static function (Iterator $iterator) use ($other): Generator {
+                    $sameCount = true;
+
                     while ($other->valid() && $iterator->valid()) {
                         $iterator->next();
                         $other->next();
                     }
 
                     if ($other->valid() !== $iterator->valid()) {
-                        yield false;
+                        $sameCount = false;
                     }
 
-                    yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($iterator);
+                    return yield $sameCount && yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($iterator);
                 };
             };
     }

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -36,25 +36,21 @@ final class Equals extends AbstractOperation
              */
             static function (Iterator $other): Closure {
                 /**
-                 * @param Iterator<TKey, T> $self
+                 * @param Iterator<TKey, T> $iterator
                  *
                  * @return Generator<int, bool>
                  */
-                return static function (Iterator $self) use ($other): Generator {
-                    $sameCount = true;
-
-                    do {
-                        if ($self->valid() !== $other->valid()) {
-                            $sameCount = false;
-
-                            break;
-                        }
-
-                        $self->next();
+                return static function (Iterator $iterator) use ($other): Generator {
+                    while ($other->valid() && $iterator->valid()) {
+                        $iterator->next();
                         $other->next();
-                    } while ($self->valid() || $other->valid());
+                    }
 
-                    yield $sameCount && yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($self);
+                    if ($other->valid() !== $iterator->valid()) {
+                        yield false;
+                    }
+
+                    yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($iterator);
                 };
             };
     }

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -50,7 +50,13 @@ final class Equals extends AbstractOperation
                         return yield false;
                     }
 
-                    return yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($iterator);
+                    $containsCallback =
+                        /**
+                         * @param T $current
+                         */
+                        static fn ($current): bool => Contains::of()($current)($other)->current();
+
+                    return yield from Every::of()(static fn (): bool => false)($containsCallback)($iterator);
                 };
             };
     }

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -35,14 +35,13 @@ final class Equals extends AbstractOperation
              * @return Closure(Iterator<TKey, T>): Generator<int, bool>
              */
             static function (Iterator $other): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
-                $pipe = Pipe::of()(
-                    Diff::of()(...$other),
-                    IsEmpty::of(),
-                );
-
-                // Point free style.
-                return $pipe;
+                /**
+                 * @param Iterator<TKey, T> $self
+                 *
+                 * @return Generator<int, bool>
+                 */
+                return static fn (Iterator $self): Generator => yield (iterator_count($other) === iterator_count($self))
+                        && yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($self);
             };
     }
 }

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+use Iterator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Equals extends AbstractOperation
+{
+    /**
+     * @pure
+     *
+     * @return Closure(Iterator<TKey, T>): Closure(Iterator<TKey, T>): Generator<int, bool>
+     */
+    public function __invoke(): Closure
+    {
+        return
+            /**
+             * @param Iterator<TKey, T> $other
+             *
+             * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+             */
+            static function (Iterator $other): Closure {
+                /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
+                $pipe = Pipe::of()(
+                    Diff::of()(...$other),
+                    IsEmpty::of(),
+                );
+
+                // Point free style.
+                return $pipe;
+            };
+    }
+}

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -41,18 +41,16 @@ final class Equals extends AbstractOperation
                  * @return Generator<int, bool>
                  */
                 return static function (Iterator $iterator) use ($other): Generator {
-                    $sameCount = true;
-
                     while ($other->valid() && $iterator->valid()) {
                         $iterator->next();
                         $other->next();
                     }
 
                     if ($other->valid() !== $iterator->valid()) {
-                        $sameCount = false;
+                        return yield false;
                     }
 
-                    return yield $sameCount && yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($iterator);
+                    return yield from Pipe::of()(Diff::of()(...$other), IsEmpty::of())($iterator);
                 };
             };
     }

--- a/src/Operation/IsEmpty.php
+++ b/src/Operation/IsEmpty.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
+use Generator;
 use Iterator;
 
 /**
@@ -23,10 +24,10 @@ final class IsEmpty extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): bool
+     * @return Closure(Iterator<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure
     {
-        return static fn (Iterator $iterator): bool => !$iterator->valid();
+        return static fn (Iterator $iterator): Generator => yield !$iterator->valid();
     }
 }

--- a/tests/static-analysis/diff.php
+++ b/tests/static-analysis/diff.php
@@ -48,8 +48,6 @@ diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...$s
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...Collection::fromIterable(['foo' => 'f'])));
 /** @psalm-suppress InvalidArgument */
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...(static fn (): Generator => yield 'bar' => 'b')()));
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...['foo' => 'f']));
 
 // VALID failures -> usage with wrong types
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */

--- a/tests/static-analysis/diff.php
+++ b/tests/static-analysis/diff.php
@@ -48,7 +48,7 @@ diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...$s
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...Collection::fromIterable(['foo' => 'f'])));
 /** @psalm-suppress InvalidArgument */
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...(static fn (): Generator => yield 'bar' => 'b')()));
-// for some reason below is allowed
+/** @psalm-suppress InvalidArgument */
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...['foo' => 'f']));
 
 // VALID failures -> usage with wrong types

--- a/tests/static-analysis/diff.php
+++ b/tests/static-analysis/diff.php
@@ -48,7 +48,7 @@ diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...$s
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...Collection::fromIterable(['foo' => 'f'])));
 /** @psalm-suppress InvalidArgument */
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...(static fn (): Generator => yield 'bar' => 'b')()));
-/** @psalm-suppress InvalidArgument */
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
 diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...['foo' => 'f']));
 
 // VALID failures -> usage with wrong types

--- a/tests/static-analysis/diff.php
+++ b/tests/static-analysis/diff.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function diff_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function diff_checkMap(CollectionInterface $collection): void
+{
+}
+
+$intGen = static fn (): Generator => yield from [2, 3];
+$intCol = Collection::fromIterable([2, 3]);
+
+$stringGen = static fn (): Generator => yield 'b';
+$stringCol = Collection::fromIterable(['b']);
+
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff(1));
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff(1, 2));
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff(...[1, 2]));
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff(...$intGen()));
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff(...$intCol));
+
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff('f'));
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff('f', 'b'));
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...['f']));
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...$stringGen()));
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...$stringCol));
+
+// This is valid in PHP 8 but Psalm does not allow it (unpacking string keys)
+/** @psalm-suppress InvalidArgument */
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...Collection::fromIterable(['foo' => 'f'])));
+/** @psalm-suppress InvalidArgument */
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...(static fn (): Generator => yield 'bar' => 'b')()));
+// for some reason below is allowed
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...['foo' => 'f']));
+
+// VALID failures -> usage with wrong types
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff('a'));
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff(1, 'a'));
+/** @phpstan-ignore-next-line */
+diff_checkList(Collection::fromIterable([1, 2, 3])->diff(...$stringCol));
+
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(1));
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(1, 'f'));
+/** @phpstan-ignore-next-line */
+diff_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->diff(...$intCol));

--- a/tests/static-analysis/equals.php
+++ b/tests/static-analysis/equals.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+function equals_check(bool $value): void
+{
+}
+
+$a = (object) ['id' => 'a'];
+$a2 = (object) ['id' => 'a'];
+$b = (object) ['id' => 'b'];
+
+equals_check(Collection::fromIterable([1, 2, 3])->equals(Collection::fromIterable([3, 2, 1])));
+equals_check(Collection::fromIterable([1, 2, 3])->equals(Collection::empty()));
+equals_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])));
+equals_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->equals(Collection::fromIterable(['foo' => 'f'])));
+equals_check(Collection::fromIterable([$a])->equals(Collection::fromIterable([$b])));
+equals_check(Collection::fromIterable([$a])->equals(Collection::fromIterable([$a])));
+equals_check(Collection::fromIterable([$a])->equals(Collection::fromIterable([$a2])));
+equals_check(Collection::fromIterable([$a, $b])->equals(Collection::fromIterable([$a2, $b])));
+equals_check(Collection::fromIterable([$a, $b])->equals(Collection::fromIterable([$b, $a])));
+
+// VALID failures -> usage with different types
+
+/** @psalm-suppress InvalidArgument -> Psalm narrows the types to 1|2|3 and 4|5 and knows these cannot work */
+equals_check(Collection::fromIterable([1, 2, 3])->equals(Collection::fromIterable([4, 5])));
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+equals_check(Collection::fromIterable([1, 2, 3])->equals(Collection::fromIterable(['a', 'b'])));
+/** @psalm-suppress InvalidArgument -> Psalm sees the keys and values are completely different */
+equals_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->equals(Collection::fromIterable(['other' => 'x'])));
+/** @psalm-suppress InvalidArgument -> Psalm sees that one collection has fewer values for keys */
+equals_check(Collection::fromIterable([$a])->equals(Collection::fromIterable([$a, $b])));


### PR DESCRIPTION
This PR:

* [x] Provides a new operation `Equals` which allows determining if two collections contain the same elements
* [x] Includes a small refactor for `IsEmpty` -> now returns a `Generator` so it can be piped. This is backwards-compatible at Collection level but a BC break at individual Operation level
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation
* [x] Bonus: static analysis check for `diff`

Related to https://github.com/loophp/collection/discussions/135#discussioncomment-1016598.