### PR TITLE
`Drop` accepts non-variadic `count`

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -638,11 +638,11 @@ Signature: ``Collection::distinct(?callable $comparatorCallback = null, ?callabl
 drop
 ~~~~
 
-Drop the n first items of the collection.
+Drop the first ``n`` items of the collection.
 
 Interface: `Dropable`_
 
-Signature: ``Collection::drop(int ...$counts): Collection;``
+Signature: ``Collection::drop(int $count): Collection;``
 
 .. code-block:: php
 
@@ -1236,7 +1236,7 @@ Signature: ``Collection::intersectKeys(...$keys): Collection;``
 intersperse
 ~~~~~~~~~~~
 
-Insert a given value at every n element of a collection and indices are not preserved.
+Insert a given value at every ``n`` element of a collection and indices are not preserved.
 
 Interface: `Intersperseable`_
 

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -909,7 +909,7 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs([3 => 'D', 4 => 'E', 5 => 'F']);
 
         $this::fromIterable(range('A', 'F'))
-            ->drop(3, 3)
+            ->drop(6)
             ->shouldIterateAs([]);
     }
 
@@ -2736,10 +2736,6 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable(range('A', 'F'))
             ->reverse()
             ->shouldIterateAs([5 => 'F', 4 => 'E', 3 => 'D', 2 => 'C', 1 => 'B', 0 => 'A']);
-
-        $this::fromIterable(range('A', 'F'))
-            ->drop(3, 3)
-            ->shouldIterateAs([]);
     }
 
     public function it_can_rsample(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -310,9 +310,9 @@ final class Collection implements CollectionInterface
         return new self(Distinct::of()($comparatorCallback)($accessorCallback), [$this->getIterator()]);
     }
 
-    public function drop(int ...$counts): CollectionInterface
+    public function drop(int $count): CollectionInterface
     {
-        return new self(Drop::of()(...$counts), [$this->getIterator()]);
+        return new self(Drop::of()($count), [$this->getIterator()]);
     }
 
     public function dropWhile(callable ...$callbacks): CollectionInterface

--- a/src/Contract/Operation/Dropable.php
+++ b/src/Contract/Operation/Dropable.php
@@ -20,9 +20,7 @@ interface Dropable
     /**
      * Skip the n items of a collection.
      *
-     * @param int ...$counts
-     *
      * @return Collection<TKey, T>
      */
-    public function drop(int ...$counts): Collection;
+    public function drop(int $count): Collection;
 }

--- a/src/Operation/Drop.php
+++ b/src/Operation/Drop.php
@@ -24,7 +24,7 @@ final class Drop extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int...): Closure(Iterator<TKey, T>): Iterator<TKey, T>
+     * @return Closure(int): Closure(Iterator<TKey, T>): Iterator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -32,12 +32,12 @@ final class Drop extends AbstractOperation
             /**
              * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
              */
-            static fn (int ...$offsets): Closure =>
+            static fn (int $count): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
                  * @return Iterator<TKey, T>
                  */
-                static fn (Iterator $iterator): Iterator => new LimitIterator($iterator, array_sum($offsets));
+                static fn (Iterator $iterator): Iterator => new LimitIterator($iterator, $count);
     }
 }

--- a/tests/static-analysis/drop.php
+++ b/tests/static-analysis/drop.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function drop_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function drop_checkMap(CollectionInterface $collection): void
+{
+}
+
+drop_checkList(Collection::fromIterable([1, 2, 3])->drop(1));
+drop_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->drop(2));
+
+// VALID failures -> `drop` does not change the key and value types
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+drop_checkList(Collection::fromIterable(['a', 'b', 'c'])->drop(1));
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+drop_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->drop(3));


### PR DESCRIPTION
This PR:

* [x] Updates `Drop` so that it only accepts one parameter - the number of items to drop
* [x] It breaks backward compatibility - will be released in version 5
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation

Related to https://github.com/loophp/collection/pull/156#discussion_r673518546.
