### PR TITLE
Update `all` operation to prevent data loss

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -12,6 +12,7 @@ $config = require __DIR__ . '/vendor/drupol/php-conventions/config/php73/php_cs_
 $config
     ->getFinder()
     ->ignoreDotFiles(false)
+    ->notPath('src/Contract/Operation/Allable.php')
     ->name(['.php_cs.dist']);
 
 $rules = $config->getRules();

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 $config = require __DIR__ . '/vendor/drupol/php-conventions/config/php73/php_cs_fixer.config.php';
 
+// specific file ignore introduced based on discussion: https://github.com/loophp/collection/pull/209#discussion_r739684664
 $config
     ->getFinder()
     ->ignoreDotFiles(false)

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1283,6 +1283,21 @@ Signature: ``Collection::isEmpty(): bool;``
 .. literalinclude:: code/operations/isEmpty.php
   :language: php
 
+jsonSerialize
+~~~~~~~~~~~~~
+
+Returns the collection items as an array, allowing serialization. Essentially calls ``all(false)``, 
+which means the collection is not normalized by default.
+
+See the section on :ref:`serialization <Serialization>`.
+
+Interface: `JsonSerializable`_
+
+Signature: ``Collection::jsonSerialize(): array;``
+
+.. literalinclude:: code/operations/jsonSerialize.php
+  :language: php
+
 key
 ~~~
 
@@ -2602,6 +2617,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Doctrine Collections: https://github.com/doctrine/collections
 .. _Generator: https://www.php.net/manual/en/language.generators.overview.php
 .. _Iterator: https://www.php.net/manual/en/class.iterator.php
+.. _JsonSerializable: https://www.php.net/manual/en/class.jsonserializable.php
 .. _symfony/var-dumper: https://packagist.org/packages/symfony/var-dumper
 .. _Traversable: https://www.php.net/manual/en/class.traversable.php
 .. _TypedIterator: https://github.com/loophp/collection/blob/master/src/Iterator/TypedIterator.php

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -70,7 +70,7 @@ Signature: ``Collection::fromGenerator(Generator $generator): Collection;``
     $generator->next();
 
     $collection = Collection::fromGenerator($generator)
-        ->all(); // [2 => 3, 3 => 4, 4 => 5]
+        ->all(); // [0 => 3, 1 => 4, 2 => 5]
 
 fromIterable
 ~~~~~~~~~~~~
@@ -221,14 +221,15 @@ When used as a ``Collection`` method, operations fall into a few main categories
 all
 ~~~
 
-Convert the collection into an array.
+Convert the collection into an array, re-indexing keys using ``Collection::normalize()`` to prevent data loss by default.
 
-.. warning:: This is a lossy operation because PHP array keys cannot be duplicated and must either be ``int`` or ``string``.
-            If you want to ensure no data is lost in the case of duplicate keys, look at the ``Collection::normalize()`` operation.
+.. warning:: An earlier version of this operation did not re-index keys by default, which meant at times data loss could occur.
+        The reason data loss could occur is because PHP array keys cannot be duplicated and must either be ``int`` or ``string``. 
+        The old behaviour can still be achieved by using the operation with the ``$normalize`` parameter as *false*.
 
 Interface: `Allable`_
 
-Signature: ``Collection::all(): array;``
+Signature: ``Collection::all(bool $normalize = true): array;``
 
 .. literalinclude:: code/operations/all.php
   :language: php
@@ -238,11 +239,9 @@ append
 
 Add one or more items to a collection.
 
-.. warning:: If appended values overwrite existing values, you might find that this operation doesn't work correctly
-             when the collection is converted into an array.
-             It's always better to never convert the collection to an array and use it in a loop.
-             However, if for some reason, you absolutely need to convert it into an array, then use the
-             ``Collection::normalize()`` operation.
+.. warning:: This operation maintains the keys of the appended items. If you wish to re-index the keys you can use the 
+            ``Collection::normalize()`` operation, or ``Collection::all()`` when converting into an array, which will apply
+            ``normalize`` by default. 
 
 Interface: `Appendable`_
 
