### PR TITLE
Update various typing information

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -287,32 +287,8 @@ Interface: `Associateable`_
 
 Signature: ``Collection::associate(?callable $callbackForKeys = null, ?callable $callbackForValues = null): Collection;``
 
-.. code-block:: php
-
-    $input = range(1, 10);
-
-    Collection::fromIterable($input)
-        ->associate(
-            static function ($key, $value) {
-                return $key * 2;
-            },
-            static function ($key, $value) {
-                return $value * 2;
-            }
-        );
-
-    // [
-    //   0 => 2,
-    //   2 => 4,
-    //   4 => 6,
-    //   6 => 8,
-    //   8 => 10,
-    //   10 => 12,
-    //   12 => 14,
-    //   14 => 16,
-    //   16 => 18,
-    //   18 => 20,
-    // ]
+.. literalinclude:: code/operations/associate.php
+  :language: php
 
 asyncMap
 ~~~~~~~~

--- a/docs/pages/code/operations/associate.php
+++ b/docs/pages/code/operations/associate.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+// Example 1: Both callbacks are provided
+$input = range(1, 5);
+
+Collection::fromIterable($input)
+    ->associate(
+        static function ($key, $value) {
+            return $key * 2;
+        },
+        static function ($value, $key) {
+            return $value * 3;
+        }
+    );
+
+// [
+//   0 => 3,
+//   2 => 6,
+//   4 => 9,
+//   6 => 12,
+//   8 => 15,
+// ]
+
+// Example 2: Only the callback for keys is provided
+$input = range(1, 5);
+
+Collection::fromIterable($input)
+    ->associate(
+        static function ($key, $value) {
+            return $key * 2;
+        }
+    );
+
+// [
+//   0 => 1,
+//   2 => 2,
+//   4 => 3,
+//   6 => 4,
+//   8 => 5,
+// ]
+
+// Example 3: Only the callback for values is provided
+$input = range(1, 5);
+
+Collection::fromIterable($input)
+    ->associate(
+        null,
+        static function ($value, $key) {
+            return $value * 3;
+        }
+    );
+
+// [
+//   0 => 3,
+//   1 => 6,
+//   2 => 9,
+//   3 => 12,
+//   4 => 15,
+// ]

--- a/phpstan-unsupported-baseline.neon
+++ b/phpstan-unsupported-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, string\\>, Closure\\(string, string\\)\\: loophp\\\\collection\\\\Iterator\\\\StringIterator\\<mixed, string\\> given\\.$#"
-			count: 1
-			path: src/Collection.php
-
-		-
 			message: "#^Generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\<mixed, array\\<int, mixed\\>\\> in PHPDoc tag @extends does not specify all template types of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\: TKey, T, NewTKey, NewT$#"
 			count: 1
 			path: src/Contract/Collection.php
@@ -21,17 +16,6 @@ parameters:
 			path: src/Contract/Operation/Unpackable.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Iterator\\\\ClosureIterator constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, string\\>, Closure\\(mixed, bool\\)\\: Generator\\<int, string, mixed, void\\> given\\.$#"
-			count: 1
-			path: src/Iterator/ResourceIterator.php
-
-		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Iterator\\\\ClosureIterator constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(Iterator, callable\\(\\)\\: mixed\\)\\: Generator\\<mixed, mixed, mixed, void\\> given\\.$#"
-			count: 1
-			path: src/Iterator/TypedIterator.php
-
-		-
 			message: "#^PHPDoc tag @template T for class loophp\\\\collection\\\\Operation\\\\Unpack with bound type array\\<int, NewT\\|NewTKey\\> is not supported\\.$#"
 			count: 1
 			path: src/Operation/Unpack.php
-

--- a/phpstan-unsupported-baseline.neon
+++ b/phpstan-unsupported-baseline.neon
@@ -6,7 +6,7 @@ parameters:
 			path: src/Collection.php
 
 		-
-			message: "#^Generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\<mixed, mixed\\> in PHPDoc tag @extends does not specify all template types of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\: TKey, T, NewTKey, NewT$#"
+			message: "#^Generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\<mixed, array\\<int, mixed\\>\\> in PHPDoc tag @extends does not specify all template types of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\: TKey, T, NewTKey, NewT$#"
 			count: 1
 			path: src/Contract/Collection.php
 
@@ -21,6 +21,17 @@ parameters:
 			path: src/Contract/Operation/Unpackable.php
 
 		-
