### PR TITLE
Fix intersperse operation.

### DIFF
--- a/spec/loophp/collection/CollectionSpec.php
+++ b/spec/loophp/collection/CollectionSpec.php
@@ -2139,8 +2139,6 @@ class CollectionSpec extends ObjectBehavior
             ->shouldIterateAs($generator());
 
         $generator = static function () {
-            yield 0 => 'foo';
-
             yield 0 => 'A';
 
             yield 1 => 'B';

--- a/src/Operation/Intersperse.php
+++ b/src/Operation/Intersperse.php
@@ -62,8 +62,11 @@ final class Intersperse extends AbstractOperation
                                 );
                             }
 
+                            $current = 0;
+
                             foreach ($iterator as $key => $value) {
-                                if (0 === $startAt++ % $atEvery) {
+                                if ($startAt === $current++) {
+                                    $startAt += $atEvery;
                                     yield $element;
                                 }
 


### PR DESCRIPTION
This PR:

* [x] Fix intersperse operation
* [ ] Provide ...
* [ ] It breaks backward compatibility
* [x] Has unit tests (phpspec)
* [ ] Has static analysis tests (psalm, phpstan)
* [ ] Has documentation
* [ ] Is an experimental thing

I think there is a bug in the intersperse operation with a starting position.\
I change the intersperse spec with the expected behavior.