### PR TITLE
Fix PHP 8.1 Deprecations

### DIFF
--- a/src/Iterator/ArrayCacheIterator.php
+++ b/src/Iterator/ArrayCacheIterator.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace loophp\collection\Iterator;
 
 use Iterator;
+use ReturnTypeWillChange;
 
 use function array_key_exists;
 
@@ -41,6 +42,7 @@ final class ArrayCacheIterator extends ProxyIterator
     /**
      * @return T
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         $data = $this->getTupleFromCache($this->key);
@@ -51,6 +53,7 @@ final class ArrayCacheIterator extends ProxyIterator
     /**
      * @return TKey
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         $data = $this->getTupleFromCache($this->key);

--- a/src/Iterator/ProxyIterator.php
+++ b/src/Iterator/ProxyIterator.php
@@ -11,6 +11,7 @@ namespace loophp\collection\Iterator;
 
 use Iterator;
 use OuterIterator;
+use ReturnTypeWillChange;
 
 /**
  * @internal
@@ -30,6 +31,7 @@ abstract class ProxyIterator implements OuterIterator
     /**
      * @return T
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         return $this->iterator->current();
@@ -46,6 +48,7 @@ abstract class ProxyIterator implements OuterIterator
     /**
      * @return TKey
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         return $this->iterator->key();

--- a/src/Iterator/PsrCacheIterator.php
+++ b/src/Iterator/PsrCacheIterator.php
@@ -12,6 +12,7 @@ namespace loophp\collection\Iterator;
 use Iterator;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use ReturnTypeWillChange;
 
 /**
  * @internal
@@ -39,6 +40,7 @@ final class PsrCacheIterator extends ProxyIterator
     /**
      * @return T
      */
+    #[ReturnTypeWillChange]
     public function current()
     {
         /** @var array{TKey, T} $data */
@@ -50,6 +52,7 @@ final class PsrCacheIterator extends ProxyIterator
     /**
      * @return TKey
      */
+    #[ReturnTypeWillChange]
     public function key()
     {
         /** @var array{TKey, T} $data */

--- a/src/Iterator/RandomIterator.php
+++ b/src/Iterator/RandomIterator.php
@@ -11,6 +11,7 @@ namespace loophp\collection\Iterator;
 
 use BadMethodCallException;
 use Iterator;
+use ReturnTypeWillChange;
 
 use function assert;
 
@@ -51,6 +52,7 @@ final class RandomIterator extends ProxyIterator
         $this->wrappedIterator = new ArrayCacheIterator($iterator);
     }
 
+    #[ReturnTypeWillChange]
     public function current()
     {
         if (!$this->valid()) {
@@ -64,6 +66,7 @@ final class RandomIterator extends ProxyIterator
         return $keyValueTuple[1];
     }
 
+    #[ReturnTypeWillChange]
     public function key()
     {
         if (!$this->valid()) {


### PR DESCRIPTION
This PR fixes new deprecations in PHP 8.1, found when using Collection in a project running this new version.
Note these can be treated as errors in local development and testing depending on the user's PHP error level config.

`
  Error: During inheritance of Iterator: Uncaught Behat\Testwork\Call\Exception\CallErrorException: 8192: Return type of loophp\collection\Iterator\ProxyIterator::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in [my-project-path]/vendor/loophp/collection/src/Iterator/ProxyIterator.php line 49 in [my-project-path]/vendor/behat/behat/src/Behat/Testwork/Call/Handler/RuntimeCallHandler.php:90
`


* [x] adds ReturnTypeWillChange attributes to iterator methods
* [x] Has unit tests (phpspec)
* [x] Has static analysis tests (psalm, phpstan)