+			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Iterator\\\\ClosureIterator constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, string\\>, Closure\\(mixed, bool\\)\\: Generator\\<int, string, mixed, void\\> given\\.$#"
+			count: 1
+			path: src/Iterator/ResourceIterator.php
+
+		-
+			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Iterator\\\\ClosureIterator constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(Iterator, callable\\(\\)\\: mixed\\)\\: Generator\\<mixed, mixed, mixed, void\\> given\\.$#"
+			count: 1
+			path: src/Iterator/TypedIterator.php
+
+		-
 			message: "#^PHPDoc tag @template T for class loophp\\\\collection\\\\Operation\\\\Unpack with bound type array\\<int, NewT\\|NewTKey\\> is not supported\\.$#"
 			count: 1
 			path: src/Operation/Unpack.php
+

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -225,10 +225,10 @@ class CollectionSpec extends ObjectBehavior
 
         $this::fromIterable($input)
             ->associate(
-                static function (int $carry, int $key, int $value): int {
+                static function (int $key, int $value): int {
                     return $key * 2;
                 },
-                static function (int $carry, int $key, int $value): int {
+                static function (int $value, int $key): int {
                     return $value * 2;
                 }
             )

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -196,9 +196,9 @@ final class Collection implements CollectionInterface
     ): CollectionInterface {
         $defaultCallback =
             /**
-             * @param T|TKey $carry
+             * @param mixed $carry
              *
-             * @return T|TKey
+             * @return mixed
              */
             static fn ($carry) => $carry;
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -466,8 +466,7 @@ final class Collection implements CollectionInterface
     public static function fromFile(string $filepath): self
     {
         return new self(
-            static fn (string $filepath): Iterator => new ResourceIterator(fopen($filepath, 'rb'), true),
-            [$filepath]
+            static fn (): Iterator => new ResourceIterator(fopen($filepath, 'rb'), true),
         );
     }
 
@@ -508,10 +507,7 @@ final class Collection implements CollectionInterface
      */
     public static function fromIterable(iterable $iterable): self
     {
-        return new self(
-            static fn (iterable $iterable): Iterator => new IterableIterator($iterable),
-            [$iterable]
-        );
+        return new self(static fn (): Iterator => new IterableIterator($iterable));
     }
 
     /**
@@ -523,13 +519,7 @@ final class Collection implements CollectionInterface
      */
     public static function fromResource($resource): self
     {
-        return new self(
-            /**
-             * @param resource $resource
-             */
-            static fn ($resource): Iterator => new ResourceIterator($resource),
-            [$resource]
-        );
+        return new self(static fn (): Iterator => new ResourceIterator($resource));
     }
 
     /**
@@ -539,10 +529,7 @@ final class Collection implements CollectionInterface
      */
     public static function fromString(string $string, string $delimiter = ''): self
     {
-        return new self(
-            static fn (string $string, string $delimiter): Iterator => new StringIterator($string, $delimiter),
-            [$string, $delimiter]
-        );
+        return new self(static fn (): Iterator => new StringIterator($string, $delimiter));
     }
 
     /**

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -154,7 +154,7 @@ use const PHP_INT_MIN;
 final class Collection implements CollectionInterface
 {
     /**
-     * @var iterable<mixed>
+     * @var iterable<int, mixed>
      */
     private iterable $parameters;
 
@@ -167,7 +167,7 @@ final class Collection implements CollectionInterface
      * @psalm-external-mutation-free
      *
      * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
-     * @param iterable<array-key, mixed> $parameters
+     * @param iterable<int, mixed> $parameters
      */
     private function __construct(callable $callable, iterable $parameters = [])
     {
@@ -449,7 +449,7 @@ final class Collection implements CollectionInterface
      * @template NewT
      *
      * @param callable(mixed ...$parameters): iterable<NewTKey, NewT> $callable
-     * @param iterable<mixed> $parameters
+     * @param iterable<int, mixed> $parameters
      *
      * @return self<NewTKey, NewT>
      */

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -235,7 +235,7 @@ use loophp\collection\Contract\Operation\Zipable;
  * @template-extends Transposeable<TKey, T>
  * @template-extends Truthyable<TKey, T>
  * @template-extends Unlinesable<TKey, T>
- * @template-extends Unpackable<TKey, T>
+ * @template-extends Unpackable<mixed, array{0: TKey, 1: T}>
  * @template-extends Unpairable<TKey, T>
  * @template-extends Untilable<TKey, T>
  * @template-extends Unwindowable<TKey, T>

--- a/src/Contract/Operation/Associateable.php
+++ b/src/Contract/Operation/Associateable.php
@@ -23,10 +23,13 @@ interface Associateable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#associate
      *
-     * @param null|callable(TKey, TKey, T, Iterator<TKey, T>):(T|TKey) $callbackForKeys
-     * @param null|callable(T, TKey, T, Iterator<TKey, T>):(T|TKey) $callbackForValues
+     * @template NewT
+     * @template NewTKey
      *
-     * @return Collection<T|TKey, T|TKey>
+     * @param callable((TKey|NewTKey)=, T=, TKey=, Iterator<TKey, T>=): NewTKey $callbackForKeys
+     * @param callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT $callbackForValues
+     *
+     * @return Collection<NewTKey, NewT>
      */
     public function associate(?callable $callbackForKeys = null, ?callable $callbackForValues = null): Collection;
 }

--- a/src/Contract/Operation/Associateable.php
+++ b/src/Contract/Operation/Associateable.php
@@ -26,8 +26,8 @@ interface Associateable
      * @template NewT
      * @template NewTKey
      *
-     * @param callable((TKey|NewTKey)=, T=, TKey=, Iterator<TKey, T>=): NewTKey $callbackForKeys
-     * @param callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT $callbackForValues
+     * @param callable(TKey=, T=, Iterator<TKey, T>=): NewTKey $callbackForKeys
+     * @param callable(T=, TKey=, Iterator<TKey, T>=): NewT $callbackForValues
      *
      * @return Collection<NewTKey, NewT>
      */

--- a/src/Contract/Operation/Zipable.php
+++ b/src/Contract/Operation/Zipable.php
@@ -22,9 +22,12 @@ interface Zipable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#zip
      *
-     * @param iterable<mixed, mixed> ...$iterables
+     * @template U
+     * @template UKey
      *
-     * @return Collection<list<mixed>, list<mixed>>
+     * @param iterable<UKey, U> ...$iterables
+     *
+     * @return Collection<list<TKey|UKey>, list<T|U>>
      */
     public function zip(iterable ...$iterables): Collection;
 }

--- a/src/Iterator/ClosureIterator.php
+++ b/src/Iterator/ClosureIterator.php
@@ -33,7 +33,7 @@ final class ClosureIterator extends ProxyIterator
 
     /**
      * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
-     * @param iterable<mixed> $parameters
+     * @param iterable<int, mixed> $parameters
      */
     public function __construct(callable $callable, iterable $parameters)
     {
@@ -48,10 +48,10 @@ final class ClosureIterator extends ProxyIterator
     }
 
     /**
-     * @return Generator<TKey, T>
+     * @return Generator<TKey, T, mixed, void>
      */
     private function getGenerator(): Generator
     {
-        return yield from ($this->callable)(...$this->parameters);
+        yield from ($this->callable)(...$this->parameters);
     }
 }

