### PR TITLE
Static analysis: Update `Map` operation.

### DIFF
--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -134,6 +134,7 @@ use loophp\collection\Contract\Operation\Zipable;
  *
  * @template TKey
  * @template T
+ * @template V
  *
  * @template-extends Allable<TKey, T>
  * @template-extends Appendable<TKey, T>
@@ -192,7 +193,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Lastable<TKey, T>
  * @template-extends Limitable<TKey, T>
  * @template-extends Linesable<TKey, T>
- * @template-extends Mapable<TKey, T>
+ * @template-extends Mapable<TKey, T, V>
  * @template-extends MapNable<TKey, T>
  * @template-extends Matchable<TKey, T>
  * @template-extends Matchingable<TKey, T>

--- a/src/Contract/Operation/Mapable.php
+++ b/src/Contract/Operation/Mapable.php
@@ -15,6 +15,7 @@ use loophp\collection\Contract\Collection;
 /**
  * @template TKey
  * @template T
+ * @template V
  */
 interface Mapable
 {
@@ -22,8 +23,6 @@ interface Mapable
      * Apply a single callback to every item of a collection and use the return value.
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#map
-     *
-     * @template V
      *
      * @param callable(T=, TKey=, Iterator<TKey, T>=): V $callback
      *


### PR DESCRIPTION
This PR:

* [ ] Fix `Map` operation
* [ ] Has static analysis tests (psalm, phpstan)
* [ ] Is an experimental thing

Psalm snippets:

* Original one (current state): https://psalm.dev/r/9d647acb4e
* Alex's idea: https://psalm.dev/r/e840743851
  * Pro: Typing is done properly
  * Cons: It requires changing the whole API
* Pol's idea: https://psalm.dev/r/bf2e69c00a
  * Pro: It does not require changing the whole API
  * Cons: So sad, it seems [to not be supported by PSalm](https://github.com/vimeo/psalm/issues/5472), but it is by PHPStan: https://phpstan.org/r/1f5caae6-4b6d-4e98-bcd7-cd7ba9d546e0

In the end, I'm here (https://psalm.dev/r/33088712ff), there's only one issue remaining.

I asked @weirdan and he proposed:
   * https://psalm.dev/r/37900dd56d
   * https://psalm.dev/r/3930c24012

I'm still experimenting on the best way to fix this issue.