### PR TITLE
Fix: Prevent warning when using odd amount of items.

### DIFF
--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -2254,6 +2254,18 @@ class CollectionSpec extends ObjectBehavior
             ->unwrap()
             ->pair()
             ->shouldIterateAs($gen());
+
+        $input = ['a', 'b', 'c'];
+
+        $gen = static function () {
+            yield 'a' => 'b';
+
+            yield 'c' => null;
+        };
+
+        $this::fromIterable($input)
+            ->pair()
+            ->shouldIterateAs($gen());
     }
 
     public function it_can_partition(): void

--- a/src/Operation/Pair.php
+++ b/src/Operation/Pair.php
@@ -34,9 +34,9 @@ final class Pair extends AbstractOperation
              * @param TKey $key
              * @param array{0: TKey, 1: T} $value
              *
-             * @return T|TKey
+             * @return T|TKey|null
              */
-            static fn ($initial, $key, array $value) => $value[0];
+            static fn ($initial, $key, array $value) => $value[0] ?? null;
 
         $callbackForValues =
             /**
@@ -44,9 +44,9 @@ final class Pair extends AbstractOperation
              * @param TKey $key
              * @param array{0: TKey, 1: T} $value
              *
-             * @return T|TKey
+             * @return T|TKey|null
              */
-            static fn ($initial, $key, array $value) => $value[1];
+            static fn ($initial, $key, array $value) => $value[1] ?? null;
 
         /** @var Closure(Iterator<TKey, T>): Generator<T|TKey, T> $pipe */
         $pipe = Pipe::of()(


### PR DESCRIPTION
This PR:

* [x] Fix warnings when using the Pair operation and when having an odd number of items in the collection.
* [x] Has unit tests (phpspec)