--- a/src/Iterator/ResourceIterator.php
+++ b/src/Iterator/ResourceIterator.php
@@ -39,7 +39,7 @@ final class ResourceIterator extends ProxyIterator
              *
              * @return Generator<int, string, mixed, void>
              */
-            static function ($resource, bool $closeResource): Generator {
+            static function ($resource) use ($closeResource): Generator {
                 try {
                     while (false !== $chunk = fgetc($resource)) {
                         yield $chunk;
@@ -51,6 +51,6 @@ final class ResourceIterator extends ProxyIterator
                 }
             };
 
-        $this->iterator = new ClosureIterator($callback, [$resource, $closeResource]);
+        $this->iterator = new ClosureIterator($callback, [$resource]);
     }
 }

--- a/src/Iterator/ResourceIterator.php
+++ b/src/Iterator/ResourceIterator.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Iterator;
 
 use Generator;
 use InvalidArgumentException;
-use IteratorIterator;
 
 use function is_resource;
 
@@ -40,7 +39,7 @@ final class ResourceIterator extends ProxyIterator
              *
              * @return Generator<int, string, mixed, void>
              */
-            static function ($resource) use ($closeResource): Generator {
+            static function ($resource, bool $closeResource): Generator {
                 try {
                     while (false !== $chunk = fgetc($resource)) {
                         yield $chunk;
@@ -52,6 +51,6 @@ final class ResourceIterator extends ProxyIterator
                 }
             };
 
-        $this->iterator = new IteratorIterator($callback($resource));
+        $this->iterator = new ClosureIterator($callback, [$resource, $closeResource]);
     }
 }

