### PR TITLE
Fix `inits` operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1233,10 +1233,8 @@ Interface: `Initsable`_
 
 Signature: ``Collection::inits(): Collection;``
 
-.. code-block:: php
-
-    Collection::fromIterable(range('a', 'c'))
-        ->inits(); // [[], ['a'], ['a', 'b'], ['a', 'b', 'c']]
+.. literalinclude:: code/operations/inits.php
+  :language: php
 
 intersect
 ~~~~~~~~~

--- a/docs/pages/code/operations/inits.php
+++ b/docs/pages/code/operations/inits.php
@@ -22,7 +22,15 @@ Collection::fromIterable(array_combine(range('A', 'C'), $input))
     ->inits(); // [[], [['A', 'a']], [['A', 'a'], ['B', 'b']], [['A', 'a'], ['B', 'b'], ['C', 'c']]]
 
 // To get only the values:
+
+// Using `map` + `array_column`
 Collection::fromIterable($input)
     ->inits()
     ->map(static fn (array $data): array => array_column($data, 1));
+    // [[], ['a'], ['a', 'b'], ['a', 'b', 'c']]
+
+// Using the `pluck` operation
+$var = Collection::fromIterable($input)
+    ->inits()
+    ->pluck('*.1');
     // [[], ['a'], ['a', 'b'], ['a', 'b', 'c']]

--- a/docs/pages/code/operations/inits.php
+++ b/docs/pages/code/operations/inits.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+Collection::fromIterable(range('a', 'c'))
+    ->inits(); // [[], [[0, 'a']], [[0, 'a'], [1, 'b']], [[0, 'a'], [1, 'b'], [2, 'c']]]

--- a/docs/pages/code/operations/inits.php
+++ b/docs/pages/code/operations/inits.php
@@ -13,5 +13,16 @@ use loophp\collection\Collection;
 
 include __DIR__ . '/../../../../vendor/autoload.php';
 
+$input = range('a', 'c');
+
 Collection::fromIterable(range('a', 'c'))
     ->inits(); // [[], [[0, 'a']], [[0, 'a'], [1, 'b']], [[0, 'a'], [1, 'b'], [2, 'c']]]
+
+Collection::fromIterable(array_combine(range('A', 'C'), $input))
+    ->inits(); // [[], [['A', 'a']], [['A', 'a'], ['B', 'b']], [['A', 'a'], ['B', 'b'], ['C', 'c']]]
+
+// To get only the values:
+Collection::fromIterable($input)
+    ->inits()
+    ->map(static fn (array $data): array => array_column($data, 1));
+    // [[], ['a'], ['a', 'b'], ['a', 'b', 'c']]

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1965,9 +1965,26 @@ class CollectionSpec extends ObjectBehavior
             ->inits()
             ->shouldIterateAs([
                 [],
-                ['a'],
-                ['a', 'b'],
-                ['a', 'b', 'c'],
+                [[0, 'a']],
+                [[0, 'a'], [1, 'b']],
+                [[0, 'a'], [1, 'b'], [2, 'c']],
+            ]);
+
+        $gen = static function (): Generator {
+            yield true => 'true';
+
+            yield false => 'false';
+
+            yield [] => 'array';
+        };
+
+        $this::fromIterable($gen())
+            ->inits()
+            ->shouldIterateAs([
+                [],
+                [[true, 'true']],
+                [[true, 'true'], [false, 'false']],
+                [[true, 'true'], [false, 'false'], [[], 'array']],
             ]);
     }
 

--- a/src/Contract/Operation/Initsable.php
+++ b/src/Contract/Operation/Initsable.php
@@ -22,7 +22,7 @@ interface Initsable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#inits
      *
-     * @return Collection<TKey, T>
+     * @return Collection<int, list<array{0: TKey, 1: T}>>
      */
     public function inits(): Collection;
 }

--- a/src/Operation/Inits.php
+++ b/src/Operation/Inits.php
@@ -24,26 +24,26 @@ final class Inits extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, list<T>>
+     * @return Closure(Iterator<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>>
      */
     public function __invoke(): Closure
     {
         $scanLeftCallback =
             /**
-             * @param array<TKey, T> $carry
-             * @param T $value
-             * @param TKey $key
+             * @param list<array{0: TKey, 1: T}> $carry
+             * @param array{0: TKey, 1: T} $value
              *
-             * @return array<TKey, T>
+             * @return list<array{0: TKey, 1: T}>
              */
-            static function (array $carry, $value, $key): array {
-                $carry[$key] = $value;
+            static function (array $carry, array $value): array {
+                $carry[] = $value;
 
                 return $carry;
             };
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, list<T>> $inits */
+        /** @var Closure(Iterator<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>> $inits */
         $inits = Pipe::of()(
+            Pack::of(),
             ScanLeft::of()($scanLeftCallback)([]),
             Normalize::of()
         );

--- a/tests/static-analysis/inits.php
+++ b/tests/static-analysis/inits.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, list<array{0: int, 1: string}>> $collection
+ */
+function inits_checkListString(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<int, list<array{0: string, 1: string}>> $collection
+ */
+function inits_checkMapString(CollectionInterface $collection): void
+{
+}
+
+$listString = range('a', 'c');
+$mapString = array_combine(range('a', 'c'), range('a', 'c'));
+
+inits_checkListString(Collection::fromIterable($listString)->inits());
+inits_checkMapString(Collection::fromIterable($mapString)->inits());


### PR DESCRIPTION
This PR:

* [x] Fix the `Inits` operation, it works with any type of keys now.
* [x] It breaks backward compatibility (minor)
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation

