### PR TITLE
Refactor/update `Span` and `Partition` in point-free

### DIFF
--- a/src/Operation/DropWhile.php
+++ b/src/Operation/DropWhile.php
@@ -27,13 +27,13 @@ final class DropWhile extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T, TKey): bool ...): Closure (Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T, TKey):bool ...$callbacks
+             * @param callable(T, TKey, Iterator<TKey, T>):bool ...$callbacks
              *
              * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
              */

--- a/src/Operation/Partition.php
+++ b/src/Operation/Partition.php
@@ -39,7 +39,7 @@ final class Partition extends AbstractOperation
                 /**
                  * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
                  */
-                static fn (callable ...$callbacks) =>
+                static fn (callable ...$callbacks): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *

--- a/src/Operation/Partition.php
+++ b/src/Operation/Partition.php
@@ -34,10 +34,14 @@ final class Partition extends AbstractOperation
             (
                 /**
                  * @param array{0:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>)), 1:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>))} $operations
+                 *
+                 * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(Iterator<TKey, T>): Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
                  */
                 static fn (array $operations): Closure =>
                 /**
                  * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
+                 *
+                 * @return Closure(Iterator<TKey, T>): Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
                  */
                 static fn (callable ...$callbacks): Closure =>
                 /**

--- a/src/Operation/Partition.php
+++ b/src/Operation/Partition.php
@@ -31,25 +31,29 @@ final class Partition extends AbstractOperation
     public function __invoke(): Closure
     {
         return
-            /**
-             * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
-             *
-             * @return Closure(Iterator<TKey, T>): Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
-             */
-            static fn (callable ...$callbacks): Closure =>
+            (
+                /**
+                 * @param array{0:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>)), 1:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>))} $operations
+                 */
+                static fn (array $operations): Closure =>
+                /**
+                 * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
+                 */
+                static fn (callable ...$callbacks) =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
                  * @return Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
-                    /** @var array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}} $filter */
-                    $filter = [Filter::of()(...$callbacks), [$iterator]];
-
-                    /** @var array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}} $reject */
-                    $reject = [Reject::of()(...$callbacks), [$iterator]];
-
-                    return yield from [$filter, $reject];
-                };
+                static fn (Iterator $iterator): Generator => yield from array_map(
+                    /**
+                     * @param Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>) $callable
+                     *
+                     * @return array{0: (Closure(Iterator<TKey, T>): Generator<TKey, T>), 1: (array{0: Iterator<TKey, T>})}
+                     */
+                    static fn (callable $callable): array => [$callable(...$callbacks), [$iterator]],
+                    $operations
+                )
+            )([(new Filter())(), (new Reject())()]);
     }
 }

--- a/src/Operation/Span.php
+++ b/src/Operation/Span.php
@@ -34,10 +34,14 @@ final class Span extends AbstractOperation
             (
                 /**
                  * @param array{0:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>)), 1:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>))} $operations
+                 *
+                 * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(Iterator<TKey, T>): Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
                  */
                 static fn (array $operations): Closure =>
                 /**
                  * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
+                 *
+                 * @return Closure(Iterator<TKey, T>): Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
                  */
                 static fn (callable ...$callbacks): Closure =>
                 /**

--- a/src/Operation/Span.php
+++ b/src/Operation/Span.php
@@ -31,25 +31,29 @@ final class Span extends AbstractOperation
     public function __invoke(): Closure
     {
         return
-            /**
-             * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
-             *
-             * @return Closure(Iterator<TKey, T>): Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
-             */
-            static fn (callable ...$callbacks): Closure =>
+            (
+                /**
+                 * @param array{0:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>)), 1:(Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>))} $operations
+                 */
+                static fn (array $operations): Closure =>
+                /**
+                 * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
+                 */
+                static fn (callable ...$callbacks) =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
                  * @return Generator<int, array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}}>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
-                    /** @var array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}} $takeWhile */
-                    $takeWhile = [TakeWhile::of()(...$callbacks), [$iterator]];
-
-                    /** @var array{0: Closure(Iterator<TKey, T>): Generator<TKey, T>, 1: array{0: Iterator<TKey, T>}} $dropWhile */
-                    $dropWhile = [DropWhile::of()(...$callbacks), [$iterator]];
-
-                    return yield from [$takeWhile, $dropWhile];
-                };
+                static fn (Iterator $iterator): Generator => yield from array_map(
+                    /**
+                     * @param Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): (Closure(Iterator<TKey, T>): Generator<TKey, T>) $callable
+                     *
+                     * @return array{0: (Closure(Iterator<TKey, T>): Generator<TKey, T>), 1: (array{0: Iterator<TKey, T>})}
+                     */
+                    static fn (callable $callable): array => [$callable(...$callbacks), [$iterator]],
+                    $operations
+                )
+            )([(new TakeWhile())(), (new DropWhile())()]);
     }
 }

--- a/src/Operation/Span.php
+++ b/src/Operation/Span.php
@@ -39,7 +39,7 @@ final class Span extends AbstractOperation
                 /**
                  * @param callable(T, TKey, Iterator<TKey, T>): bool ...$callbacks
                  */
-                static fn (callable ...$callbacks) =>
+                static fn (callable ...$callbacks): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *

--- a/src/Operation/TakeWhile.php
+++ b/src/Operation/TakeWhile.php
@@ -27,7 +27,7 @@ final class TakeWhile extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool):Closure (Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T, TKey, Iterator<TKey, T>): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {


### PR DESCRIPTION
This PR:

* [x] Rewrite `Partition` operation in point free style and without local variables.
* [x] Rewrite `Span` operation in point free style and without local variables.
* [x] Fix typing information of `TakeWhile` and `DropWhile`

