### PR TITLE
SA: Update operations.

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -702,15 +702,19 @@ final class Collection implements CollectionInterface
     public function partition(callable ...$callbacks): CollectionInterface
     {
         // TODO: Move this docblock above closure when https://github.com/phpstan/phpstan/issues/3770 lands.
-        $mapCallback = static function (array $partitionResult): CollectionInterface {
+        $mapCallback =
             /**
-             * @var Closure(Iterator<TKey, T>): Generator<TKey, T> $callback
-             * @var array{0: Iterator<TKey, T>} $parameters
+             * @param array{0: (Closure(Iterator<TKey, T>): Generator<TKey, T>), 1: (array{0: Iterator<TKey, T>})} $partitionResult
              */
-            [$callback, $parameters] = $partitionResult;
+            static function (array $partitionResult): CollectionInterface {
+                /**
+                 * @var Closure(Iterator<TKey, T>): Generator<TKey, T> $callback
+                 * @var array{0: Iterator<TKey, T>} $parameters
+                 */
+                [$callback, $parameters] = $partitionResult;
 
-            return self::fromCallable($callback, $parameters);
-        };
+                return self::fromCallable($callback, $parameters);
+            };
 
         return new self(Pipe::of()(Partition::of()(...$callbacks), Map::of()($mapCallback)), [$this->getIterator()]);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -851,15 +851,19 @@ final class Collection implements CollectionInterface
     public function span(callable ...$callbacks): CollectionInterface
     {
         // TODO: Move this docblock above closure when https://github.com/phpstan/phpstan/issues/3770 lands.
-        $mapCallback = static function (array $spanResult): CollectionInterface {
+        $mapCallback =
             /**
-             * @var Closure(Iterator<TKey, T>): Generator<TKey, T> $callback
-             * @var array{0: Iterator<TKey, T>} $parameters
+             * @param array{0: (Closure(Iterator<TKey, T>): Generator<TKey, T>), 1: (array{0: Iterator<TKey, T>})} $spanResult
              */
-            [$callback, $parameters] = $spanResult;
+            static function (array $spanResult): CollectionInterface {
+                /**
+                 * @var Closure(Iterator<TKey, T>): Generator<TKey, T> $callback
+                 * @var array{0: Iterator<TKey, T>} $parameters
+                 */
+                [$callback, $parameters] = $spanResult;
 
-            return self::fromCallable($callback, $parameters);
-        };
+                return self::fromCallable($callback, $parameters);
+            };
 
         return new self(Pipe::of()(Span::of()(...$callbacks), Map::of()($mapCallback)), [$this->getIterator()]);
     }

--- a/src/Operation/Partition.php
+++ b/src/Operation/Partition.php
@@ -49,7 +49,7 @@ final class Partition extends AbstractOperation
                     /** @var array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}} $reject */
                     $reject = [Reject::of()(...$callbacks), [$iterator]];
 
-                    yield from [$filter, $reject];
+                    return yield from [$filter, $reject];
                 };
     }
 }

--- a/src/Operation/Span.php
+++ b/src/Operation/Span.php
@@ -49,7 +49,7 @@ final class Span extends AbstractOperation
                     /** @var array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}} $dropWhile */
                     $dropWhile = [DropWhile::of()(...$callbacks), [$iterator]];
 
-                    yield from [$takeWhile, $dropWhile];
+                    return yield from [$takeWhile, $dropWhile];
                 };
     }
 }

--- a/src/Operation/Transpose.php
+++ b/src/Operation/Transpose.php
@@ -46,7 +46,7 @@ final class Transpose extends AbstractOperation
                 $callbackForKeys =
                     /**
                      * @param array $carry
-                     * @param array<int, TKey> $key
+                     * @param non-empty-array<int, TKey> $key
                      *
                      * @return TKey
                      */

--- a/src/Operation/Unpair.php
+++ b/src/Operation/Unpair.php
@@ -24,7 +24,7 @@ final class Unpair extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, array{TKey, T}>
+     * @return Closure(Iterator<TKey, T>): Generator<int, array<TKey, T>>
      */
     public function __invoke(): Closure
     {
@@ -32,7 +32,7 @@ final class Unpair extends AbstractOperation
             /**
              * @param Iterator<TKey, T> $iterator
              *
-             * @return Generator<int, array{TKey, T}>
+             * @return Generator<int, array<TKey, T>>
              */
             static function (Iterator $iterator): Generator {
                 foreach ($iterator as $key => $value) {

--- a/tests/static-analysis/scanLeft.php
+++ b/tests/static-analysis/scanLeft.php
@@ -13,7 +13,8 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 $sum = static fn (int $carry, int $value): int => $carry + $value;
-$concat = static fn (?string $carry, string $string): string => sprintf('%s%s', (string) $carry, $string);
+$concat = static fn (string $carry, string $string): string => sprintf('%s%s', $carry, $string);
+$concatWithNull = static fn (?string $carry, string $string): string => sprintf('%s%s', (string) $carry, $string);
 $toString =
     /**
      * @param bool|string $carry
@@ -50,5 +51,5 @@ function scanLeft_checkListOfSize1String(CollectionInterface $collection): void
 
 scanLeft_checkListInt(Collection::fromIterable([1, 2, 3])->scanLeft($sum, 5));
 scanLeft_checkListString(Collection::fromIterable(range('a', 'c'))->scanLeft($concat, ''));
-scanLeft_checkListStringWithNull(Collection::fromIterable(range('a', 'c'))->scanLeft($concat));
+scanLeft_checkListStringWithNull(Collection::fromIterable(range('a', 'c'))->scanLeft($concatWithNull));
 scanLeft_checkListOfSize1String(Collection::fromIterable([10])->scanLeft($toString, true));

--- a/tests/static-analysis/scanRight.php
+++ b/tests/static-analysis/scanRight.php
@@ -13,7 +13,8 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 $sum = static fn (int $carry, int $value): int => $carry + $value;
-$concat = static fn (?string $carry, string $string): string => sprintf('%s%s', (string) $carry, $string);
+$concat = static fn (string $carry, string $string): string => sprintf('%s%s', $carry, $string);
+$concatWithNull = static fn (?string $carry, string $string): string => sprintf('%s%s', (string) $carry, $string);
 $toString =
     /**
      * @param bool|string $carry
@@ -50,5 +51,5 @@ function scanRight_checkListOfSize1String(CollectionInterface $collection): void
 
 scanRight_checkListInt(Collection::fromIterable([1, 2, 3])->scanRight($sum, 5));
 scanRight_checkListString(Collection::fromIterable(range('a', 'c'))->scanRight($concat, ''));
-scanRight_checkListStringWithNull(Collection::fromIterable(range('a', 'c'))->scanRight($concat));
+scanRight_checkListStringWithNull(Collection::fromIterable(range('a', 'c'))->scanRight($concatWithNull));
 scanRight_checkListOfSize1String(Collection::fromIterable([10])->scanRight($toString, true));


### PR DESCRIPTION
This PR:

* [x] Fix some typing informations
* [x] Investigated on why Psalm >= 4.9.0 trigger issues with `scanLeft` and `scanRight` SA tests. (After bisecting Psalm, the commit introducing the issue is https://github.com/vimeo/psalm/commit/acc7ee261c106b4ae91f333ff4a9939b6e858bf3 from PR https://github.com/vimeo/psalm/pull/6072). Turns out that it was normal actually. To be confirmed.

