### PR TITLE
Introduce helpers for static constructors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     "autoload": {
         "psr-4": {
             "loophp\\collection\\": "./src/"
-        }
+        },
+        "files": ["src/Utils/helpers.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,9 @@
         "psr-4": {
             "loophp\\collection\\": "./src/"
         },
-        "files": ["src/Utils/helpers.php"]
+        "files": [
+            "src/Utils/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -29,6 +29,7 @@ use PhpSpec\Exception\Example\MatcherException;
 use PhpSpec\ObjectBehavior;
 use stdClass;
 use function gettype;
+use function loophp\collection\Utils\collectIterable;
 use const INF;
 use const PHP_EOL;
 use const PHP_VERSION_ID;
@@ -36,6 +37,13 @@ use const PHP_VERSION_ID;
 class CollectionSpec extends ObjectBehavior
 {
     private const PHP_8 = 80_000;
+
+    public function getMatchers(): array
+    {
+        return [
+            'beSameAs' => static fn (CollectionInterface $subject, CollectionInterface $expected): bool => $subject->same($expected),
+        ];
+    }
 
     public function it_can_all(): void
     {
@@ -436,6 +444,13 @@ class CollectionSpec extends ObjectBehavior
             ->beConstructedThrough('fromIterable', [new ArrayObject([1, 2, 3])]);
 
         $this->shouldImplement(Collection::class);
+    }
+
+    public function it_can_be_constructed_with_collectIterable(): void
+    {
+        $input = [1, 2, 3];
+
+        $this::fromIterable($input)->shouldBeSameAs(collectIterable($input));
     }
 
     public function it_can_be_instantiated_with_withClosure(): void

--- a/src/Utils/helpers.php
+++ b/src/Utils/helpers.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Utils;
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+use function function_exists;
+
+if (!function_exists('collectIterable')) {
+    /**
+     * @pure
+     *
+     * @template TKey
+     * @template T
+     *
+     * @param iterable<TKey, T> $iterable
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    function collectIterable(iterable $iterable): CollectionInterface
+    {
+        return Collection::fromIterable($iterable);
+    }
+}

--- a/src/Utils/helpers.php
+++ b/src/Utils/helpers.php
@@ -11,6 +11,7 @@ namespace loophp\collection\Utils;
 
 use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
+
 use function function_exists;
 
 if (!function_exists('collectIterable')) {


### PR DESCRIPTION
This PR provides helper functions that can be used to instantiate Collection.
The main advantages are:
- fewer characters to type
- less import aliasing, e.g. when using the [CollectionInterface](https://github.com/loophp/collection/blob/master/src/Contract/Collection.php) as param or return type users always need to have 2 imports with the existing static constructors - one for the interface and one for the [Collection](https://github.com/loophp/collection/blob/master/src/Collection.php) class (see discussion link below)

* [x] Provides helper functions
* [ ] Has unit tests (phpspec)
* [ ] Has static analysis tests (psalm, phpstan)
* [ ] Has documentation

Related to https://github.com/loophp/collection/discussions/135#discussioncomment-1016598.