### PR TITLE
Fix/update PHPStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "infection/infection": "^0.23.0 || ^0.24.0",
         "infection/phpspec-adapter": "^0.1.2",
         "phpspec/phpspec": "^7.1",
-        "phpstan/phpstan-strict-rules": "^0.12",
+        "phpstan/phpstan-strict-rules": "^1.0",
         "psr/cache": "^1.0",
         "symfony/cache": "^5"
     },

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -24,6 +24,7 @@ parameters:
       - "/vendor/"
 
   # PHPStan
+  tasks.phpstan.level: 8
   tasks.phpstan.blocking: true
   tasks.phpstan.ignore_patterns:
     - "/.github/"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,26 +6,6 @@ parameters:
 			path: src/Operation/Combinate.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Operation\\\\Group\\:\\:__invoke\\(\\) should return Closure\\(Iterator\\<TKey, T\\>\\)\\: Generator\\<int, array\\<int, T\\>, mixed, mixed\\> but returns Closure\\(Iterator\\)\\: Generator\\<int, array\\<int, mixed\\>&nonEmpty, mixed, void\\>\\.$#"
-			count: 1
-			path: src/Operation/Group.php
-
-		-
-			message: "#^Strict comparison using \\=\\=\\= between array\\(\\) and array\\<int, T\\>&nonEmpty will always evaluate to false\\.$#"
-			count: 1
-			path: src/Operation/Permutate.php
-
-		-
-			message: "#^Anonymous function should return EmptyIterator but return statement is missing\\.$#"
-			count: 1
-			path: src/Operation/Times.php
-
-		-
-			message: "#^Anonymous function should have native return typehint \"\\?T\"\\.$#"
-			count: 1
-			path: src/Operation/Unwindow.php
-
-		-
 			message: "#^Foreach overwrites \\$value with its value variable\\.$#"
 			count: 1
 			path: src/Operation/Unwindow.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,292 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:empty\\(\\) should return loophp\\\\collection\\\\Collection\\<NewTKey, NewT\\> but returns loophp\\\\collection\\\\Collection\\<\\(int&NewTKey\\)\\|\\(NewTKey&string\\), NewT\\>\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
+			message: "#^Template type NewT of method loophp\\\\collection\\\\Collection\\:\\:empty\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
+			message: "#^Template type NewTKey of method loophp\\\\collection\\\\Collection\\:\\:empty\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$comparatorCallback contains unresolvable type\\.$#"
+			count: 1
+			path: src/Contract/Operation/Duplicateable.php
+
+		-
+			message: "#^Template type T of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Rangeable\\:\\:range\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Contract/Operation/Rangeable.php
+
+		-
+			message: "#^Template type TKey of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Rangeable\\:\\:range\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Contract/Operation/Rangeable.php
+
+		-
+			message: "#^PHPDoc tag @param for parameter \\$comparatorCallback contains unresolvable type\\.$#"
+			count: 1
+			path: src/Contract/Operation/Sameable.php
+
+		-
+			message: "#^Template type TKey of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Unfoldable\\:\\:unfold\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Contract/Operation/Unfoldable.php
+
+		-
+			message: "#^Anonymous function should return string but returns class\\-string\\|false\\.$#"
+			count: 1
+			path: src/Iterator/TypedIterator.php
+
+		-
+			message: "#^Property loophp\\\\collection\\\\Iterator\\\\ProxyIterator\\<TKey,T\\>\\:\\:\\$iterator \\(Iterator\\<TKey, T\\>\\) does not accept loophp\\\\collection\\\\Iterator\\\\ClosureIterator\\<TKey, T\\|\\(T&null\\)\\>\\.$#"
+			count: 1
+			path: src/Iterator/TypedIterator.php
+
+		-
+			message: "#^Template type NewT of method loophp\\\\collection\\\\Operation\\\\Associate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Associate.php
+
+		-
+			message: "#^Template type NewTKey of method loophp\\\\collection\\\\Operation\\\\Associate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Associate.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\AsyncMap\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/AsyncMap.php
+
+		-
 			message: "#^Anonymous function with return type void returns void but should not return anything\\.$#"
 			count: 2
 			path: src/Operation/Combinate.php
 
 		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Combine\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Combine.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Current\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Current.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Distinct\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Distinct.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 1