--- a/src/Iterator/ResourceIterator.php
+++ b/src/Iterator/ResourceIterator.php
@@ -38,7 +38,7 @@ final class ResourceIterator extends ProxyIterator
             /**
              * @param resource $resource
              *
-             * @return Generator<int, string>
+             * @return Generator<int, string, mixed, void>
              */
             static function ($resource) use ($closeResource): Generator {
                 try {

--- a/src/Iterator/TypedIterator.php
+++ b/src/Iterator/TypedIterator.php
@@ -28,7 +28,7 @@ final class TypedIterator extends ProxyIterator
 {
     /**
      * @param Iterator<TKey, T> $iterator
-     * @param null|callable(mixed): string $getType
+     * @param callable(T): string $getType
      */
     public function __construct(Iterator $iterator, ?callable $getType = null)
     {
@@ -55,7 +55,13 @@ final class TypedIterator extends ProxyIterator
             };
 
         $this->iterator = new ClosureIterator(
-            static function (Iterator $iterator) use ($getType): Generator {
+            /**
+             * @param Iterator<TKey, T> $iterator
+             * @param callable(T): string $getType
+             *
+             * @return Generator<TKey, T|null>
+             */
+            static function (Iterator $iterator, callable $getType): Generator {
                 $previousType = null;
 
                 foreach ($iterator as $key => $value) {
@@ -81,7 +87,7 @@ final class TypedIterator extends ProxyIterator
                     yield $key => $value;
                 }
             },
-            [$iterator]
+            [$iterator, $getType]
         );
     }
 }

--- a/src/Iterator/TypedIterator.php
+++ b/src/Iterator/TypedIterator.php
@@ -57,13 +57,16 @@ final class TypedIterator extends ProxyIterator
         $this->iterator = new ClosureIterator(
             /**
              * @param Iterator<TKey, T> $iterator
-             * @param callable(T): string $getType
              *
              * @return Generator<TKey, T|null>
              */
-            static function (Iterator $iterator, callable $getType): Generator {
+            static function (Iterator $iterator) use ($getType): Generator {
                 $previousType = null;
 
+                /**
+                 * @var TKey $key
+                 * @var T $value
+                 */
                 foreach ($iterator as $key => $value) {
                     if (null === $value) {
                         yield $key => $value;
@@ -87,7 +90,7 @@ final class TypedIterator extends ProxyIterator
                     yield $key => $value;
                 }
             },
-            [$iterator, $getType]
+            [$iterator]
         );
     }
 }

--- a/src/Iterator/TypedIterator.php
+++ b/src/Iterator/TypedIterator.php
@@ -28,7 +28,7 @@ final class TypedIterator extends ProxyIterator
 {
     /**
      * @param Iterator<TKey, T> $iterator
-     * @param callable(T): string $getType
+     * @param null|callable(T): string $getType
      */
     public function __construct(Iterator $iterator, ?callable $getType = null)
     {

--- a/src/Operation/Associate.php
+++ b/src/Operation/Associate.php
@@ -27,45 +27,48 @@ final class Associate extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(TKey, TKey, T, Iterator<TKey, T>): (T|TKey) ...): Closure((callable(T, TKey, T, Iterator<TKey, T>): (T|TKey))...): Closure(Iterator<TKey, T>): Generator<TKey|T, T|TKey>
+     * @template NewTKey
+     * @template NewT
+     *
+     * @return Closure((callable((TKey|NewTKey)=, T=, TKey=, Iterator<TKey, T>=): NewTKey) ...): Closure((callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT)...): Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(TKey, TKey, T, Iterator<TKey, T>): (T|TKey) ...$callbackForKeys
+             * @param callable((TKey|NewTKey)=, T=, TKey=, Iterator<TKey, T>=): NewTKey ...$callbackForKeys
              *
-             * @return Closure((callable(T, TKey, T, Iterator<TKey, T>): (T|TKey))...): Closure(Iterator<TKey, T>): Generator<TKey|T, T|TKey>
+             * @return Closure((callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT)...): Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
              */
             static fn (callable ...$callbackForKeys): Closure =>
                 /**
-                 * @param callable(T, TKey, T, Iterator<TKey, T>): (T|TKey) ...$callbackForValues
+                 * @param callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT ...$callbackForValues
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey|T, T|TKey>
+                 * @return Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
                  */
                 static fn (callable ...$callbackForValues): Closure =>
                     /**
                      * @param Iterator<TKey, T> $iterator
                      *
-                     * @return Generator<T|TKey, T|TKey>
+                     * @return Generator<NewTKey, NewT>
                      */
                     static function (Iterator $iterator) use ($callbackForKeys, $callbackForValues): Generator {
                         $callbackFactory =
                             /**
                              * @param TKey $key
                              *
-                             * @return Closure(T): Closure(T|TKey, callable(T|TKey, TKey, T, Iterator<TKey, T>): (T|TKey), int, Iterator<TKey, T>): (T|TKey)
+                             * @return Closure(T): Closure(T|TKey, callable((T|TKey)=, TKey=, T=, Iterator<TKey, T>=): (T|TKey), int, Iterator<TKey, T>): (T|TKey)
                              */
                             static fn ($key): Closure =>
                                 /**
                                  * @param T $value
                                  *
-                                 * @return Closure(T|TKey, callable(T|TKey, TKey, T, Iterator<TKey, T>): (T|TKey), int, Iterator<TKey, T>): (T|TKey)
+                                 * @return Closure(T|TKey, callable((T|TKey)=, TKey=, T=, Iterator<TKey, T>=): (T|TKey), int, Iterator<TKey, T>): (T|TKey)
                                  */
                                 static fn ($value): Closure =>
                                     /**
                                      * @param T|TKey $accumulator
-                                     * @param callable(T|TKey, TKey, T, Iterator<TKey, T>): (T|TKey) $callback
+                                     * @param callable((T|TKey)=, TKey=, T=, Iterator<TKey, T>=): (T|TKey) $callback
                                      * @param Iterator<TKey, T> $iterator
                                      *
                                      * @return T|TKey
@@ -75,10 +78,10 @@ final class Associate extends AbstractOperation
                         foreach ($iterator as $key => $value) {
                             $reduceCallback = $callbackFactory($key)($value);
 
-                            /** @var Generator<int, T|TKey> $k */
+                            /** @var Generator<int, NewTKey> $k */
                             $k = Reduce::of()($reduceCallback)($key)(new ArrayIterator($callbackForKeys));
 
-                            /** @var Generator<int, T|TKey> $c */
+                            /** @var Generator<int, NewT> $c */
                             $c = Reduce::of()($reduceCallback)($value)(new ArrayIterator($callbackForValues));
 
                             yield $k->current() => $c->current();

--- a/src/Operation/Associate.php
+++ b/src/Operation/Associate.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Operation;
 
-use ArrayIterator;
 use Closure;
 use Generator;
 use Iterator;
@@ -30,61 +29,31 @@ final class Associate extends AbstractOperation
      * @template NewTKey
      * @template NewT
      *
-     * @return Closure((callable((TKey|NewTKey)=, T=, TKey=, Iterator<TKey, T>=): NewTKey) ...): Closure((callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT)...): Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
+     * @return Closure(callable(TKey=, T=, Iterator<TKey, T>=): NewTKey): Closure(callable(T=, TKey=, Iterator<TKey, T>=): NewT): Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable((TKey|NewTKey)=, T=, TKey=, Iterator<TKey, T>=): NewTKey ...$callbackForKeys
+             * @param callable(TKey=, T=, Iterator<TKey, T>=): NewTKey $callbackForKeys
              *
-             * @return Closure((callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT)...): Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
+             * @return Closure((callable(T=, TKey=, Iterator<TKey, T>=): NewT)): Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
              */
-            static fn (callable ...$callbackForKeys): Closure =>
+            static fn (callable $callbackForKeys): Closure =>
                 /**
-                 * @param callable((T|NewT)=, T=, TKey=, Iterator<TKey, T>=): NewT ...$callbackForValues
+                 * @param callable(T=, TKey=, Iterator<TKey, T>=): NewT $callbackForValues
                  *
                  * @return Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
                  */
-                static fn (callable ...$callbackForValues): Closure =>
+                static fn (callable $callbackForValues): Closure =>
                     /**
                      * @param Iterator<TKey, T> $iterator
                      *
                      * @return Generator<NewTKey, NewT>
                      */
                     static function (Iterator $iterator) use ($callbackForKeys, $callbackForValues): Generator {
-                        $callbackFactory =
-                            /**
-                             * @param TKey $key
-                             *
-                             * @return Closure(T): Closure(T|TKey, callable((T|TKey)=, TKey=, T=, Iterator<TKey, T>=): (T|TKey), int, Iterator<TKey, T>): (T|TKey)
-                             */
-                            static fn ($key): Closure =>
-                                /**
-                                 * @param T $value
-                                 *
-                                 * @return Closure(T|TKey, callable((T|TKey)=, TKey=, T=, Iterator<TKey, T>=): (T|TKey), int, Iterator<TKey, T>): (T|TKey)
-                                 */
-                                static fn ($value): Closure =>
-                                    /**
-                                     * @param T|TKey $accumulator
-                                     * @param callable((T|TKey)=, TKey=, T=, Iterator<TKey, T>=): (T|TKey) $callback
-                                     * @param Iterator<TKey, T> $iterator
-                                     *
-                                     * @return T|TKey
-                                     */
-                                    static fn ($accumulator, callable $callback, int $callbackId, Iterator $iterator) => $callback($accumulator, $key, $value, $iterator);
-
                         foreach ($iterator as $key => $value) {
-                            $reduceCallback = $callbackFactory($key)($value);
-
-                            /** @var Generator<int, NewTKey> $k */
-                            $k = Reduce::of()($reduceCallback)($key)(new ArrayIterator($callbackForKeys));
-
-                            /** @var Generator<int, NewT> $c */
-                            $c = Reduce::of()($reduceCallback)($value)(new ArrayIterator($callbackForValues));
-
-                            yield $k->current() => $c->current();
+                            yield $callbackForKeys($key, $value, $iterator) => $callbackForValues($value, $key, $iterator);
                         }
                     };
     }

--- a/src/Operation/Flip.php
+++ b/src/Operation/Flip.php
@@ -30,22 +30,21 @@ final class Flip extends AbstractOperation
     {
         $callbackForKeys =
             /**
-             * @param mixed $carry
              * @param TKey $key
              * @param T $value
              *
              * @return T
              */
-            static fn ($carry, $key, $value) => $value;
+            static fn ($key, $value) => $value;
 
         $callbackForValues =
             /**
-             * @param mixed $carry
+             * @param T $value
              * @param TKey $key
              *
              * @return TKey
              */
-            static fn ($carry, $key) => $key;
+            static fn ($value, $key) => $key;
 
         /** @var Closure(Iterator<TKey, T>): Generator<T, TKey> $associate */
         $associate = Associate::of()($callbackForKeys)($callbackForValues);

--- a/src/Operation/Normalize.php
+++ b/src/Operation/Normalize.php
@@ -24,7 +24,7 @@ final class Normalize extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, T>
+     * @return Closure(Iterator<TKey, T>): Generator<int, T, mixed, void>
      */
     public function __invoke(): Closure
     {
@@ -32,7 +32,7 @@ final class Normalize extends AbstractOperation
             /**
              * @param Iterator<TKey, T> $iterator
              *
-             * @return Generator<int, T>
+             * @return Generator<int, T, mixed, void>
              */
             static function (Iterator $iterator): Generator {
                 foreach ($iterator as $value) {

--- a/src/Operation/Pair.php
+++ b/src/Operation/Pair.php
@@ -30,23 +30,20 @@ final class Pair extends AbstractOperation
     {
         $callbackForKeys =
             /**
-             * @param T $initial
              * @param TKey $key
              * @param array{0: TKey, 1: T} $value
              *
              * @return TKey|null
              */
-            static fn ($initial, $key, array $value) => $value[0] ?? null;
+            static fn ($key, array $value) => $value[0] ?? null;
 
         $callbackForValues =
             /**
-             * @param T $initial
-             * @param TKey $key
              * @param array{0: TKey, 1: T} $value
              *
              * @return T|null
              */
-            static fn ($initial, $key, array $value) => $value[1] ?? null;
+            static fn (array $value) => $value[1] ?? null;
 
         /** @var Closure(Iterator<TKey, T>): Generator<T, T|null> $pipe */
         $pipe = Pipe::of()(

--- a/src/Operation/Reverse.php
+++ b/src/Operation/Reverse.php
@@ -37,7 +37,7 @@ final class Reverse extends AbstractOperation
              */
             static fn (array $carry, array $value): array => [...$value, ...$carry];
 
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T, mixed, void> $pipe */
         $pipe = Pipe::of()(
             (new Pack())(),
             Reduce::of()($callback)([]),

--- a/src/Operation/Transpose.php
+++ b/src/Operation/Transpose.php
@@ -34,22 +34,19 @@ final class Transpose extends AbstractOperation
     {
         $callbackForKeys =
             /**
-             * @param array $carry
              * @param non-empty-array<int, TKey> $key
              *
              * @return TKey
              */
-            static fn (array $carry, array $key) => reset($key);
+            static fn (array $key) => reset($key);
 
         $callbackForValues =
             /**
-             * @param array $carry
-             * @param array<int, TKey> $key
              * @param array<int, T> $value
              *
              * @return array<int, T>
              */
-            static fn (array $carry, array $key, array $value): array => $value;
+            static fn (array $value): array => $value;
 
         /** @var Closure(Iterator<TKey, T>): Generator<TKey, list<T>> $pipe */
         $pipe = Pipe::of()(

--- a/src/Operation/Unpack.php
+++ b/src/Operation/Unpack.php
@@ -41,16 +41,15 @@ final class Unpack extends AbstractOperation
              *
              * @return NewTKey
              */
-            static fn ($initial, int $key, array $value) => $value[0];
+            static fn (int $key, array $value) => $value[0];
 
         $callbackForValues =
             /**
-             * @param NewT $initial
              * @param T $value
              *
              * @return NewT
              */
-            static fn ($initial, int $key, array $value) => $value[1];
+            static fn (array $value) => $value[1];
 
         /** @var Closure(Iterator<TKey, T>): Generator<NewTKey, NewT> $pipe */
         $pipe = Pipe::of()(

--- a/src/Operation/Unpair.php
+++ b/src/Operation/Unpair.php
@@ -24,7 +24,7 @@ final class Unpair extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, (TKey|T)>
+     * @return Closure(Iterator<TKey, T>): Generator<int, (TKey|T), mixed, void>
      */
     public function __invoke(): Closure
     {
@@ -32,7 +32,7 @@ final class Unpair extends AbstractOperation
             /**
              * @param Iterator<TKey, T> $iterator
              *
-             * @return Generator<int, (TKey|T)>
+             * @return Generator<int, (TKey|T), mixed, void>
              */
             static function (Iterator $iterator): Generator {
                 foreach ($iterator as $key => $value) {

--- a/src/Operation/Unwords.php
+++ b/src/Operation/Unwords.php
@@ -28,7 +28,7 @@ final class Unwords extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, (T | string)>): Generator<TKey, string> $implode */
+        /** @var Closure(Iterator<TKey, (T|string)>): Generator<TKey, string, mixed, void> $implode */
         $implode = Implode::of()(' ');
 
         // Point free style.

--- a/src/Operation/Zip.php
+++ b/src/Operation/Zip.php
@@ -29,34 +29,37 @@ final class Zip extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(iterable<mixed, mixed>...): Closure(Iterator<TKey, T>): Iterator<list<TKey|mixed>, list<T|mixed>>
+     * @template UKey
+     * @template U
+     *
+     * @return Closure(iterable<UKey, U>...): Closure(Iterator<TKey, T>): Iterator<list<TKey|UKey>, list<T|U>>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param iterable<mixed, mixed> ...$iterables
+             * @param iterable<UKey, U> ...$iterables
              *
-             * @return Closure(Iterator<TKey, T>): Iterator<list<TKey|mixed>, list<T|mixed>>
+             * @return Closure(Iterator<TKey, T>): Iterator<list<TKey|UKey>, list<T|U>>
              */
             static function (iterable ...$iterables): Closure {
                 $buildArrayIterator =
                     /**
-                     * @param list<iterable<mixed, mixed>> $iterables
+                     * @param list<iterable<UKey, U>> $iterables
                      */
                     static fn (array $iterables): Closure =>
                     /**
                      * @param Iterator<TKey, T> $iterator
                      *
-                     * @return ArrayIterator<int, (Iterator<TKey, T>|IterableIterator<mixed, mixed>)>
+                     * @return ArrayIterator<int, (Iterator<TKey, T>|IterableIterator<UKey, U>)>
                      */
                     static fn (Iterator $iterator): Iterator => new ArrayIterator([
                         $iterator,
                         ...array_map(
                             /**
-                             * @param iterable<mixed, mixed> $iterable
+                             * @param iterable<UKey, U> $iterable
                              *
-                             * @return IterableIterator<mixed, mixed>
+                             * @return IterableIterator<UKey, U>
                              */
                             static fn (iterable $iterable): IterableIterator => new IterableIterator($iterable),
                             $iterables
@@ -65,7 +68,7 @@ final class Zip extends AbstractOperation
 
                 $buildMultipleIterator =
                     /**
-                     * @return Closure(ArrayIterator<int, (Iterator<TKey, T>|IterableIterator<mixed, mixed>)>): MultipleIterator
+                     * @return Closure(ArrayIterator<int, (Iterator<TKey, T>|IterableIterator<UKey, U>)>): MultipleIterator
                      */
                     Reduce::of()(
                         /**
@@ -78,7 +81,7 @@ final class Zip extends AbstractOperation
                         }
                     )(new MultipleIterator(MultipleIterator::MIT_NEED_ANY));
 
-                /** @var Closure(Iterator<TKey, T>): Generator<list<TKey|mixed>, list<T|mixed>> $pipe */
+                /** @var Closure(Iterator<TKey, T>): Generator<list<TKey|UKey>, list<T|U>> $pipe */
                 $pipe = Pipe::of()(
                     $buildArrayIterator($iterables),
                     $buildMultipleIterator,

--- a/tests/static-analysis/associate.php
+++ b/tests/static-analysis/associate.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function associate_checkIntInt(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function associate_checkStringString(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<string, bool> $collection
+ */
+function associate_checkStringBool(CollectionInterface $collection): void
+{
+}
+
+$square = static fn (int $val): int => $val ** 2;
+$toBoldString = static fn (int $val): string => sprintf('*%s*', $val);
+$isEven = static fn (int $val): bool => 0 === $val % 2;
+
+associate_checkIntInt(Collection::fromIterable([1, 2, 3])->associate($square, $square));
+associate_checkStringString(Collection::fromIterable([1, 2, 3])->associate($toBoldString, $toBoldString));
+associate_checkStringBool(Collection::fromIterable([1, 2, 3])->associate($toBoldString, $isEven));

--- a/tests/static-analysis/unpack.php
+++ b/tests/static-analysis/unpack.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function unpack_checkListInt(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<int, string> $collection
+ */
+function unpack_checkListString(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function unpack_checkListStringWithString(CollectionInterface $collection): void
+{
+}
+
+$infiniteIntIntGenerator = static function (): Generator {
+    while (true) {
+        yield [random_int(-10, 10), random_int(-10, 10)];
+    }
+};
+
+$infiniteIntStringGenerator = static function (): Generator {
+    while (true) {
+        yield [random_int(-10, 10), chr(random_int(0, 255))];
+    }
+};
+
+$infiniteStringStringGenerator = static function (): Generator {
+    while (true) {
+        yield [chr(random_int(0, 255)), chr(random_int(0, 255))];
+    }
+};
+
+unpack_checkListInt(Collection::fromIterable($infiniteIntIntGenerator())->unpack());
+unpack_checkListString(Collection::fromIterable($infiniteIntStringGenerator())->unpack());
+unpack_checkListStringWithString(Collection::fromIterable($infiniteStringStringGenerator())->unpack());

--- a/tests/static-analysis/zip.php
+++ b/tests/static-analysis/zip.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<list<int>, list<int|string>> $collection
+ */
+function zip_checkIntString(CollectionInterface $collection): void
+{
+}
+
+zip_checkIntString(Collection::fromIterable(range(1, 3))->zip(range('a', 'c')));
+
+/**
+ * @param CollectionInterface<list<bool|int>, list<bool|string>> $collection
+ */
+function zip_checkBoolString(CollectionInterface $collection): void
+{
+}
+
+$generator =
+    /**
+     * @return Generator<bool, bool>
+     */
+    static function (): Generator {
+        yield true => true;
+
+        yield false => false;
+
+        yield true => true;
+    };
+
+zip_checkBoolString(Collection::fromIterable($generator())->zip(range('a', 'c')));

--- a/tests/static-analysis/zip.php
+++ b/tests/static-analysis/zip.php
@@ -13,18 +13,30 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
+ * @param CollectionInterface<list<bool>, list<bool>> $collection
+ */
+function zip_checkBoolBool(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<list<bool|int>, list<bool|string>> $collection
+ */
+function zip_checkBoolString(CollectionInterface $collection): void
+{
+}
+
+/**
  * @param CollectionInterface<list<int>, list<int|string>> $collection
  */
 function zip_checkIntString(CollectionInterface $collection): void
 {
 }
 
-zip_checkIntString(Collection::fromIterable(range(1, 3))->zip(range('a', 'c')));
-
 /**
- * @param CollectionInterface<list<bool|int>, list<bool|string>> $collection
+ * @param CollectionInterface<list<bool|int>, list<bool|int|string>> $collection
  */
-function zip_checkBoolString(CollectionInterface $collection): void
+function zip_checkBoolStringInt(CollectionInterface $collection): void
 {
 }
 
@@ -40,4 +52,15 @@ $generator =
         yield true => true;
     };
 
+// With one single parameter
+zip_checkBoolBool(Collection::fromIterable($generator())->zip($generator()));
 zip_checkBoolString(Collection::fromIterable($generator())->zip(range('a', 'c')));
+zip_checkIntString(Collection::fromIterable(range(1, 3))->zip(range('a', 'c')));
+
+// With two parameters of the same types
+zip_checkBoolBool(Collection::fromIterable($generator())->zip($generator(), $generator()));
+
+// With two parameters of different types
+// Fails with PHPStan, not in PSalm.
+/** @phpstan-ignore-next-line */
+zip_checkBoolStringInt(Collection::fromIterable($generator())->zip(range('a', 'c'), range(1, 3)));


### PR DESCRIPTION
This PR:

* [x] The `Associate` class is no more variadic - (Minor BC Break - only when using the `Associate` class on its own)
* [x] Fix `Zip` and `Associate` typing information
* [x] Update `Unpack` operation and its interface. 
* [x] Has static analysis tests (psalm, phpstan)
* [x] `Associate` documentation/examples has been updated - added more examples.