### PR TITLE
Fix `All` operation for standalone usage

### DIFF
--- a/docs/pages/code/operations/all.php
+++ b/docs/pages/code/operations/all.php
@@ -9,8 +9,12 @@ declare(strict_types=1);
 
 namespace App;
 
+use ArrayIterator;
 use Generator;
 use loophp\collection\Collection;
+use loophp\collection\Operation\All;
+use loophp\collection\Operation\Filter;
+use loophp\collection\Operation\Pipe;
 
 include __DIR__ . '/../../../../vendor/autoload.php';
 
@@ -36,3 +40,9 @@ $collection = Collection::fromIterable(['foo' => 1, 'bar' => 2]);
 
 print_r($collection->all(false)); // ['foo' => 1, 'bar' => 2]
 print_r($collection->all()); // [1, 2]
+
+// Example 3 -> standalone operation usage
+$even = static fn (int $value): bool => $value % 2 === 0;
+
+$piped = Pipe::of()(Filter::of()($even), All::of()(true))(new ArrayIterator([1, 2, 3, 4]));
+print_r(iterator_to_array($piped)); // [2, 4]

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -178,7 +178,7 @@ final class Collection implements CollectionInterface
 
     public function all(bool $normalize = true): array
     {
-        return All::of()($normalize)($this->getIterator());
+        return iterator_to_array(All::of()($normalize)($this->getIterator()));
     }
 
     public function append(...$items): CollectionInterface

--- a/src/Operation/All.php
+++ b/src/Operation/All.php
@@ -23,22 +23,20 @@ final class All extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(bool): Closure(Iterator<TKey, T>): list<T>|array<TKey, T>
+     * @return Closure(bool): Closure(Iterator<TKey, T>): Iterator<int, T>|Iterator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): list<T>|array<TKey, T>
+             * @return Closure(Iterator<TKey, T>): Iterator<int, T>|Iterator<TKey, T>
              */
             static fn (bool $normalize): Closure =>
                 /**
                  * @param Iterator<TKey, T> $iterator
                  *
-                 * @return array<TKey, T>|list<T>
+                 * @return Iterator<int, T>|Iterator<TKey, T>
                  */
-                static fn (Iterator $iterator): array => $normalize
-                    ? iterator_to_array((new Normalize())()($iterator))
-                    : iterator_to_array($iterator);
+                static fn (Iterator $iterator): Iterator => $normalize ? (new Normalize())()($iterator) : $iterator;
     }
 }


### PR DESCRIPTION
This PR:

* [x] Fixes usage of the `All` as standalone with `Pipe`
* [x] Has documentation

Follows https://github.com/loophp/collection/pull/209#discussion_r743463086. Every operation needs to return an `Iterator` in order to be pipeable.
