### PR TITLE
Add Operation: `Same`

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -716,15 +716,16 @@ Compare two collections for equality. Collections are considered *equal* if:
 * they have the same number of elements;
 * they contain the same elements, regardless of the order they appear in or their keys.
 
-Elements will be compared using strict equality (``===``).
+Elements will be compared using strict equality (``===``). If you want to customize how elements
+are compared or the order in which the keys/values appear is important, use the ``same`` operation.
 
 .. tip:: This operation enables comparing ``Collection`` objects in PHPUnit tests using
     the dedicated `assertObjectEquals`_ assertion. 
 
 .. warning:: Because this operation *needs to traverse both collections* to determine if
-    the same elements are contained within them, a performance cost is incurred. Even though
-    the operation will stop as soon as it encounters an element of one collection that cannot
-    be found in the other, it is not recommended to use this for potentially large collections.
+    the same elements are contained within them, a performance cost is incurred. The operation will stop
+    as soon as it encounters an element of one collection that cannot be found in the other. However, 
+    it is not recommended to use it for potentially large collections, where ``same`` can be used instead.
 
 Interface: `Equalsable`_
 
@@ -1842,6 +1843,9 @@ Compare two collections for sameness. Collections are considered *same* if:
 By default elements and keys will be compared using strict equality (``===``). However,
 this behaviour can be customized with a comparator callback. This should be a curried function
 which takes first the left value and key, then the right value and key, and returns a boolean.
+
+This operation will stop and return a value as soon as one of the collections has been seen fully
+or as soon as the comparison yields *false* for any key-value pair.
 
 Interface: `Sameable`_
 

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1831,6 +1831,25 @@ Signature: ``Collection::rsample(float $probability): Collection;``
     $collection->rsample(1.0); // [1, 2, 3, 4, 5]
     $collection->rsample(0.5); // will get about half of the elements at random
 
+same
+~~~~
+
+Compare two collections for sameness. Collections are considered *same* if:
+
+* they have the same number of elements;
+* they have the same keys and elements, in the same order.
+
+By default elements and keys will be compared using strict equality (``===``). However,
+this behaviour can be customized with a comparator callback. This should be a curried function
+which takes first the left value and key, then the right value and key, and returns a boolean.
+
+Interface: `Sameable`_
+
+Signature: ``Collection::same(Collection $other, ?callable $comparatorCallback = null): bool;``
+
+.. literalinclude:: code/operations/same.php
+    :language: php
+
 scale
 ~~~~~
 
@@ -2527,6 +2546,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Rejectable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Rejectable.php
 .. _Reverseable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Reverseable.php
 .. _RSampleable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/RSampleable.php
+.. _Sameable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Sameable.php
 .. _Scaleable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Scaleable.php
 .. _ScanLeftable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/ScanLeftable.php
 .. _ScanLeft1able: https://github.com/loophp/collection/blob/master/src/Contract/Operation/ScanLeft1able.php

--- a/docs/pages/code/operations/equals.php
+++ b/docs/pages/code/operations/equals.php
@@ -28,6 +28,9 @@ Collection::fromIterable([1, 2, 3])
 Collection::fromIterable(['foo' => 'f'])
     ->equals(Collection::fromIterable(['foo' => 'f'])); // true
 
+Collection::fromIterable(['foo' => 'f'])
+    ->same(Collection::fromIterable(['bar' => 'f'])); // true
+
 Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])
     ->equals(Collection::fromIterable(['foo' => 'f', 'baz' => 'b'])); // true
 

