### PR TITLE
refactor: Update `Window` operation in point free style.

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -2439,16 +2439,16 @@ window
 Loop the collection yielding windows of data by adding a given number of items to the current item.
 Initially the windows yielded will be smaller, until size ``1 + $size`` is reached.
 
+.. tip:: To remove the window size constraint and have a dynamic window size, set the ``$size`` to ``-1``.
+
+.. note:: When ``$size`` is equal to ``0``, the window will only contain the current element, wrapped in an array.
+
 Interface: `Windowable`_
 
 Signature: ``Collection::window(int $size): Collection;``
 
-.. code-block:: php
-
-     $data = range('a', 'd');
-
-     Collection::fromIterable($data)
-        ->window(2); // [['a'], ['a', 'b'], ['a', 'b', 'c'], ['b', 'c', 'd']]
+.. literalinclude:: code/operations/window.php
+  :language: php
 
 words
 ~~~~~

--- a/docs/pages/code/operations/window.php
+++ b/docs/pages/code/operations/window.php
@@ -16,13 +16,13 @@ include __DIR__ . '/../../../../vendor/autoload.php';
 $data = range('a', 'e');
 
 Collection::fromIterable($data)
-   ->window(0); // [['a'], ['b'], ['c'], ['d'], ['e']]
+    ->window(0); // [['a'], ['b'], ['c'], ['d'], ['e']]
 
 Collection::fromIterable($data)
-   ->window(1); // [['a'], ['a', 'b'], ['b', 'c'], ['c', 'd'], ['d', 'e']]
+    ->window(1); // [['a'], ['a', 'b'], ['b', 'c'], ['c', 'd'], ['d', 'e']]
 
 Collection::fromIterable($data)
-   ->window(2); // [['a'], ['a', 'b'], ['a', 'b', 'c'], ['b', 'c', 'd'], ['c', 'd', 'e']]
+    ->window(2); // [['a'], ['a', 'b'], ['a', 'b', 'c'], ['b', 'c', 'd'], ['c', 'd', 'e']]
 
 Collection::fromIterable($data)
-   ->window(-1); // [['a'], ['a', 'b'], ['a', 'b', 'c'], ['a', 'b', 'c', 'd'], ['a', 'b', 'c', 'd', 'e']]
+    ->window(-1); // [['a'], ['a', 'b'], ['a', 'b', 'c'], ['a', 'b', 'c', 'd'], ['a', 'b', 'c', 'd', 'e']]

--- a/docs/pages/code/operations/window.php
+++ b/docs/pages/code/operations/window.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$data = range('a', 'e');
+
+Collection::fromIterable($data)
+   ->window(0); // [['a'], ['b'], ['c'], ['d'], ['e']]
+
+Collection::fromIterable($data)
+   ->window(1); // [['a'], ['a', 'b'], ['b', 'c'], ['c', 'd'], ['d', 'e']]
+
+Collection::fromIterable($data)
+   ->window(2); // [['a'], ['a', 'b'], ['a', 'b', 'c'], ['b', 'c', 'd'], ['c', 'd', 'e']]
+
+Collection::fromIterable($data)
+   ->window(-1); // [['a'], ['a', 'b'], ['a', 'b', 'c'], ['a', 'b', 'c', 'd'], ['a', 'b', 'c', 'd', 'e']]

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -4012,15 +4012,15 @@ class CollectionSpec extends ObjectBehavior
 
     public function it_can_window(): void
     {
-        $this::fromIterable(range('a', 'c'))
+        $this::fromIterable(['a' => 'A', 'b' => 'B', 'c' => 'C'])
             ->window(0)
             ->shouldIterateAs([
-                ['a'],
-                ['b'],
-                ['c'],
+                'a' => ['A'],
+                'b' => ['B'],
+                'c' => ['C'],
             ]);
 
-        $this::fromIterable(range('a', 'z'))
+        $this::fromIterable(range('a', 'e'))
             ->window(2)
             ->shouldIterateAs([
                 0 => [
@@ -4045,111 +4045,13 @@ class CollectionSpec extends ObjectBehavior
                     1 => 'd',
                     2 => 'e',
                 ],
-                5 => [
-                    0 => 'd',
-                    1 => 'e',
-                    2 => 'f',
-                ],
-                6 => [
-                    0 => 'e',
-                    1 => 'f',
-                    2 => 'g',
-                ],
-                7 => [
-                    0 => 'f',
-                    1 => 'g',
-                    2 => 'h',
-                ],
-                8 => [
-                    0 => 'g',
-                    1 => 'h',
-                    2 => 'i',
-                ],
-                9 => [
-                    0 => 'h',
-                    1 => 'i',
-                    2 => 'j',
-                ],
-                10 => [
-                    0 => 'i',
-                    1 => 'j',
-                    2 => 'k',
-                ],
-                11 => [
-                    0 => 'j',
-                    1 => 'k',
-                    2 => 'l',
-                ],
-                12 => [
-                    0 => 'k',
-                    1 => 'l',
-                    2 => 'm',
-                ],
-                13 => [
-                    0 => 'l',
-                    1 => 'm',
-                    2 => 'n',
-                ],
-                14 => [
-                    0 => 'm',
-                    1 => 'n',
-                    2 => 'o',
-                ],
-                15 => [
-                    0 => 'n',
-                    1 => 'o',
-                    2 => 'p',
-                ],
-                16 => [
-                    0 => 'o',
-                    1 => 'p',
-                    2 => 'q',
-                ],
-                17 => [
-                    0 => 'p',
-                    1 => 'q',
-                    2 => 'r',
-                ],
-                18 => [
-                    0 => 'q',
-                    1 => 'r',
-                    2 => 's',
-                ],
-                19 => [
-                    0 => 'r',
-                    1 => 's',
-                    2 => 't',
-                ],
-                20 => [
-                    0 => 's',
-                    1 => 't',
-                    2 => 'u',
-                ],
-                21 => [
-                    0 => 't',
-                    1 => 'u',
-                    2 => 'v',
-                ],
-                22 => [
-                    0 => 'u',
-                    1 => 'v',
-                    2 => 'w',
-                ],
-                23 => [
-                    0 => 'v',
-                    1 => 'w',
-                    2 => 'x',
-                ],
-                24 => [
-                    0 => 'w',
-                    1 => 'x',
-                    2 => 'y',
-                ],
-                25 => [
-                    0 => 'x',
-                    1 => 'y',
-                    2 => 'z',
-                ],
+            ]);
+
+        // Unsupported - but tested.
+        $this::fromIterable(range('a', 'e'))
+            ->window(-2)
+            ->shouldIterateAs([
+                [],[],[],[],[]
             ]);
     }
 

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -3999,9 +3999,13 @@ class CollectionSpec extends ObjectBehavior
 
     public function it_can_window(): void
     {
-        $this::fromIterable(range('a', 'z'))
+        $this::fromIterable(range('a', 'c'))
             ->window(0)
-            ->shouldIterateAs(range('a', 'z'));
+            ->shouldIterateAs([
+                ['a'],
+                ['b'],
+                ['c'],
+            ]);
 
         $this::fromIterable(range('a', 'z'))
             ->window(2)

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -4051,7 +4051,7 @@ class CollectionSpec extends ObjectBehavior
         $this::fromIterable(range('a', 'e'))
             ->window(-2)
             ->shouldIterateAs([
-                [],[],[],[],[]
+                [], [], [], [], [],
             ]);
     }
 

