### PR TITLE
[PHPStan Baseline] Fix Errors Part 2 + Modify `Unfold` Operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -124,21 +124,7 @@ Signature: ``Collection::range(float $start = 0.0, float $end = INF, float $step
 
 .. code-block:: php
 
-    $fibonacci = static function ($a = 0, $b = 1): array {
-        return [$b, $a + $b];
-    };
-
     $even = Collection::range(0, 20, 2); // [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20]
-
-Another example
-
-.. code-block:: php
-
-    $even = Collection::unfold(static function ($carry) {return $carry + 2;}, -2);
-    $odd = Collection::unfold(static function ($carry) {return $carry + 2;}, -1);
-    // Is the same as
-    $even = Collection::range(0, \INF, 2);
-    $odd = Collection::range(1, \INF, 2);
 
 times
 ~~~~~
@@ -158,34 +144,14 @@ unfold
 
 Create a collection by yielding from a callback with an initial value.
 
-.. warning:: The callback return values are reused as callback arguments at the next callback call.
+.. warning:: The callback needs to return a list of values which will be reused as callback arguments 
+            on the next callback call. Therefore, the returned list should contain values of the same type
+            as the parameters for the callback function.
 
 Signature: ``Collection::unfold(callable $callback, ...$parameters): Collection;``
 
-.. code-block:: php
-
-    // A list of Naturals from 1 to Infinity.
-    Collection::unfold(fn($n) => $n + 1, 1)
-        ->normalize();
-
-.. code-block:: php
-
-    $fibonacci = static function ($a = 0, $b = 1): array {
-        return [$b, $a + $b];
-    };
-
-    Collection::unfold($fibonacci)
-        ->limit(10); // [[0, 1], [1, 1], [1, 2], [2, 3], [3, 5], [5, 8], [8, 13], [13, 21], [21, 34], [34, 55]]
-
-Another example
-
-.. code-block:: php
-
-    $even = Collection::unfold(static function (int $carry): int {return $carry + 2;}, -2);
-    $odd = Collection::unfold(static function (int $carry): int {return $carry + 2;}, -1);
-    // Is the same as
-    $even = Collection::range(0, \INF, 2);
-    $odd = Collection::range(1, \INF, 2);
+.. literalinclude:: code/operations/unfold.php
+  :language: php
 
 Methods (operations)
 --------------------
@@ -2305,17 +2271,14 @@ Signature: ``Collection::until(callable ...$callbacks): Collection;``
 .. code-block:: php
 
     // The Collatz conjecture (https://en.wikipedia.org/wiki/Collatz_conjecture)
-    $collatz = static function (int $value): int
-    {
-        return 0 === $value % 2 ?
-            $value / 2:
-            $value * 3 + 1;
-    };
+    $collatz = static fn (int $value): array => 0 === $value % 2 
+            ? [$value / 2]
+            : [$value * 3 + 1];
 
     $collection = Collection::unfold($collatz, 10)
-        ->until(static function ($number): bool {
-            return 1 === $number;
-        });
+        ->unwrap()
+        ->normalize()
+        ->until(static fn ($number): bool => 1 === $number);
 
 unwindow
 ~~~~~~~~

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -2277,7 +2277,6 @@ Signature: ``Collection::until(callable ...$callbacks): Collection;``
 
     $collection = Collection::unfold($collatz, 10)
         ->unwrap()
-        ->normalize()
         ->until(static fn ($number): bool => 1 === $number);
 
 unwindow

--- a/docs/pages/code/collatz-conjecture.php
+++ b/docs/pages/code/collatz-conjecture.php
@@ -18,7 +18,6 @@ $collatz = static fn (int $value): array => 0 === $value % 2
 
 $collection = Collection::unfold($collatz, 10)
     ->unwrap()
-    ->normalize()
-    ->until(static fn ($number): bool => 1 === $number);
+    ->until(static fn (int $number): bool => 1 === $number);
 
 print_r($c->all()); // [25, 76, 38, 19, 58, 29, 88, 44, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1]

--- a/docs/pages/code/collatz-conjecture.php
+++ b/docs/pages/code/collatz-conjecture.php
@@ -12,17 +12,13 @@ include __DIR__ . '/../../../vendor/autoload.php';
 use loophp\collection\Collection;
 
 // The Collatz conjecture (https://en.wikipedia.org/wiki/Collatz_conjecture)
-$collatz = static function (int $value): int {
-    return 0 === $value % 2 ?
-        $value / 2 :
-        $value * 3 + 1;
-};
+$collatz = static fn (int $value): array => 0 === $value % 2
+    ? [$value / 2]
+    : [$value * 3 + 1];
 
-$c = Collection::unfold($collatz, 25)
-    ->until(
-        static function ($number): bool {
-            return 1 === $number;
-        }
-    );
+$collection = Collection::unfold($collatz, 10)
+    ->unwrap()
+    ->normalize()
+    ->until(static fn ($number): bool => 1 === $number);
 
 print_r($c->all()); // [25, 76, 38, 19, 58, 29, 88, 44, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1]

--- a/docs/pages/code/e.php
+++ b/docs/pages/code/e.php
@@ -19,7 +19,8 @@ $fact = static fn (float $number): float => (float) Collection::range(1, $number
     ->foldLeft($multiplication, 1)
     ->current();
 
-$number_e_approximation = Collection::unfold(static fn (int $i = 0): int => $i + 1)
+$number_e_approximation = Collection::unfold(static fn (int $i = 0): array => [$i + 1])
+    ->unwrap()
     ->map(static fn (float $value): float => $value / $fact($value))
     ->until(static fn (float $value): bool => 10 ** -12 > $value)
     ->foldLeft($addition, 0)

--- a/docs/pages/code/fibonacci.php
+++ b/docs/pages/code/fibonacci.php
@@ -11,9 +11,7 @@ include __DIR__ . '/../../../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
-$fibonacci = static function (int $a = 0, int $b = 1): array {
-    return [$b, $b + $a];
-};
+$fibonacci = static fn (int $a = 0, int $b = 1): array => [$b, $b + $a];
 
 $c = Collection::unfold($fibonacci)
     ->pluck(0)    // Get the first item of each result.

--- a/docs/pages/code/monte-carlo.php
+++ b/docs/pages/code/monte-carlo.php
@@ -23,18 +23,11 @@ $monteCarloMethod = static function ($in = 0, $total = 1): array {
 };
 
 $pi_approximation = Collection::unfold($monteCarloMethod)
-    ->map(
-        static function ($value) {
-            return 4 * $value['in'] / $value['total'];
-        }
-    )
+    ->map(static fn ($value) => 4 * $value['in'] / $value['total'])
     ->window(1)
     ->drop(1)
-    ->until(
-        static function (array $value): bool {
-            return 0.00001 > abs($value[0] - $value[1]);
-        }
-    )
+    ->until(static fn (array $value): bool => 0.00001 > abs($value[0] - $value[1]))
+    ->unwrap()
     ->last();
 
-print_r($pi_approximation->all());
+print_r($pi_approximation->all()); // [3.14...]

--- a/docs/pages/code/operations/unfold.php
+++ b/docs/pages/code/operations/unfold.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+use const INF;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+// Example 1 -> A list of Naturals from 1 to Infinity (use `limit` to keep only a set of them)
+Collection::unfold(static fn (int $n): array => [$n + 1], 1)
+    ->unwrap()
+    ->all(); // [1, 2, 3, 4, ...]
+
+// Example 2 -> fibonacci sequence
+Collection::unfold(static fn (int $a = 0, int $b = 1): array => [$b, $a + $b])
+    ->pluck(0)
+    ->limit(10)
+    ->all(); // [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+
+// Example 3 -> infinite range, similar to the `range` operation
+$even = Collection::unfold(static fn ($carry): array => [$carry + 2], -2)->unwrap();
+$odd = Collection::unfold(static fn ($carry): array => [$carry + 2], -1)->unwrap();
+
+// Is the same as
+$even = Collection::range(0, INF, 2);
+$odd = Collection::range(1, INF, 2);

--- a/docs/pages/code/random-generator.php
+++ b/docs/pages/code/random-generator.php
@@ -12,11 +12,10 @@ include __DIR__ . '/../../../vendor/autoload.php';
 use loophp\collection\Collection;
 
 // Generate 300 distinct random numbers between 0 and 1000
-$random = static function () {
-    return mt_rand() / mt_getrandmax();
-};
+$random = static fn (): array => [mt_rand() / mt_getrandmax()];
 
 $random_numbers = Collection::unfold($random)
+    ->unwrap()
     ->map(static fn ($value): float => floor($value * 1000) + 1)
     ->distinct()
     ->limit(300)

--- a/docs/pages/code/random-numbers-distribution.php
+++ b/docs/pages/code/random-numbers-distribution.php
@@ -16,11 +16,10 @@ $min = 0;
 $max = 1000;
 $groups = 100;
 
-$randomGenerator = static function () use ($min, $max): int {
-    return random_int($min, $max);
-};
+$randomGenerator = static fn (): array => [random_int($min, $max)];
 
 $distribution = Collection::unfold($randomGenerator)
+    ->unwrap()
     ->limit($max)
     ->map(
         static function (int $value) use ($max, $groups): string {
@@ -53,7 +52,7 @@ $distribution = Collection::unfold($randomGenerator)
         }
     );
 
-print_r($distribution->all());
+print_r($distribution->all(false));
 
 /*
 Array

--- a/docs/pages/code/simple.php
+++ b/docs/pages/code/simple.php
@@ -113,20 +113,17 @@ Collection::fromIterable(range('A', 'Z'))
     );
 
 // Generate 300 distinct random numbers between 0 and 1000
-$random = static function () {
-    return mt_rand() / mt_getrandmax();
-};
+$random = static fn (): array => [mt_rand() / mt_getrandmax()];
 
 Collection::unfold($random)
+    ->unwrap()
     ->map(static fn ($value): float => floor($value * 1000) + 1)
     ->distinct()
     ->limit(300)
     ->all();
 
 // Fibonacci using the static method ::unfold()
-$fibonacci = static function ($a = 0, $b = 1): array {
-    return [$b, $b + $a];
-};
+$fibonacci = static fn ($a = 0, $b = 1): array => [$b, $b + $a];
 
 Collection::unfold($fibonacci)
     // Get the first item of each result.
@@ -134,14 +131,10 @@ Collection::unfold($fibonacci)
     // Limit the amount of results to 10.
     ->limit(10)
     // Convert to regular array.
-    ->all(); // [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
+    ->all(); // [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 
 Collection::unfold($fibonacci)
-    ->map(
-        static function (array $value, $key) {
-            return $value[1] / $value[0];
-        }
-    )
+    ->map(static fn (array $value) => $value[1] / $value[0])
     ->limit(100)
     ->last(); // 1.6180339887499
 
@@ -212,14 +205,11 @@ Collection::fromIterable([0, 2, 4, 6, 8, 10])
 // Iterator over the function: f(x) = r * x * (1-x)
 // Change that parameter $r to see different behavior.
 // More on this: https://en.wikipedia.org/wiki/Logistic_map
-$function = static function ($x = .3, $r = 2) {
-    return $r * $x * (1 - $x);
-};
+$function = static fn ($x = .3, $r = 2): array => [$r * $x * (1 - $x)];
 
 Collection::unfold($function)
-    ->map(static function ($value): float {
-        return round($value, 2);
-    })
+    ->unwrap()
+    ->map(static fn ($value): float => round($value, 2))
     ->limit(10)
     ->all(); // [0.42, 0.48, 0.49, 0.49, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5]
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Anonymous function should return string but returns class\\-string\\|false\\.$#"
-			count: 1
-			path: src/Iterator/TypedIterator.php
-
-		-
-			message: "#^Property loophp\\\\collection\\\\Iterator\\\\ProxyIterator\\<TKey,T\\>\\:\\:\\$iterator \\(Iterator\\<TKey, T\\>\\) does not accept loophp\\\\collection\\\\Iterator\\\\ClosureIterator\\<TKey, T\\|\\(T&null\\)\\>\\.$#"
-			count: 1
-			path: src/Iterator/TypedIterator.php
-
-		-
 			message: "#^Template type NewT of method loophp\\\\collection\\\\Operation\\\\Associate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/Associate.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,11 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Template type TKey of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Unfoldable\\:\\:unfold\\(\\) is not referenced in a parameter\\.$#"
-			count: 1
-			path: src/Contract/Operation/Unfoldable.php
-
-		-
 			message: "#^Anonymous function should return string but returns class\\-string\\|false\\.$#"
 			count: 1
 			path: src/Iterator/TypedIterator.php

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -3634,7 +3634,7 @@ class CollectionSpec extends ObjectBehavior
 
     public function it_can_unfold(): void
     {
-        $this::unfold(static function (int $n): int {return $n + 1; }, 1)
+        $this::unfold(static fn (int $n): int => $n + 1, 1)
             ->limit(10)
             ->shouldIterateAs([
                 0 => 2,
@@ -3649,32 +3649,13 @@ class CollectionSpec extends ObjectBehavior
                 9 => 11,
             ]);
 
-        $fibonacci = static function ($value1, $value2) {
-            return [$value2, $value1 + $value2];
-        };
-
-        $this::unfold($fibonacci, 0, 1)
+        $this::unfold(static fn (int $a, int $b) => [$b, $a + $b], 0, 1)
             ->limit(10)
             ->shouldIterateAs([[1, 1], [1, 2], [2, 3], [3, 5], [5, 8], [8, 13], [13, 21], [21, 34], [34, 55], [55, 89]]);
 
-        $plusOne = static function ($value) {
-            return $value + 1;
-        };
-
-        $this::unfold($plusOne, 0)
+        $this::unfold(static fn (int $val): int => $val + 1, 0)
             ->limit(10)
-            ->shouldIterateAs([
-                1,
-                2,
-                3,
-                4,
-                5,
-                6,
-                7,
-                8,
-                9,
-                10,
-            ]);
+            ->shouldIterateAs([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     }
 
     public function it_can_unlines(): void

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -3737,9 +3737,15 @@ class CollectionSpec extends ObjectBehavior
 
         $this::unfold($collatz, 10)
             ->unwrap()
-            ->normalize()
             ->until(static fn (int $number): bool => 1 === $number)
-            ->shouldIterateAs([5, 16, 8, 4, 2, 1]);
+            ->shouldIterateAs([
+                0 => 5,
+                0 => 16,
+                0 => 8,
+                0 => 4,
+                0 => 2,
+                0 => 1,
+            ]);
 
         $input = range(1, 10);
 

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -3737,14 +3737,15 @@ class CollectionSpec extends ObjectBehavior
 
         $this::unfold($collatz, 10)
             ->unwrap()
+            ->normalize()
             ->until(static fn (int $number): bool => 1 === $number)
             ->shouldIterateAs([
-                0 => 5,
-                0 => 16,
-                0 => 8,
-                0 => 4,
-                0 => 2,
-                0 => 1,
+                5,
+                16,
+                8,
+                4,
+                2,
+                1,
             ]);
 
         $input = range(1, 10);

--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -3638,7 +3638,7 @@ class CollectionSpec extends ObjectBehavior
             ->limit(5)
             ->shouldIterateAs([[0], [2], [4], [6], [8]]);
 
-        $this::unfold(static fn (int $a, int $b) => [$b, $a + $b], 0, 1)
+        $this::unfold(static fn (int $a, int $b): array => [$b, $a + $b], 0, 1)
             ->pluck(0)
             ->limit(10)
             ->shouldIterateAs([1, 1, 2, 3, 5, 8, 13, 21, 34, 55]);

--- a/src/Contract/Operation/Timesable.php
+++ b/src/Contract/Operation/Timesable.php
@@ -14,7 +14,10 @@ use loophp\collection\Contract\Collection;
 interface Timesable
 {
     /**
-     * Create a new instance by invoking the callback a given amount of times.
+     * Create a collection by invoking a callback a given amount of times.
+     * If no callback is provided, then it will create a simple list of incremented integers.
+     *
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#times
      *
      * @template T
      *

--- a/src/Contract/Operation/Unfoldable.php
+++ b/src/Contract/Operation/Unfoldable.php
@@ -20,10 +20,10 @@ interface Unfoldable
      *
      * @template T
      *
-     * @param callable(T ...): (T|list<T>) $callback
+     * @param callable(T ...): list<T> $callback
      * @param T ...$parameters
      *
-     * @return Collection<int, T>
+     * @return Collection<int, list<T>>
      */
     public static function unfold(callable $callback, ...$parameters): Collection;
 }

--- a/src/Contract/Operation/Unfoldable.php
+++ b/src/Contract/Operation/Unfoldable.php
@@ -14,10 +14,13 @@ use loophp\collection\Contract\Collection;
 interface Unfoldable
 {
     /**
-     * @template TKey
+     * Create a collection by yielding from a callback with an initial value.
+     *
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#unfold
+     *
      * @template T
      *
-     * @param callable(mixed|T...): (mixed|array<TKey, T>) $callback
+     * @param callable(T ...): (T|list<T>) $callback
      * @param T ...$parameters
      *
      * @return Collection<int, T>

--- a/src/Contract/Operation/Unwordsable.php
+++ b/src/Contract/Operation/Unwordsable.php
@@ -21,7 +21,7 @@ interface Unwordsable
      * Opposite of `words` and similar to `unlines`, creates a single string
      * from multiple strings using one space as the glue.
      *
-     * @sse https://loophp-collection.readthedocs.io/en/stable/pages/api.html#unwords
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#unwords
      *
      * @return Collection<TKey, string>
      */

--- a/src/Iterator/TypedIterator.php
+++ b/src/Iterator/TypedIterator.php
@@ -15,6 +15,7 @@ use Iterator;
 
 use function get_class;
 use function gettype;
+use function is_object;
 
 /**
  * @internal
@@ -28,7 +29,7 @@ final class TypedIterator extends ProxyIterator
 {
     /**
      * @param Iterator<TKey, T> $iterator
-     * @param null|callable(T): string $getType
+     * @param null|callable(mixed): string $getType
      */
     public function __construct(Iterator $iterator, ?callable $getType = null)
     {
@@ -37,10 +38,8 @@ final class TypedIterator extends ProxyIterator
              * @param mixed $variable
              */
             static function ($variable): string {
-                $type = gettype($variable);
-
-                if ('object' !== $type) {
-                    return $type;
+                if (!is_object($variable)) {
+                    return gettype($variable);
                 }
 
                 $interfaces = class_implements($variable);
@@ -63,10 +62,6 @@ final class TypedIterator extends ProxyIterator
             static function (Iterator $iterator) use ($getType): Generator {
                 $previousType = null;
 
-                /**
-                 * @var TKey $key
-                 * @var T $value
-                 */
                 foreach ($iterator as $key => $value) {
                     if (null === $value) {
                         yield $key => $value;

--- a/src/Operation/Unfold.php
+++ b/src/Operation/Unfold.php
@@ -12,8 +12,6 @@ namespace loophp\collection\Operation;
 use Closure;
 use Generator;
 
-use function is_array;
-
 /**
  * @immutable
  *
@@ -27,7 +25,7 @@ final class Unfold extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(callable(T...): (list<T>)): Closure(): Generator<int, T|list<T>>
+     * @return Closure(T...): Closure(callable(T...): list<T>): Closure(): Generator<int, list<T>>
      */
     public function __invoke(): Closure
     {
@@ -35,23 +33,21 @@ final class Unfold extends AbstractOperation
             /**
              * @param T ...$parameters
              *
-             * @return Closure(callable(T...): (list<T>)): Closure(): Generator<int, T|list<T>>
+             * @return Closure(callable(T...): list<T>): Closure(): Generator<int, list<T>>
              */
             static fn (...$parameters): Closure =>
                 /**
-                 * @param callable(T...): (T|list<T>) $callback
+                 * @param callable(T...): list<T> $callback
                  *
-                 * @return Closure(): Generator<int, T|list<T>>
+                 * @return Closure(): Generator<int, list<T>>
                  */
                 static fn (callable $callback): Closure =>
                     /**
-                     * @return Generator<int, list<T>|T>
+                     * @return Generator<int, list<T>>
                      */
                     static function () use ($parameters, $callback): Generator {
                         while (true) {
-                            $parameters = is_array($parameters)
-                                ? $callback(...$parameters)
-                                : $callback($parameters);
+                            $parameters = $callback(...$parameters);
 
                             yield $parameters;
                         }

--- a/src/Operation/Unfold.php
+++ b/src/Operation/Unfold.php
@@ -11,6 +11,7 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
+use function is_array;
 
 /**
  * @immutable
@@ -25,7 +26,7 @@ final class Unfold extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(callable(T...): (list<T>)): Closure(): Generator<int, T>
+     * @return Closure(T...): Closure(callable(T...): (list<T>)): Closure(): Generator<int, T|list<T>>
      */
     public function __invoke(): Closure
     {
@@ -33,22 +34,23 @@ final class Unfold extends AbstractOperation
             /**
              * @param T ...$parameters
              *
-             * @return Closure(callable(T...): (list<T>)): Closure(): Generator<int, T>
+             * @return Closure(callable(T...): (list<T>)): Closure(): Generator<int, T|list<T>>
              */
             static fn (...$parameters): Closure =>
                 /**
                  * @param callable(T...): (T|list<T>) $callback
                  *
-                 * @return Closure(): Generator<int, T>
+                 * @return Closure(): Generator<int, T|list<T>>
                  */
                 static fn (callable $callback): Closure =>
                     /**
-                     * @return Generator<int, T>
+                     * @return Generator<int, list<T>|T>
                      */
                     static function () use ($parameters, $callback): Generator {
                         while (true) {
-                            /** @var T $parameters */
-                            $parameters = $callback(...array_values((array) $parameters));
+                            $parameters = is_array($parameters)
+                                ? $callback(...$parameters)
+                                : $callback($parameters);
 
                             yield $parameters;
                         }

--- a/src/Operation/Unfold.php
+++ b/src/Operation/Unfold.php
@@ -25,7 +25,7 @@ final class Unfold extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(callable(mixed|T...): (mixed|array<TKey, T>)): Closure(): Generator<int, T>
+     * @return Closure(T...): Closure(callable(T...): (list<T>)): Closure(): Generator<int, T>
      */
     public function __invoke(): Closure
     {
@@ -33,11 +33,11 @@ final class Unfold extends AbstractOperation
             /**
              * @param T ...$parameters
              *
-             * @return Closure(callable(mixed|T...): (array<TKey, T>)): Closure(): Generator<int, T>
+             * @return Closure(callable(T...): (list<T>)): Closure(): Generator<int, T>
              */
             static fn (...$parameters): Closure =>
                 /**
-                 * @param callable(mixed|T...): (mixed|array<TKey, T>) $callback
+                 * @param callable(T...): (T|list<T>) $callback
                  *
                  * @return Closure(): Generator<int, T>
                  */

--- a/src/Operation/Unfold.php
+++ b/src/Operation/Unfold.php
@@ -11,6 +11,7 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
+
 use function is_array;
 
 /**

--- a/tests/static-analysis/unfold.php
+++ b/tests/static-analysis/unfold.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function unfold_checkList(CollectionInterface $collection): void
+{
+}
+/**
+ * @param CollectionInterface<int, list<int>> $collection
+ */
+function unfold_checkListOfLists(CollectionInterface $collection): void
+{
+}
+
+$plusTwo = static fn (int $n = 0): array => [$n + 2];
+$fib = static fn (int $a = 0, int $b = 1): array => [$b, $a + $b];
+
+unfold_checkList(Collection::unfold($plusTwo)->unwrap());
+unfold_checkList(Collection::unfold($plusTwo, -2)->unwrap());
+
+// VALID use cases -> PHPStan thinks the collection is of type Collection<int, array<int, mixed>>, but Psalm works
+
+/** @phpstan-ignore-next-line */
+unfold_checkListOfLists(Collection::unfold($plusTwo));
+/** @phpstan-ignore-next-line */
+unfold_checkListOfLists(Collection::unfold($plusTwo, -2));
+/** @phpstan-ignore-next-line */
+unfold_checkListOfLists(Collection::unfold($fib));
+/** @phpstan-ignore-next-line */
+unfold_checkListOfLists(Collection::unfold($fib, 0, 1));
+
+// VALID use case -> `Pluck` can return various things so analysers cannot know the type is correct
+
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+unfold_checkList(Collection::unfold($fib)->pluck(0));
+
+// INVALID use case -> parameters of different types
+
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+unfold_checkListOfLists(Collection::unfold(static fn (int $a = 0, float $b = 1): array => [$b, $a + $b]));
+
+// INVALID use case -> returning list of different type than the closure parameter
+
+/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+unfold_checkListOfLists(Collection::unfold(static fn (int $n = 0): array => [(string) ($n + 2)]));


### PR DESCRIPTION
This PR:

* [x] Fixes more PHPStan baseline errors
* [x] Refactors the `Unfold` operation to make it more consistent in usage
* [x] Breaks backwards compatibility
* [x] Has unit tests
* [x] Has static analysis checks
* [x] Has documentation

Follows #216.