--- a/docs/pages/code/operations/same.php
+++ b/docs/pages/code/operations/same.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+use stdClass;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+Collection::fromIterable([1, 2, 3])
+    ->same(Collection::fromIterable([1, 2, 3])); // true
+
+Collection::fromIterable([1, 2, 3])
+    ->same(Collection::fromIterable([3, 1, 2])); // false
+
+Collection::fromIterable([1, 2, 3])
+    ->same(Collection::fromIterable([1, 2])); // false
+
+Collection::fromIterable([1, 2, 3])
+    ->same(Collection::fromIterable([1, 2, 4])); // false
+
+Collection::fromIterable(['foo' => 'f'])
+    ->same(Collection::fromIterable(['foo' => 'f'])); // true
+
+Collection::fromIterable(['foo' => 'f'])
+    ->same(Collection::fromIterable(['bar' => 'f'])); // false
+
+Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])
+    ->same(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])); // true
+
+Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])
+    ->same(Collection::fromIterable(['bar' => 'b', 'foo' => 'f'])); // false
+
+$a = (object) ['id' => 'a'];
+$a2 = (object) ['id' => 'a'];
+
+Collection::fromIterable([$a])
+    ->equals(Collection::fromIterable([$a])); // true
+
+Collection::fromIterable([$a])
+    ->equals(Collection::fromIterable([$a2])); // false
+
+$comparator = static fn (string $left) => static fn (string $right): bool => $left === $right;
+$this::fromIterable(['foo' => 'f'])
+    ->same(Collection::fromIterable(['bar' => 'f']), $comparator); // true
+
+$comparator = static fn ($left, $leftKey) => static fn ($right, $rightKey): bool => $left === $right
+    && mb_strtolower($leftKey) === mb_strtolower($rightKey);
+$this::fromIterable(['foo' => 'f'])
+    ->same(Collection::fromIterable(['FOO' => 'f']), $comparator); // true
+
+$comparator = static fn (stdClass $left) => static fn (stdClass $right): bool => $left->id === $right->id;
+$this::fromIterable([$a])
+    ->same(Collection::fromIterable([$a2]), $comparator); // true

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1089,11 +1089,6 @@ class CollectionSpec extends ObjectBehavior
             ->equals(Collection::fromIterable([1, 2, 4]))
             ->shouldBe(false);
 
-        // different lengths, missing elements
-        $this::fromIterable([1, 2, 3])
-            ->equals(Collection::fromIterable([1, 2]))
-            ->shouldBe(false);
-
         // different lengths, extra elements in first
         $this::fromIterable([1, 2, 3, 4])
             ->equals(Collection::fromIterable([1, 2, 3]))
@@ -1114,28 +1109,30 @@ class CollectionSpec extends ObjectBehavior
             ->equals(Collection::fromIterable([$a2]))
             ->shouldBe(false);
 