--- a/src/Contract/Operation/Windowable.php
+++ b/src/Contract/Operation/Windowable.php
@@ -19,7 +19,7 @@ interface Windowable
 {
     /**
      * Loop the collection yielding windows of data by adding a given number of items to the current item.
-     * Initially the windows yielded will be smaller, until size` 1 + $size` is reached.
+     * Initially the windows yielded will be smaller, until size `1 + $size` is reached.
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#window
      *

--- a/src/Operation/Window.php
+++ b/src/Operation/Window.php
@@ -26,7 +26,7 @@ final class Window extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T|list<T>>
+     * @return Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, list<T>>
      */
     public function __invoke(): Closure
     {

--- a/src/Operation/Window.php
+++ b/src/Operation/Window.php
@@ -32,27 +32,22 @@ final class Window extends AbstractOperation
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T|list<T>>
+             * @return Closure(Iterator<TKey, T>): Generator<TKey, list<T>>
              */
-            static fn (int $size): Closure =>
-                /**
-                 * @param Iterator<TKey, T> $iterator
-                 *
-                 * @return Generator<TKey, list<T>|T>
-                 */
-                static function (Iterator $iterator) use ($size): Generator {
-                    if (0 === $size) {
-                        return yield from $iterator;
-                    }
+            static function (int $size): Closure {
+                /** @var Closure(Iterator<TKey, T>): Generator<TKey, list<T>> $reduction */
+                $reduction = Reduction::of()(
+                    /**
+                     * @param list<T> $stack
+                     * @param T $current
+                     *
+                     * @return list<T>
+                     */
+                    static fn (array $stack, $current): array => array_slice([...$stack, $current], ++$size * -1)
+                )([]);
 
-                    ++$size;
-                    $size *= -1;
-
-                    $stack = [];
-
-                    foreach ($iterator as $key => $current) {
-                        yield $key => $stack = array_slice([...$stack, $current], $size);
-                    }
-                };
+                // Point free style.
+                return $reduction;
+            };
     }
 }


### PR DESCRIPTION
This PR:

* [x] Update `Window` in point free style.
* [x] Has unit tests (phpspec)
* [x] Has updated tests
* [x] Has updated documentation
* [x] Is a minor BC break - The behavior has changed when the ```$size``` is zero, which is more in sync with what the Window operation does and avoid mixing types (```T|list<T>``` => ```list<T>```)
  Before: ```Collection::fromIterable(['a', 'b', 'c'])->window(0); // ['a', 'b', 'c']```
  After:  ```Collection::fromIterable(['a', 'b', 'c'])->window(0); // [['a'], ['b'], ['c']]```
  