@@ -255,12 +254,8 @@ Signature: ``Collection::append(...$items): Collection;``
 
     Collection::fromIterable(['1', '2', '3'])
         ->append('4')
-        ->append('5', '6'); // [0 => 5, 1 => 6, 2 => 3]
-
-    Collection::fromIterable(['1', '2', '3'])
-        ->append('4')
         ->append('5', '6')
-        ->normalize(); // ['1', '2', '3', '4', '5', '6']
+        ->all(); // ['1', '2', '3', '4', '5', '6']
 
 apply
 ~~~~~
@@ -1049,7 +1044,7 @@ Signature: ``Collection::frequency(): Collection;``
 
     $collection = Collection::fromIterable(['a', 'b', 'c', 'b', 'c', 'c'])
         ->frequency()
-        ->all(); // [1 => 'a', 2 => 'b', 3 => 'c'];
+        ->all(false); // [1 => 'a', 2 => 'b', 3 => 'c'];
 
 get
 ~~~
@@ -1480,17 +1475,12 @@ Signature: ``Collection::merge(iterable ...$sources): Collection;``
     $collection = Collection::fromIterable(['a', 'b', 'c'])
         ->merge(Collection::fromIterable(['d', 'e']);
 
-    $collection->all(); // ['d', 'e', 'c'] -> 'a' and 'b' are lost due to key overlap
-    $collection->normalize()->all() // ['a', 'b', 'c', 'd', 'e']
+    $collection->all() // ['a', 'b', 'c', 'd', 'e']
 
 normalize
 ~~~~~~~~~
 
 Replace, reorder and use numeric keys on a collection.
-
-.. note:: If you want to retrieve collection elements as an array via ``Collection::all()`` instead of
-        consuming the collection through a ``foreach``, most often you will want to use this method
-        before the array transformation in order to prevent data loss.
 
 Interface: `Normalizeable`_
 
@@ -1723,11 +1713,9 @@ prepend
 
 Push an item onto the beginning of the collection.
 
-.. warning:: If prepended values overwrite existing values or keys, you might find that this operation doesn't work correctly
-             when the collection is converted into an array.
-             It's always better to never convert the collection to an array and use it in a loop.
-             However, if for some reason, you absolutely need to convert it into an array, then use the
-             ``Collection::normalize()`` operation.
+.. warning:: This operation maintains the keys of the prepended items. If you wish to re-index the keys you can use the 
+            ``Collection::normalize()`` operation, or ``Collection::all()`` when converting into an array, which will apply
+            ``normalize`` by default. 
 
 Interface: `Prependable`_
 
@@ -1741,12 +1729,6 @@ Signature: ``Collection::prepend(...$items): Collection;``
     Collection::fromIterable(['1', '2', '3'])
         ->prepend('4')
         ->prepend('5', '6')
-        ->all(); // [0 => 1, 1 => 2, 2 => 3]
-
-    Collection::fromIterable(['1', '2', '3'])
-        ->prepend('4')
-        ->prepend('5', '6')
-        ->normalize()
         ->all(); // ['5', '6', '4', '1', '2', '3']
 
 product

--- a/docs/pages/code/duplicate-keys.php
+++ b/docs/pages/code/duplicate-keys.php
@@ -31,8 +31,7 @@ $wrapped = $frequency
 
 // Method 2 -> normalized collection
 $normalized = $frequency
-    ->normalize() // Replace keys with numerical indexes
-    ->all(); // Convert to regular array
+    ->all(); // Convert to regular array and replace keys with numerical indexes
 
 /**
  * [0 => 'a', 1 => 'b', 2 => 'c', 3 => 'd', 4 => 'e'].
@@ -44,10 +43,10 @@ $normalized = $frequency
 $collection = Collection::fromIterable(range(1, 10))
     ->filter(static fn ($value): bool => $value % 3 === 0);
 
-$filtered = $collection->all(); // [2 => 3, 5 => 6, 8 => 9]
-$filteredNormalized = $collection->normalize()->all(); // [0 => 3, 1 => 6, 2 => 9]
+$filtered = $collection->all(false); // [2 => 3, 5 => 6, 8 => 9]
+$filteredNormalized = $collection->all(); // [0 => 3, 1 => 6, 2 => 9]
 
-// Method 2 -> consuming the collection as an iterator
+// Method 3 -> consuming the collection as an iterator
 foreach ($frequency as $k => $v) {
     var_dump("({$k}, {$v})");
 }

--- a/docs/pages/code/extending-collection.php
+++ b/docs/pages/code/extending-collection.php
@@ -51,6 +51,6 @@ final class FoobarCollection implements FoobarCollectionInterface
     }
 
     // This example is intentionally incomplete.
-    // For the sake of brevity, I did not added all the remaining
+    // For the sake of brevity, I did not add all the remaining
     // methods to satisfy the FoobarCollectionInterface.
 }

--- a/docs/pages/code/operations/all.php
+++ b/docs/pages/code/operations/all.php
@@ -9,16 +9,12 @@ declare(strict_types=1);
 
 namespace App;
 
-use ArrayIterator;
 use Generator;
 use loophp\collection\Collection;
-use loophp\collection\Operation\All;
-use loophp\collection\Operation\Filter;
-use loophp\collection\Operation\Pipe;
 
 include __DIR__ . '/../../../../vendor/autoload.php';
 
-// Example 1 -> usage with Collection
+// Example 1 -> usage with "list" collection
 $generator = static function (): Generator {
     yield 0 => 'a';
 
@@ -30,10 +26,13 @@ $generator = static function (): Generator {
 };
 
 $collection = Collection::fromIterable($generator());
-print_r($collection->all()); // [0 => 'c', 1 => 'b', 2 => 'd']
+print_r($collection->all(false)); // [0 => 'c', 1 => 'b', 2 => 'd']
 
-// Example 2 -> standalone usage
-$even = static fn (int $value): bool => $value % 2 === 0;
+$collection = Collection::fromIterable($generator());
+print_r($collection->all()); // ['a', 'b', 'c', 'd']
 
-$piped = Pipe::of()(Filter::of()($even), All::of())(new ArrayIterator([1, 2, 3, 4]));
-print_r($piped); // [2, 4]
+// Example 2 -> usage with "map" collection
+$collection = Collection::fromIterable(['foo' => 1, 'bar' => 2]);
+
+print_r($collection->all(false)); // ['foo' => 1, 'bar' => 2]
+print_r($collection->all()); // [1, 2]

--- a/docs/pages/code/operations/jsonSerialize.php
+++ b/docs/pages/code/operations/jsonSerialize.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+Collection::fromIterable([1, 2, 3])
+    ->jsonSerialize(); // [1, 2, 3]
+
+Collection::fromIterable([1, 2, 3])
+    ->filter(static fn (int $val): bool => $val % 2 !== 0)
+    ->jsonSerialize(); // [0 => 1, 2 => 3]
+
+Collection::fromIterable(['foo' => 1, 'bar' => 2])
+    ->jsonSerialize(); // ['foo' => 1, 'bar' => 2]

--- a/docs/pages/code/operations/partition.php
+++ b/docs/pages/code/operations/partition.php
@@ -26,7 +26,7 @@ $input = array_combine(range('a', 'l'), [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3]);
     ->all();
 
 // Numbers that are greater than 5
-print_r($left->all());
+print_r($left->all(false));
 /*
 [
     ['f', 6],
@@ -37,7 +37,7 @@ print_r($left->all());
  */
 
 // Numbers that are not greater than 5
-print_r($right->all());
+print_r($right->all(false));
 /*
 [
     ['a', 1],
@@ -58,7 +58,7 @@ $left = Collection::fromIterable($input)
     ->current();
 
 // Numbers that are greater than 5
-print_r($left->all());
+print_r($left->all(false));
 /*
 [
 ['f', 6],

--- a/docs/pages/code/random-generator.php
+++ b/docs/pages/code/random-generator.php
@@ -20,7 +20,6 @@ $random_numbers = Collection::unfold($random)
     ->map(static fn ($value): float => floor($value * 1000) + 1)
     ->distinct()
     ->limit(300)
-    ->normalize()
     ->all();
 
 print_r($random_numbers);

--- a/docs/pages/code/serialization.php
+++ b/docs/pages/code/serialization.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+// Example 1 -> using `json_encode`
+
+// a) with list, ordered keys
+json_encode(Collection::fromIterable([1, 2, 3])); // JSON: '[1, 2, 3]'
+
+// b) with list, missing keys
+$col = Collection::fromIterable([1, 2, 3])
+    ->filter(static fn (int $val): bool => $val % 2 !== 0); // [0 => 1, 2 => 3]
+
+json_encode($col); // JSON: '{"0": 1, "2": 3}'
+
+// c) with list, missing keys, with `normalize`
+$col = Collection::fromIterable([1, 2, 3])
+    ->filter(static fn (int $val): bool => $val % 2 !== 0)
+    ->normalize(); // [0 => 1, 1 => 3]
+
+json_encode($col); // JSON: '[1, 3]'
+
+// d) with associative array
+json_encode(Collection::fromIterable(['foo' => 1, 'bar' => 2])); // JSON: '{"foo": 1, "bar": 2}'
+
+// e) with associative array, with `normalize`
+
+$col = Collection::fromIterable(['foo' => 1, 'bar' => 2])
+    ->normalize(); // [0 => 1, 1 => 2]
+
+json_encode($col); // JSON: '[1, 2]'
+
+// Example 2 -> using custom serializer (all previous behaviors apply)
+
+/** @var Symfony\Component\Serializer\Serializer $serializer */
+$serializer = new Serializer(); // parameters omitted for brevity
+
+$serializer->serialize(Collection::fromIterable([1, 2, 3]), 'json'); // JSON: '[1, 2, 3]'

--- a/docs/pages/code/simple.php
+++ b/docs/pages/code/simple.php
@@ -29,13 +29,11 @@ $collection
 // Append items.
 $collection
     ->append('F', 'G', 'H')
-    ->normalize()
     ->all(); // ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
 
 // Prepend items.
 $collection
     ->prepend('1', '2', '3')
-    ->normalize()
     ->all(); // ['1', '2', '3', 'A', 'B', 'C', 'D', 'E']
 
 // Split a collection into chunks of a given size.
@@ -123,7 +121,6 @@ Collection::unfold($random)
     ->map(static fn ($value): float => floor($value * 1000) + 1)
     ->distinct()
     ->limit(300)
-    ->normalize()
     ->all();
 
 // Fibonacci using the static method ::unfold()

--- a/docs/pages/code/text-analysis.php
+++ b/docs/pages/code/text-analysis.php
@@ -26,6 +26,6 @@ $collection = Collection::fromString($contents)
     // Sort values.
     ->sort()
     // Convert to array.
-    ->all();
+    ->all(false);
 
 print_r($collection);

--- a/docs/pages/principles.rst
+++ b/docs/pages/principles.rst
@@ -102,8 +102,7 @@ In addition to these, in *PHPSpec* we can use the `iterateAs`_ matcher to assert
 final collection object will iterate.
 
 The last option is to transform the collection object into an array with the :ref:`all <All>` operation
-and use any assertion that we would normally use for arrays. However, beware of the potential
-loss of data that can happen when doing this - see the operation's documentation.
+and use any assertion that we would normally use for arrays.
 
 Usability
 ---------

--- a/docs/pages/usage.rst
+++ b/docs/pages/usage.rst
@@ -56,7 +56,7 @@ result. We can see that some data is missing, why?
 The reason that the frequency analysis for letters 'a' and 'b' is missing
 is because when you call the method ``Collection::all()`` with a *false* parameter, 
 the collection converts the lazy collection into a regular PHP array, 
-and PHP doesn't allow having multiple time the same key, so it overrides 
+and PHP doesn't allow having multiple time the same key; thus, it overrides 
 the previous data and there will be missing information in the resulting array.
 
 In order to prevent this, by default the ``all`` operation will also apply

--- a/docs/pages/usage.rst
+++ b/docs/pages/usage.rst
@@ -51,24 +51,24 @@ result. We can see that some data is missing, why?
         // Run the frequency analysis tool.
         ->frequency()
         // Convert to regular array.
-        ->all(); // [5 => 'e', 4 => 'd', 3 => 'c']
+        ->all(false); // [5 => 'e', 4 => 'd', 3 => 'c']
 
 The reason that the frequency analysis for letters 'a' and 'b' is missing
-is because when you call the method ``Collection::all()``, the collection converts
-the lazy collection into a regular PHP array, and PHP doesn't allow having
-multiple time the same key, so it overrides the previous data and there will be
-missing information in the resulting array.
+is because when you call the method ``Collection::all()`` with a *false* parameter, 
+the collection converts the lazy collection into a regular PHP array, 
+and PHP doesn't allow having multiple time the same key, so it overrides 
+the previous data and there will be missing information in the resulting array.
 
-In order to circumvent this, you can either ``wrap`` the final result or
-``normalize`` it.
-A better way would be to not convert this into an array and use the lazy
-collection as an iterator.
+In order to prevent this, by default the ``all`` operation will also apply
+``normalize``, re-indexing and re-ordering the keys. However, this might not always
+be the desired outcome, like in this instance (see examples below).
 
-Wrapping the result will wrap each result into a PHP array.
-Normalizing the result will replace keys with a numerical index, but then
-you might lose some information then.
+Other ways to circumvent this PHP array limitation:
 
-It's up to you to decide which one you want to use.
+* use the ``wrap`` operation on the final result, wrapping each key-value pair in a PHP array
+* do not convert the collection to an array and use it as an iterator instead
+
+It's up to you to decide which approach to take based on your use case.
 
 .. literalinclude:: code/duplicate-keys.php
   :language: php

--- a/docs/pages/usage.rst
+++ b/docs/pages/usage.rst
@@ -73,6 +73,22 @@ It's up to you to decide which approach to take based on your use case.
 .. literalinclude:: code/duplicate-keys.php
   :language: php
 
+Serialization
+~~~~~~~~~~~~~
+
+The collection object implements the `JsonSerializable`_ interface, thus allowing
+for JSON serialization using the built-in PHP function ``json_encode`` or a 
+custom serializer like the `Symfony Serializer`_.
+
+.. tip:: By default the collection is not normalized when serializing, which allows
+        its usage as an associative array. However, when it is used as a list and
+        there are missing keys, the ``normalize`` operation should be applied before
+        serialization; not doing so will likely not result in the desired outcome, as
+        shown in the example below.
+
+.. literalinclude:: code/serialization.php
+  :language: php
+
 Extending collection
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -175,3 +191,5 @@ Lazy json parsing
   :language: php
 
 .. _article: https://not-a-number.io/2019/php-composition-and-inheritance/
+.. _JsonSerializable: https://www.php.net/manual/en/class.jsonserializable.php
+.. _Symfony Serializer: https://symfony.com/doc/current/components/serializer.html

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -3456,6 +3456,20 @@ class CollectionSpec extends ObjectBehavior
             )
             ->shouldNotThrow(Exception::class)
             ->during('squash');