-        // only in PHP 8 due to unpacking iterable with string keys
-        if (PHP_VERSION_ID >= 80000) {
-            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
-                ->shouldBe(true);
+        // "maps" with string keys and values
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+            ->shouldBe(true);
 
-            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-                ->equals(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
-                ->shouldBe(true);
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->equals(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
+            ->shouldBe(true);
 
-            $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-                ->equals(Collection::fromIterable(['bar' => 'b']))
-                ->shouldBe(false);
+        $this::fromIterable(['foo' => 'f'])
+            ->equals(Collection::fromIterable(['bar' => 'f']))
+            ->shouldBe(true);
 
-            $this::fromIterable(['foo' => 'f'])
-                ->equals(Collection::fromIterable(['bar' => 'b']))
-                ->shouldBe(false);
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->equals(Collection::fromIterable(['bar' => 'b']))
+            ->shouldBe(false);
 
-            $this::fromIterable(['foo' => 'f'])
-                ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
-                ->shouldBe(false);
-        }
+        $this::fromIterable(['foo' => 'f'])
+            ->equals(Collection::fromIterable(['bar' => 'b']))
+            ->shouldBe(false);
+
+        $this::fromIterable(['foo' => 'f'])
+            ->equals(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+            ->shouldBe(false);
     }
 
     public function it_can_every(): void
@@ -2754,6 +2751,120 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable(range(1, 10))
             ->rsample(.5)
             ->shouldNotHaveCount(10);
+    }
+
+    public function it_can_same(): void
+    {
+        $a = (object) ['id' => 'a'];
+        $a2 = (object) ['id' => 'a'];
+        $b = (object) ['id' => 'b'];
+
+        // empty variations
+        $this::empty()
+            ->same(Collection::empty())
+            ->shouldBe(true);
+
+        $this::empty()
+            ->same(Collection::fromIterable([1]))
+            ->shouldBe(false);
+
+        $this::fromIterable([1])
+            ->same(Collection::empty())
+            ->shouldBe(false);
+
+        // same elements, same order (same keys)
+        $this::fromIterable([1, 2, 3])
+            ->same(Collection::fromIterable([1, 2, 3]))
+            ->shouldBe(true);
+
+        $this::fromIterable([$a, $b])
+            ->same(Collection::fromIterable([$a, $b]))
+            ->shouldBe(true);
+
+        // same elements, different order (different keys)
+        $this::fromIterable([1, 2, 3])
+            ->same(Collection::fromIterable([3, 1, 2]))
+            ->shouldBe(false);
+
+        $this::fromIterable([$a, $b])
+            ->same(Collection::fromIterable([$b, $a]))
+            ->shouldBe(false);
+
+        // same lengths, with one element different
+        $this::fromIterable([1, 2, 3])
+            ->same(Collection::fromIterable([1, 2, 4]))
+            ->shouldBe(false);
+
+        // different lengths, extra elements in first
+        $this::fromIterable([1, 2, 3, 4])
+            ->same(Collection::fromIterable([1, 2, 3]))
+            ->shouldBe(false);
+
+        // different lengths, extra elements in second
+        $this::fromIterable([1, 2, 3])
+            ->same(Collection::fromIterable([1, 2, 3, 4]))
+            ->shouldBe(false);
+
+        // objects, different instances and contents
+        $this::fromIterable([$a])
+            ->same(Collection::fromIterable([$b]))
+            ->shouldBe(false);
+
+        // objects, different instances but same contents
+        $this::fromIterable([$a])
+            ->same(Collection::fromIterable([$a2]))
+            ->shouldBe(false);
+
+        // "maps" with string keys and values
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->same(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+            ->shouldBe(true);
+
+        $this::fromIterable(['foo' => 'f'])
+            ->same(Collection::fromIterable(['bar' => 'f']))
+            ->shouldBe(false);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->same(Collection::fromIterable(['bar' => 'b', 'foo' => 'f']))
+            ->shouldBe(false);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->same(Collection::fromIterable(['bar' => 'b']))
+            ->shouldBe(false);
+
+        $this::fromIterable(['foo' => 'f'])
+            ->same(Collection::fromIterable(['bar' => 'b']))
+            ->shouldBe(false);
+
+        $this::fromIterable(['FOO' => 'f'])
+            ->same(Collection::fromIterable(['foo' => 'f']))
+            ->shouldBe(false);
+
+        $this::fromIterable(['foo' => 'f'])
+            ->same(Collection::fromIterable(['foo' => 'f', 'bar' => 'b']))
+            ->shouldBe(false);
+
+        // custom comparators
+        $comparator = static fn ($left) => static fn ($right): bool => (int) $left === (int) $right;
+        $this::fromIterable([1, 2, 3])
+            ->same(Collection::fromIterable(['1', '2', '3']), $comparator)
+            ->shouldBe(true);
+
+        $comparator = static fn ($left) => static fn ($right): bool => $left === $right;
+        $this::fromIterable(['foo' => 'f'])
+            ->same(Collection::fromIterable(['bar' => 'f']), $comparator)
+            ->shouldBe(true);
+
+        $comparator = static fn ($left, $leftKey) => static fn ($right, $rightKey): bool => $left === $right
+            && mb_strtolower($leftKey) === mb_strtolower($rightKey);
+        $this::fromIterable(['foo' => 'f'])
+            ->same(Collection::fromIterable(['FOO' => 'f']), $comparator)
+            ->shouldBe(true);
+
+        $comparator = static fn (stdClass $left) => static fn (stdClass $right): bool => $left->id === $right->id;
+        $this::fromIterable([$a])
+            ->same(Collection::fromIterable([$a2]), $comparator)
+            ->shouldBe(true);
     }
 
     public function it_can_scale(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -100,6 +100,7 @@ use loophp\collection\Operation\Reduction;
 use loophp\collection\Operation\Reject;
 use loophp\collection\Operation\Reverse;
 use loophp\collection\Operation\RSample;
+use loophp\collection\Operation\Same;
 use loophp\collection\Operation\Scale;
 use loophp\collection\Operation\ScanLeft;
 use loophp\collection\Operation\ScanLeft1;
@@ -746,6 +747,25 @@ final class Collection implements CollectionInterface
     public function rsample(float $probability): CollectionInterface
     {
         return new self(RSample::of()($probability), [$this->getIterator()]);
+    }
+
+    public function same(CollectionInterface $other, ?callable $comparatorCallback = null): bool
+    {
+        $comparatorCallback ??=
+            /**
+             * @param T $leftValue
+             * @param TKey $leftKey
+             *
+             * @return Closure(T, TKey): bool
+             */
+            static fn ($leftValue, $leftKey): Closure =>
+                /**
+                 * @param T $rightValue
+                 * @param TKey $rightKey
+                 */
+                static fn ($rightValue, $rightKey): bool => $leftValue === $rightValue && $leftKey === $rightKey;
+
+        return (new self(Same::of()($other->getIterator())($comparatorCallback), [$this->getIterator()]))->getIterator()->current();
     }
 
     public function scale(

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -94,6 +94,7 @@ use loophp\collection\Contract\Operation\Reductionable;
 use loophp\collection\Contract\Operation\Rejectable;
 use loophp\collection\Contract\Operation\Reverseable;
 use loophp\collection\Contract\Operation\RSampleable;
+use loophp\collection\Contract\Operation\Sameable;
 use loophp\collection\Contract\Operation\Scaleable;
 use loophp\collection\Contract\Operation\ScanLeft1able;
 use loophp\collection\Contract\Operation\ScanLeftable;
@@ -214,6 +215,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Rejectable<TKey, T>
  * @template-extends Reverseable<TKey, T>
  * @template-extends RSampleable<TKey, T>
+ * @template-extends Sameable<TKey, T>
  * @template-extends Scaleable<TKey, T>
  * @template-extends ScanLeft1able<TKey, T>
  * @template-extends ScanLeftable<TKey, T>
@@ -332,6 +334,7 @@ interface Collection extends
     Rejectable,
     Reverseable,
     RSampleable,
+    Sameable,
     Scaleable,
     ScanLeft1able,
     ScanLeftable,

--- a/src/Contract/Operation/Sameable.php
+++ b/src/Contract/Operation/Sameable.php
@@ -15,12 +15,13 @@ use loophp\collection\Contract\Collection;
  * @template TKey
  * @template T
  */
-interface Equalsable
+interface Sameable
 {
     /**
-     * Check if the collection equals another collection..
+     * Check if the collection is the same as another collection.
      *
      * @param Collection<TKey, T> $other
+     * @param null|callable(T, TKey): (Closure(T, TKey): bool) $comparatorCallback
      */
-    public function equals(Collection $other): bool;
+    public function same(Collection $other, ?callable $comparatorCallback = null): bool;
 }

--- a/src/Operation/Same.php
+++ b/src/Operation/Same.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+use Iterator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Same extends AbstractOperation
+{
+    /**
+     * @pure
+     *
+     * @return Closure(Iterator<TKey, T>): Closure(callable(T, TKey): Closure(T, TKey): bool): Closure(Iterator<TKey, T>): Generator<int, bool>
+     */
+    public function __invoke(): Closure
+    {
+        return
+            /**
+             * @param Iterator<TKey, T> $other
+             *
+             * @return Closure(callable(T, TKey): Closure(T, TKey): bool): Closure(Iterator<TKey, T>): Generator<int, bool>
+             */
+            static fn (Iterator $other): Closure =>
+                /**
+                 * @param callable(T, TKey): (Closure(T, TKey): bool) $comparatorCallback
+                 *
+                 * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+                 */
+                static fn (callable $comparatorCallback): Closure =>
+                    /**
+                     * @param Iterator<TKey, T> $iterator
+                     *
+                     * @return Generator<int, bool>
+                     */
+                    static function (Iterator $iterator) use ($other, $comparatorCallback): Generator {
+                        $isSame = true;
+
+                        while ($iterator->valid() && $other->valid()) {
+                            if (!$comparatorCallback($iterator->current(), $iterator->key())($other->current(), $other->key())) {
+                                $isSame = false;
+                            }
+
+                            $iterator->next();
+                            $other->next();
+                        }
+
+                        if ($iterator->valid() !== $other->valid()) {
+                            $isSame = false;
+                        }
+
+                        yield $isSame;
+                    };
+    }
+}

--- a/src/Operation/Same.php
+++ b/src/Operation/Same.php
@@ -58,6 +58,7 @@ final class Same extends AbstractOperation
                             $other->next();
                         }
 
+                        // TODO: Use single return line when FriendsOfPHP/PHP-CS-Fixer#5810 is fixed.
                         if ($iterator->valid() !== $other->valid()) {
                             return yield false;
                         }

--- a/src/Operation/Same.php
+++ b/src/Operation/Same.php
@@ -18,6 +18,8 @@ use Iterator;
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class Same extends AbstractOperation
 {
@@ -47,11 +49,9 @@ final class Same extends AbstractOperation
                      * @return Generator<int, bool>
                      */
                     static function (Iterator $iterator) use ($other, $comparatorCallback): Generator {
-                        $isSame = true;
-
                         while ($iterator->valid() && $other->valid()) {
                             if (!$comparatorCallback($iterator->current(), $iterator->key())($other->current(), $other->key())) {
-                                $isSame = false;
+                                return yield false;
                             }
 
                             $iterator->next();
@@ -59,10 +59,10 @@ final class Same extends AbstractOperation
                         }
 
                         if ($iterator->valid() !== $other->valid()) {
-                            $isSame = false;
+                            return yield false;
                         }
 
-                        yield $isSame;
+                        return yield true;
                     };
     }
 }

--- a/src/Operation/Same.php
+++ b/src/Operation/Same.php
@@ -58,7 +58,7 @@ final class Same extends AbstractOperation
                             $other->next();
                         }
 
-                        // TODO: Use single return line when FriendsOfPHP/PHP-CS-Fixer#5810 is fixed.
+                        // TODO: Use single return line when FriendsOfPHP/PHP-CS-Fixer/issues/5810 is fixed.
                         if ($iterator->valid() !== $other->valid()) {
                             return yield false;
                         }

--- a/tests/static-analysis/same.php
+++ b/tests/static-analysis/same.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+function same_check(bool $value): void
+{
+}
+
+$a = (object) ['id' => 'a'];
+$a2 = (object) ['id' => 'a'];
+$b = (object) ['id' => 'b'];
+
+same_check(Collection::fromIterable([1, 2, 3])->same(Collection::fromIterable([3, 2, 1])));
+same_check(Collection::fromIterable([1, 2, 3])->same(Collection::empty()));
+same_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->same(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])));
+same_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->same(Collection::fromIterable(['foo' => 'f'])));
+same_check(Collection::fromIterable([$a])->same(Collection::fromIterable([$b])));
+same_check(Collection::fromIterable([$a])->same(Collection::fromIterable([$a])));
+same_check(Collection::fromIterable([$a])->same(Collection::fromIterable([$a2])));
+same_check(Collection::fromIterable([$a, $b])->same(Collection::fromIterable([$a2, $b])));
+same_check(Collection::fromIterable([$a, $b])->same(Collection::fromIterable([$b, $a])));
+
+$comparator = static fn (string $left): Closure => static fn (string $right): bool => $left === $right;
+same_check(Collection::fromIterable(['foo' => 'f'])->same(Collection::fromIterable(['foo' => 'f']), $comparator));
+
+$comparator = static fn (string $left, string $leftKey): Closure => static fn (string $right, string $rightKey): bool => $left === $right
+    && mb_strtolower($leftKey) === mb_strtolower($rightKey);
+same_check(Collection::fromIterable(['foo' => 'f'])->same(Collection::fromIterable(['foo' => 'f']), $comparator));
+
+$comparator = static fn (stdClass $left): Closure => static fn (stdClass $right): bool => $left->id === $right->id;
+same_check(Collection::fromIterable([$a])->same(Collection::fromIterable([$a2]), $comparator));
+
+// VALID failures -> usage with different types
+// Note some of these might be allowed due to the option of having a custom comparator
+// We'll need to see if this causes issues - we might want to allow comparing collections with different template types
+
+/** @psalm-suppress InvalidArgument -> Psalm narrows the types to 1|2|3 and 4|5 and knows these cannot work */
+same_check(Collection::fromIterable([1, 2, 3])->same(Collection::fromIterable([4, 5])));
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+same_check(Collection::fromIterable([1, 2, 3])->same(Collection::fromIterable(['a', 'b'])));
+/** @psalm-suppress InvalidArgument -> Psalm sees the keys and values are completely different */
+same_check(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->same(Collection::fromIterable(['other' => 'x'])));
+/** @psalm-suppress InvalidArgument -> Psalm sees that one collection has fewer values for keys */
+same_check(Collection::fromIterable([$a])->same(Collection::fromIterable([$a, $b])));
+
+$comparator = static fn (string $left): Closure => static fn (string $right): bool => $left === $right;
+/** @psalm-suppress InvalidArgument -> Psalm narrows the types and sees that the keys are different */
+same_check(Collection::fromIterable(['foo' => 'f'])->same(Collection::fromIterable(['bar' => 'f']), $comparator));
+
+$comparator = static fn (string $left, string $leftKey): Closure => static fn (string $right, string $rightKey): bool => $left === $right
+    && mb_strtolower($leftKey) === mb_strtolower($rightKey);
+/** @psalm-suppress InvalidArgument -> Psalm sees that the keys are different */
+same_check(Collection::fromIterable(['foo' => 'f'])->same(Collection::fromIterable(['FOO' => 'f']), $comparator));


### PR DESCRIPTION
This PR:

* [x] Provides a new operation `Same` which allows determining if two collections are the same
* [x] Allows custom item comparison via a callable -> if this is not provided, by default we consider two collections the same if the have the same items and keys, in the same order
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation

Follows #152.
Related to https://github.com/loophp/collection/discussions/135#discussioncomment-1016598.
