### PR TITLE
refactor: Make constructor private.

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -169,7 +169,7 @@ final class Collection implements CollectionInterface
      * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
      * @param iterable<array-key, mixed> $parameters
      */
-    public function __construct(callable $callable, iterable $parameters = [])
+    final private function __construct(callable $callable, iterable $parameters = [])
     {
         $this->source = $callable;
         $this->parameters = $parameters;

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -169,7 +169,7 @@ final class Collection implements CollectionInterface
      * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
      * @param iterable<array-key, mixed> $parameters
      */
-    final private function __construct(callable $callable, iterable $parameters = [])
+    private function __construct(callable $callable, iterable $parameters = [])
     {
         $this->source = $callable;
         $this->parameters = $parameters;


### PR DESCRIPTION
To improve usability, I think it's better to prevent the use of regular Collection construction in favor of static constructors.

This PR:

* [x] It breaks backward compatibility
* [x] Make the Collection constructor private.