+
+        $this::fromIterable([16, 4, 9, 9])
+            ->map(
+                static function (int $value): int {
+                    if (-100 > $value) {
+                        throw new Exception('This should not error');
+                    }
+
+                    return (int) sqrt($value);
+                }
+            )
+            ->squash()
+            ->all(false)
+            ->shouldReturn([4, 2, 3, 3]);
     }
 
     public function it_can_strict_allow(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -531,18 +531,26 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs([0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
     }
 
-    public function it_can_be_json_encoded()
+    public function it_can_be_json_encoded_as_list(): void
+    {
+        $input = ['a', 'b', 'c'];
+
+        $this->beConstructedThrough('fromIterable', [$input]);
+        $this->shouldImplement(JsonSerializable::class);
+
+        $this->jsonSerialize()->shouldReturn($this->all(false));
+        $this->jsonSerialize()->shouldReturn($input);
+    }
+
+    public function it_can_be_json_encoded_as_map(): void
     {
         $input = ['a' => 'A', 'b' => 'B', 'c' => 'C'];
 
         $this->beConstructedThrough('fromIterable', [$input]);
+        $this->shouldImplement(JsonSerializable::class);
 
-        $this
-            ->jsonSerialize()
-            ->shouldReturn($this->all());
-
-        $this
-            ->shouldImplement(JsonSerializable::class);
+        $this->jsonSerialize()->shouldReturn($this->all(false));
+        $this->jsonSerialize()->shouldReturn($input);
     }
 
     public function it_can_be_returned_as_an_array(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -41,12 +41,20 @@ class CollectionSpec extends ObjectBehavior
     public function it_can_all(): void
     {
         $this::fromIterable([1, 2, 3])
+            ->all(false)
+            ->shouldIterateAs([1, 2, 3]);
+
+        $this::fromIterable([1, 2, 3])
             ->all()
             ->shouldIterateAs([1, 2, 3]);
 
         $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
-            ->all()
+            ->all(false)
             ->shouldIterateAs(['foo' => 'f', 'bar' => 'b']);
+
+        $this::fromIterable(['foo' => 'f', 'bar' => 'b'])
+            ->all()
+            ->shouldIterateAs(['f', 'b']);
 
         $duplicateKeyGen = static function (): Generator {
             yield 'a' => 1;
@@ -60,8 +68,12 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs($duplicateKeyGen());
 
         $this::fromIterable($duplicateKeyGen())
-            ->all()
+            ->all(false)
             ->shouldIterateAs(['a' => 3, 'b' => 2]);
+
+        $this::fromIterable($duplicateKeyGen())
+            ->all()
+            ->shouldIterateAs([1, 2, 3]);
     }
 
     public function it_can_append(): void
@@ -716,7 +728,7 @@ class CollectionSpec extends ObjectBehavior
 
         $this::fromIterable(range('a', 'c'))
             ->combinate()
-            ->all()
+            ->all(false)
             ->shouldBeEqualTo(
                 [
                     0 => [

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -885,7 +885,7 @@ final class Collection implements CollectionInterface
 
     public function squash(): CollectionInterface
     {
-        return self::fromIterable($this->pack()->all())->unpack();
+        return self::fromIterable($this->pack()->all(false))->unpack();
     }
 
     public function strict(?callable $callback = null): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -624,7 +624,7 @@ final class Collection implements CollectionInterface
      */
     public function jsonSerialize(): array
     {
-        return $this->all();
+        return $this->all(false);
     }
 
     public function key(int $index = 0)

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -176,9 +176,9 @@ final class Collection implements CollectionInterface
         $this->parameters = $parameters;
     }
 
-    public function all(): array
+    public function all(bool $normalize = true): array
     {
-        return All::of()($this->getIterator());
+        return All::of()($normalize)($this->getIterator());
     }
 
     public function append(...$items): CollectionInterface

--- a/src/Contract/Operation/Allable.php
+++ b/src/Contract/Operation/Allable.php
@@ -20,7 +20,10 @@ interface Allable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#all
      *
-     * @return array<TKey, T>
+     * @param bool $normalize
+     *
+     * @return list<T>|array<TKey, T>
+     * @psalm-return ($normalize is true ? list<T> : array<TKey, T>)
      */
-    public function all(): array;
+    public function all(bool $normalize = true): array;
 }

--- a/src/Operation/All.php
+++ b/src/Operation/All.php
@@ -23,16 +23,22 @@ final class All extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): array<TKey, T>
+     * @return Closure(bool): Closure(Iterator<TKey, T>): list<T>|array<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
-             *
-             * @return array<TKey, T>
+             * @return Closure(Iterator<TKey, T>): list<T>|array<TKey, T>
              */
-            static fn (Iterator $iterator): array => iterator_to_array($iterator);
+            static fn (bool $normalize): Closure =>
+                /**
+                 * @param Iterator<TKey, T> $iterator
+                 *
+                 * @return array<TKey, T>|list<T>
+                 */
+                static fn (Iterator $iterator): array => $normalize
+                    ? iterator_to_array((new Normalize())()($iterator))
+                    : iterator_to_array($iterator);
     }
 }

--- a/tests/static-analysis/all.php
+++ b/tests/static-analysis/all.php
@@ -31,9 +31,9 @@ function all_checkMixed(array $array): void
 }
 
 all_checkList(Collection::empty()->all());
-all_checkMap(Collection::empty()->all());
+all_checkMap(Collection::empty()->all(false));
 all_checkMixed(Collection::empty()->all());
 
 all_checkList(Collection::fromIterable([1, 2, 3])->all());
-all_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all());
+all_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all(false));
 all_checkMixed(Collection::fromIterable([1, 2, 'b', '5', 4])->all());