+			path: src/Operation/DropWhile.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Duplicate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Duplicate.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 1
+			path: src/Operation/Filter.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Find\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Find.php
+
+		-
+			message: "#^Template type IKey of method loophp\\\\collection\\\\Operation\\\\FlatMap\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/FlatMap.php
+
+		-
+			message: "#^Template type IValue of method loophp\\\\collection\\\\Operation\\\\FlatMap\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/FlatMap.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Get\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Get.php
+
+		-
+			message: "#^Method loophp\\\\collection\\\\Operation\\\\Group\\:\\:__invoke\\(\\) should return Closure\\(Iterator\\<TKey, T\\>\\)\\: Generator\\<int, array\\<int, T\\>, mixed, mixed\\> but returns Closure\\(Iterator\\)\\: Generator\\<int, non\\-empty\\-array\\<int, mixed\\>, mixed, void\\>\\.$#"
+			count: 1
+			path: src/Operation/Group.php
+
+		-
+			message: "#^Template type NewTKey of method loophp\\\\collection\\\\Operation\\\\GroupBy\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/GroupBy.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Map\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Map.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 2
+			path: src/Operation/MatchOne.php
+
+		-
+			message: "#^PHPDoc tag @var for constant loophp\\\\collection\\\\Operation\\\\Nullsy\\:\\:VALUES contains unresolvable type\\.$#"
+			count: 1
+			path: src/Operation/Nullsy.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Product\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Product.php
+
+		-
+			message: "#^Template type UKey of method loophp\\\\collection\\\\Operation\\\\Product\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Product.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Reduce\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Reduce.php
+
+		-
+			message: "#^Template type W of method loophp\\\\collection\\\\Operation\\\\Reduce\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Reduce.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Reduction\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Reduction.php
+
+		-
+			message: "#^Template type W of method loophp\\\\collection\\\\Operation\\\\Reduction\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Reduction.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 1
+			path: src/Operation/Reject.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\ScanLeft\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/ScanLeft.php
+
+		-
+			message: "#^Template type W of method loophp\\\\collection\\\\Operation\\\\ScanLeft\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/ScanLeft.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\ScanLeft1\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/ScanLeft1.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\ScanRight\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/ScanRight.php
+
+		-
+			message: "#^Template type W of method loophp\\\\collection\\\\Operation\\\\ScanRight\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/ScanRight.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\ScanRight1\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/ScanRight1.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 1
+			path: src/Operation/Since.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 1
+			path: src/Operation/Split.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 1
+			path: src/Operation/TakeWhile.php
+
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 1
+			path: src/Operation/Unfold.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects array\\<int, callable\\(mixed, mixed, Iterator\\<mixed, mixed\\>\\)\\: bool\\>, array\\<int\\|string, callable\\(\\)\\: mixed\\> given\\.$#"
+			count: 1
+			path: src/Operation/Until.php
+
+		-
 			message: "#^Foreach overwrites \\$value with its value variable\\.$#"
 			count: 1
 			path: src/Operation/Unwindow.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Zip\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Zip.php
+
+		-
+			message: "#^Template type UKey of method loophp\\\\collection\\\\Operation\\\\Zip\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Zip.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function all_checkList expects array\\<int, int\\>, array\\<int\\|string, mixed\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/all.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function all_checkMap expects array\\<string, int\\>, array\\<int\\|string, mixed\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/all.php
+
+		-
+			message: "#^Parameter \\#1 \\$array of function all_checkMixed expects array\\<int, int\\|string\\>, array\\<int\\|string, mixed\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/all.php
+
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 2
+			path: tests/static-analysis/flip.php
+
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 4
+			path: tests/static-analysis/random.php
+
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 4
+			path: tests/static-analysis/shuffle.php
+
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 3
+			path: tests/static-analysis/unpack.php
+
+		-
+			message: "#^While loop condition is always true\\.$#"
+			count: 2
+			path: tests/static-analysis/wrap.php
 

--- a/phpstan-unsupported-baseline.neon
+++ b/phpstan-unsupported-baseline.neon
@@ -4,18 +4,3 @@ parameters:
 			message: "#^Generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\<mixed, array\\<int, mixed\\>\\> in PHPDoc tag @extends does not specify all template types of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\: TKey, T, NewTKey, NewT$#"
 			count: 1
 			path: src/Contract/Collection.php
-
-		-
-			message: "#^PHPDoc tag @template T for class loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable with bound type array\\<int, NewT\\|NewTKey\\> is not supported\\.$#"
-			count: 1
-			path: src/Contract/Operation/Unpackable.php
-
-		-
-			message: "#^PHPDoc tag @template T for interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable with bound type array\\<int, NewT\\|NewTKey\\> is not supported\\.$#"
-			count: 1
-			path: src/Contract/Operation/Unpackable.php
-
-		-
-			message: "#^PHPDoc tag @template T for class loophp\\\\collection\\\\Operation\\\\Unpack with bound type array\\<int, NewT\\|NewTKey\\> is not supported\\.$#"
-			count: 1
-			path: src/Operation/Unpack.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,3 +1,5 @@
+parameters:
+	reportUnmatchedIgnoredErrors: false
 includes:
 	- phpstan-baseline.neon
 	- phpstan-unsupported-baseline.neon

--- a/src/Contract/Operation/Timesable.php
+++ b/src/Contract/Operation/Timesable.php
@@ -16,8 +16,6 @@ interface Timesable
     /**
      * Create a new instance by invoking the callback a given amount of times.
      *
-     * @template TKey
-     * @template TKey
      * @template T
      *
      * @param null|callable(int): (int|T) $callback

--- a/src/Operation/Times.php
+++ b/src/Operation/Times.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use EmptyIterator;
 use Generator;
 use Iterator;
 
@@ -47,7 +46,7 @@ final class Times extends AbstractOperation
                      */
                     static function (?Iterator $iterator = null) use ($number, $callback): Generator {
                         if (1 > $number) {
-                            return new EmptyIterator();
+                            return;
                         }
 
                         $callback ??= static fn (int $value): int => $value;


### PR DESCRIPTION
This PR:

* [x] Fix PHPStan 1.0 new issues (_because of updated level 8_)
* [x] Update baselines and remove obsolete PHPStan issues thanks to new features in PHPStan 1.0
* [x] Update baselines and append new errors detected by PHPStan 1.0
* [x] Fix PHPStan to level 8
* [x] Find why PHPStan fails on PHP 7.4 and not on 8 - Fixed by disabling `reportUnmatchedIgnoredErrors`

Fixes #210 
