### PR TITLE
refactor(groupbyable)!: simplify implementation and update typing info

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1084,13 +1084,11 @@ Signature: ``Collection::group(): Collection;``
 groupBy
 ~~~~~~~
 
-Group items based on their keys.
-
-The default behaviour can be customized with a callback.
+Group items based on the provided callback.
 
 Interface: `GroupByable`_
 
-Signature: ``Collection::groupBy(?callable $callback = null): Collection;``
+Signature: ``Collection::groupBy(callable $callback): Collection;``
 
 .. code-block:: php
 
@@ -1104,7 +1102,7 @@ Signature: ``Collection::groupBy(?callable $callback = null): Collection;``
     };
 
     $collection = Collection::fromIterable($callback())
-        ->groupBy(); // [1 => ['a', 'b', 'c'], 2 => ['d', 'e'], 3 => ['f']]
+        ->groupBy(static fn (string $char, int $key): int => $key); // [1 => ['a', 'b', 'c'], 2 => ['d', 'e'], 3 => ['f']]
 
 has
 ~~~

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -1805,7 +1805,7 @@ class CollectionSpec extends ObjectBehavior
         };
 
         $this::fromCallable($callback)
-            ->groupBy()
+            ->groupBy(static fn (string $value, int $key): int => $key)
             ->shouldIterateAs([
                 1 => [
                     'a',
@@ -1854,11 +1854,6 @@ class CollectionSpec extends ObjectBehavior
                     19,
                 ],
             ]);
-
-        $input = range(0, 20);
-        $this::fromIterable($input)
-            ->groupBy(static function () {return null; })
-            ->shouldIterateAs($input);
     }
 
     public function it_can_has(): void

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -556,7 +556,7 @@ final class Collection implements CollectionInterface
         return new self(Group::of(), [$this->getIterator()]);
     }
 
-    public function groupBy(?callable $callable = null): CollectionInterface
+    public function groupBy(callable $callable): CollectionInterface
     {
         return new self(GroupBy::of()($callable), [$this->getIterator()]);
     }

--- a/src/Contract/Operation/GroupByable.php
+++ b/src/Contract/Operation/GroupByable.php
@@ -23,7 +23,11 @@ interface GroupByable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#groupby
      *
-     * @return Collection<TKey, T>
+     * @template NewTKey of array-key
+     *
+     * @param callable(T=, TKey=): NewTKey $callable
+     *
+     * @return Collection<NewTKey, non-empty-list<T>>
      */
-    public function groupBy(?callable $callable = null): Collection;
+    public function groupBy(callable $callable): Collection;
 }

--- a/tests/static-analysis/groupbyable.php
+++ b/tests/static-analysis/groupbyable.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, non-empty-list<string>> $collection
+ */
+function groupby_sameKeyType(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, non-empty-list<string>> $collection
+ */
+function groupby_newKeyType(CollectionInterface $collection): void
+{
+}
+
+$foo = [
+    0 => 'foo',
+    1 => 'bar',
+    2 => 'baz',
+];
+
+groupby_sameKeyType(
+    Collection::fromIterable($foo)->groupBy(static fn (string $value, int $key): int => $key)
+);
+
+groupby_newKeyType(
+    Collection::fromIterable($foo)->groupBy(static fn (string $value): string => $value)
+);
+
+// VALID failure -> invalid key types
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+Collection::fromIterable($foo)->groupBy(static fn () => null);
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+Collection::fromIterable($foo)->groupBy(static fn (): stdClass => new stdClass());


### PR DESCRIPTION
This PR:

* [x] Simplify `GroupBy` implementations to ease use
* [x] Fix `GroupByable` operations static analysis
* [x] It breaks backward compatibility
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)

Follows #206.
Closes #206.