--- a/tests/static-analysis/all.php
+++ b/tests/static-analysis/all.php
@@ -35,5 +35,16 @@ all_checkMap(Collection::empty()->all(false));
 all_checkMixed(Collection::empty()->all());
 
 all_checkList(Collection::fromIterable([1, 2, 3])->all());
-all_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all(false));
+all_checkList(Collection::fromIterable([1, 2, 3])->all(false));
 all_checkMixed(Collection::fromIterable([1, 2, 'b', '5', 4])->all());
+all_checkMixed(Collection::fromIterable([1, 2, 'b', '5', 4])->all(false));
+
+// VALID failures -> improper usage
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+all_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all());
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+all_checkList(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all(false));
+
+//# PHPStan limitation -> does not support conditional return types, but Psalm does
+/** @phpstan-ignore-next-line */
+all_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all(false));

--- a/tests/static-analysis/first.php
+++ b/tests/static-analysis/first.php
@@ -60,6 +60,6 @@ first_checkStringElement(Collection::fromIterable(['foo' => 'bar'])->first()->cu
 
 // VALID failures - these keys don't exist
 /** @psalm-suppress InvalidArrayOffset */
-first_checkIntElement(Collection::fromIterable([1, 2, 3])->first()->all()[4]);
-/** @psalm-suppress InvalidArrayOffset @phpstan-ignore-next-line */
-first_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->first()->all()[0]);
+first_checkIntElement(Collection::fromIterable([1, 2, 3])->first()->all(false)[4]);
+/** @psalm-suppress InvalidArrayOffset */
+first_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->first()->all(false)[0]);

