### PR TITLE
Findable: Template param order matters

### DIFF
--- a/src/Contract/Operation/Findable.php
+++ b/src/Contract/Operation/Findable.php
@@ -12,8 +12,8 @@ namespace loophp\collection\Contract\Operation;
 use Iterator;
 
 /**
- * @template T
  * @template TKey
+ * @template T
  */
 interface Findable
 {


### PR DESCRIPTION
This PR:

* [x] Fixes an issue with `Findable`: the order of the type parameters matters -  if `T` is first then static analysers will think that in the `callback` provided the first parameter needs to be the key instead of the value.

Not sure how this didn't cause any failures in the static analysis checks we have :(. But it's causing failures in other projects trying to use release 6.0