--- a/tests/static-analysis/head.php
+++ b/tests/static-analysis/head.php
@@ -60,6 +60,6 @@ head_checkStringElement(Collection::fromIterable(['foo' => 'bar'])->head()->curr
 
 // VALID failures - these keys don't exist
 /** @psalm-suppress InvalidArrayOffset */
-head_checkIntElement(Collection::fromIterable([1, 2, 3])->head()->all()[4]);
-/** @psalm-suppress InvalidArrayOffset @phpstan-ignore-next-line */
-head_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->head()->all()[0]);
+head_checkIntElement(Collection::fromIterable([1, 2, 3])->head()->all(false)[4]);
+/** @psalm-suppress InvalidArrayOffset */
+head_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->head()->all(false)[0]);

--- a/tests/static-analysis/last.php
+++ b/tests/static-analysis/last.php
@@ -60,6 +60,6 @@ last_checkStringElement(Collection::fromIterable(['foo' => 'bar'])->last()->curr
 
 // VALID failures - these keys don't exist
 /** @psalm-suppress InvalidArrayOffset */
-last_checkIntElement(Collection::fromIterable([1, 2, 3])->last()->all()[4]);
-/** @psalm-suppress InvalidArrayOffset @phpstan-ignore-next-line */
-last_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->last()->all()[0]);
+last_checkIntElement(Collection::fromIterable([1, 2, 3])->last()->all(false)[4]);
+/** @psalm-suppress InvalidArrayOffset */
+last_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->last()->all(false)[0]);


### PR DESCRIPTION
This PR:

* [x] Modifies the `all` operation to apply `normalize` by default. Also allows usage without `normalize` via a bool param
* [x] It breaks backward compatibility
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation

Fixes https://github.com/loophp/collection/issues/208.
