### PR TITLE
Use `new` keywords

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,16 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:partition\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<TKey, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, loophp\\\\collection\\\\Collection\\<mixed, mixed\\>\\>\\.$#"
-			count: 1
-			path: src/Collection.php
-
-		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:span\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<TKey, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, loophp\\\\collection\\\\Collection\\<mixed, mixed\\>\\>\\.$#"
-			count: 1
-			path: src/Collection.php
-
-		-
 			message: "#^Template type NewT of method loophp\\\\collection\\\\Operation\\\\Associate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/Associate.php

--- a/phpstan-unsupported-baseline.neon
+++ b/phpstan-unsupported-baseline.neon
@@ -1,6 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: "#^Generic type loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\<mixed, array\\<int, mixed\\>\\> in PHPDoc tag @extends does not specify all template types of interface loophp\\\\collection\\\\Contract\\\\Operation\\\\Unpackable\\: TKey, T, NewTKey, NewT$#"
-			count: 1
-			path: src/Contract/Collection.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,4 +2,3 @@ parameters:
 	reportUnmatchedIgnoredErrors: true
 includes:
 	- phpstan-baseline.neon
-	- phpstan-unsupported-baseline.neon

--- a/src/Contract/Operation/Mapable.php
+++ b/src/Contract/Operation/Mapable.php
@@ -23,11 +23,9 @@ interface Mapable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#map
      *
-     * @template V
+     * @param callable(T=, TKey=, Iterator<TKey, T>=): mixed $callback
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): V $callback
-     *
-     * @return Collection<TKey, V>
+     * @return Collection<TKey, mixed>
      */
     public function map(callable $callback): Collection;
 }

--- a/src/Contract/Operation/ScanLeft1able.php
+++ b/src/Contract/Operation/ScanLeft1able.php
@@ -25,11 +25,9 @@ interface ScanLeft1able
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanleft1
      *
-     * @template V
+     * @param callable(T|mixed, T, TKey, Iterator<TKey, T>): mixed $callback
      *
-     * @param callable(T|V, T, TKey, Iterator<TKey, T>): V $callback
-     *
-     * @return Collection<int|TKey, T|V>
+     * @return Collection<int|TKey, T|mixed>
      */
     public function scanLeft1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/ScanLeftable.php
+++ b/src/Contract/Operation/ScanLeftable.php
@@ -25,13 +25,10 @@ interface ScanLeftable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanleft
      *
-     * @template V
-     * @template W
+     * @param callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed $callback
+     * @param mixed $initial
      *
-     * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
-     * @param V $initial
-     *
-     * @return Collection<int|TKey, V|W>
+     * @return Collection<int|TKey, mixed>
      */
     public function scanLeft(callable $callback, $initial = null): Collection;
 }

--- a/src/Contract/Operation/ScanRight1able.php
+++ b/src/Contract/Operation/ScanRight1able.php
@@ -25,11 +25,9 @@ interface ScanRight1able
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanright1
      *
-     * @template V
+     * @param callable(T|mixed, T, TKey, Iterator<TKey, T>): mixed $callback
      *
-     * @param callable(T|V, T, TKey, Iterator<TKey, T>): V $callback
-     *
-     * @return Collection<int|TKey, T|V>
+     * @return Collection<int|TKey, T|mixed>
      */
     public function scanRight1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/ScanRightable.php
+++ b/src/Contract/Operation/ScanRightable.php
@@ -25,13 +25,10 @@ interface ScanRightable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanright
      *
-     * @template V
-     * @template W
+     * @param callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed $callback
+     * @param mixed $initial
      *
-     * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
-     * @param V $initial
-     *
-     * @return Collection<int|TKey, V|W>
+     * @return Collection<int|TKey, mixed>
      */
     public function scanRight(callable $callback, $initial = null): Collection;
 }

--- a/src/Contract/Operation/Unpackable.php
+++ b/src/Contract/Operation/Unpackable.php
@@ -13,10 +13,7 @@ use loophp\collection\Contract\Collection;
 
 /**
  * @template TKey
- * @template T of array{0: NewTKey, 1: NewT}
- *
- * @template NewTKey
- * @template NewT
+ * @template T
  */
 interface Unpackable
 {
@@ -25,7 +22,7 @@ interface Unpackable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#unpack
      *
-     * @return Collection<NewTKey, NewT>
+     * @return Collection<mixed, mixed>
      */
     public function unpack(): Collection;
 }

--- a/src/Operation/AsyncMap.php
+++ b/src/Operation/AsyncMap.php
@@ -64,7 +64,7 @@ final class AsyncMap extends AbstractOperation
                          */
                         static fn (array $value): array => [$value[0], $callback($value[1], $value[0])];
 
-                    $iter = map(fromIterable(Pack::of()($iterator)), new LocalSemaphore(32), parallel($parallelCallBack));
+                    $iter = map(fromIterable((new Pack())()($iterator)), new LocalSemaphore(32), parallel($parallelCallBack));
 
                     while (wait($iter->advance())) {
                         /** @var array{0: TKey, 1: V} $item */

--- a/src/Operation/AsyncMapN.php
+++ b/src/Operation/AsyncMapN.php
@@ -77,7 +77,7 @@ final class AsyncMapN extends AbstractOperation
                          */
                         static fn (array $value): array => [$value[0], array_reduce($callbacks, $callbackFactory($value[0]), $value[1])];
 
-                    $iter = map(fromIterable(Pack::of()($iterator)), new LocalSemaphore(32), parallel($callback));
+                    $iter = map(fromIterable((new Pack())()($iterator)), new LocalSemaphore(32), parallel($callback));
 
                     while (wait($iter->advance())) {
                         /** @var array{0: mixed, 1: mixed} $item */

--- a/src/Operation/Chunk.php
+++ b/src/Operation/Chunk.php
@@ -43,7 +43,7 @@ final class Chunk extends AbstractOperation
                  */
                 static function (Iterator $iterator) use ($sizes): Generator {
                     /** @var Iterator<int, int> $sizesIterator */
-                    $sizesIterator = Cycle::of()(new ArrayIterator($sizes));
+                    $sizesIterator = (new Cycle())()(new ArrayIterator($sizes));
 
                     $values = [];
 

--- a/src/Operation/Collapse.php
+++ b/src/Operation/Collapse.php
@@ -37,7 +37,7 @@ final class Collapse extends AbstractOperation
             static fn ($value): bool => is_iterable($value);
 
         /** @var Closure(Iterator<TKey, (T|iterable<TKey, T>)>): Generator<TKey, T> $pipe */
-        $pipe = Pipe::of()(
+        $pipe = (new Pipe())()(
             (new Filter())()($filterCallback),
             (new Flatten())()(1),
         );

--- a/src/Operation/Column.php
+++ b/src/Operation/Column.php
@@ -48,11 +48,11 @@ final class Column extends AbstractOperation
                         static fn ($value, $key, Iterator $iterator): bool => $key === $column;
 
                 /** @var Closure(Iterator<TKey, T>): Generator<int, mixed> $pipe */
-                $pipe = Pipe::of()(
-                    Transpose::of(),
+                $pipe = (new Pipe())()(
+                    (new Transpose())(),
                     (new Filter())()($filterCallbackBuilder($column)),
-                    Head::of(),
-                    Flatten::of()(1)
+                    (new Head())(),
+                    (new Flatten())()(1)
                 );
 
                 // Point free style.

--- a/src/Operation/Combine.php
+++ b/src/Operation/Combine.php
@@ -56,8 +56,8 @@ final class Combine extends AbstractOperation
                 /** @var Closure(Iterator<TKey, T>): Generator<null|U, null|T> $pipe */
                 $pipe = Pipe::of()(
                     $buildMultipleIterable($keys),
-                    Flatten::of()(1),
-                    Pair::of(),
+                    (new Flatten())()(1),
+                    (new Pair())(),
                 );
 
                 // Point free style.

--- a/src/Operation/Contains.php
+++ b/src/Operation/Contains.php
@@ -46,7 +46,7 @@ final class Contains extends AbstractOperation
                         static fn ($right): bool => $left === $right;
 
                 /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $matchOne */
-                $matchOne = MatchOne::of()(static fn (): bool => true)(...array_map($callback, $values));
+                $matchOne = (new MatchOne())()(static fn (): bool => true)(...array_map($callback, $values));
 
                 // Point free style.
                 return $matchOne;

--- a/src/Operation/Current.php
+++ b/src/Operation/Current.php
@@ -44,9 +44,9 @@ final class Current extends AbstractOperation
              */
             static function ($default) use ($index): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<int, T|V> $pipe */
-                $pipe = Pipe::of()(
+                $pipe = (new Pipe())()(
                     (new Normalize())(),
-                    Get::of()($index)($default)
+                    (new Get())()($index)($default)
                 );
 
                 // Point free style.

--- a/src/Operation/Every.php
+++ b/src/Operation/Every.php
@@ -80,11 +80,11 @@ final class Every extends AbstractOperation
                                     static fn ($value, $key, Iterator $iterator): bool => $reducer1($value, $key, $iterator) !== $reducer2($value, $key, $iterator);
 
                         /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
-                        $pipe = Pipe::of()(
-                            Map::of()($mapCallback($callbackReducer($callbacks))($callbackReducer($matchers))),
-                            DropWhile::of()(static fn (bool $value): bool => $value),
-                            Append::of()(true),
-                            Head::of(),
+                        $pipe = (new Pipe())()(
+                            (new Map())()($mapCallback($callbackReducer($callbacks))($callbackReducer($matchers))),
+                            (new DropWhile())()(static fn (bool $value): bool => $value),
+                            (new Append())()(true),
+                            (new Head())(),
                         );
 
                         // Point free style.

--- a/src/Operation/Explode.php
+++ b/src/Operation/Explode.php
@@ -37,7 +37,7 @@ final class Explode extends AbstractOperation
              */
             static function (...$explodes): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<int, list<T>> $split */
-                $split = Split::of()(Splitable::REMOVE)(
+                $split = (new Split())()(Splitable::REMOVE)(
                     ...array_map(
                         /**
                          * @param T $explode

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -46,10 +46,10 @@ final class Find extends AbstractOperation
                  */
                 static function (callable ...$callbacks) use ($default): Closure {
                     /** @var Closure(Iterator<TKey, T>): Generator<TKey, T|V> $pipe */
-                    $pipe = Pipe::of()(
+                    $pipe = (new Pipe())()(
                         (new Filter())()(...$callbacks),
-                        Append::of()($default),
-                        Head::of(),
+                        (new Append())()($default),
+                        (new Head())(),
                     );
 
                     // Point free style.

--- a/src/Operation/FlatMap.php
+++ b/src/Operation/FlatMap.php
@@ -39,9 +39,9 @@ final class FlatMap extends AbstractOperation
              */
             static function (callable $callback): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<IKey, IValue> $flatMap */
-                $flatMap = Pipe::of()(
-                    Map::of()($callback),
-                    Flatten::of()(1)
+                $flatMap = (new Pipe())()(
+                    (new Map())()($callback),
+                    (new Flatten())()(1)
                 );
 
                 // Point free style

--- a/src/Operation/FoldLeft.php
+++ b/src/Operation/FoldLeft.php
@@ -44,9 +44,9 @@ final class FoldLeft extends AbstractOperation
                  */
                 static function ($initial = null) use ($callback): Closure {
                     /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
-                    $pipe = Pipe::of()(
-                        ScanLeft::of()($callback)($initial),
-                        Last::of()
+                    $pipe = (new Pipe())()(
+                        (new ScanLeft())()($callback)($initial),
+                        (new Last())()
                     );
 
                     // Point free style.

--- a/src/Operation/FoldLeft1.php
+++ b/src/Operation/FoldLeft1.php
@@ -38,9 +38,9 @@ final class FoldLeft1 extends AbstractOperation
              */
             static function (callable $callback): Closure {
                 /** @var Closure(Iterator<TKey, T>):(Generator<int|TKey, T|null>) $pipe */
-                $pipe = Pipe::of()(
-                    ScanLeft1::of()($callback),
-                    Last::of()
+                $pipe = (new Pipe())()(
+                    (new ScanLeft1())()($callback),
+                    (new Last())()
                 );
 
                 // Point free style.

--- a/src/Operation/FoldRight.php
+++ b/src/Operation/FoldRight.php
@@ -38,9 +38,9 @@ final class FoldRight extends AbstractOperation
              */
             static fn (callable $callback): Closure => static function ($initial = null) use ($callback): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
-                $pipe = Pipe::of()(
-                    ScanRight::of()($callback)($initial),
-                    Head::of()
+                $pipe = (new Pipe())()(
+                    (new ScanRight())()($callback)($initial),
+                    (new Head())()
                 );
 
                 // Point free style.

--- a/src/Operation/FoldRight1.php
+++ b/src/Operation/FoldRight1.php
@@ -38,9 +38,9 @@ final class FoldRight1 extends AbstractOperation
              */
             static function (callable $callback): Closure {
                 /** @var Closure(Iterator<TKey, T>):(Generator<int|TKey, T|null>) $pipe */
-                $pipe = Pipe::of()(
-                    ScanRight1::of()($callback),
-                    Head::of()
+                $pipe = (new Pipe())()(
+                    (new ScanRight1())()($callback),
+                    (new Head())()
                 );
 
                 // Point free style.

--- a/src/Operation/Get.php
+++ b/src/Operation/Get.php
@@ -51,10 +51,10 @@ final class Get extends AbstractOperation
                         static fn ($value, $key): bool => $key === $keyToGet;
 
                     /** @var Closure(Iterator<TKey, T>): (Generator<TKey, T|V>) $pipe */
-                    $pipe = Pipe::of()(
+                    $pipe = (new Pipe())()(
                         (new Filter())()($filterCallback),
-                        Append::of()($default),
-                        Head::of()
+                        (new Append())()($default),
+                        (new Head())()
                     );
 
                     // Point free style.

--- a/src/Operation/GroupBy.php
+++ b/src/Operation/GroupBy.php
@@ -60,9 +60,9 @@ final class GroupBy extends AbstractOperation
                         };
 
                 /** @var Closure(Iterator<TKey, T>): Generator<NewTKey, non-empty-list<T>> $pipe */
-                $pipe = Pipe::of()(
-                    Reduce::of()($reducerFactory($callable))([]),
-                    Flatten::of()(1)
+                $pipe = (new Pipe())()(
+                    (new Reduce())()($reducerFactory($callable))([]),
+                    (new Flatten())()(1)
                 );
 
                 // Point free style.

--- a/src/Operation/Has.php
+++ b/src/Operation/Has.php
@@ -38,7 +38,7 @@ final class Has extends AbstractOperation
              */
             static function (callable ...$callbacks): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
-                $pipe = MatchOne::of()(static fn (): bool => true)(
+                $pipe = (new MatchOne())()(static fn (): bool => true)(
                     ...array_map(
                         static fn (callable $callback): callable =>
                             /**

--- a/src/Operation/IfThenElse.php
+++ b/src/Operation/IfThenElse.php
@@ -50,7 +50,7 @@ final class IfThenElse extends AbstractOperation
                      */
                     static function (callable $else) use ($condition, $then): Closure {
                         /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $map */
-                        $map = Map::of()(
+                        $map = (new Map())()(
                             /**
                              * @param T $value
                              * @param TKey $key

--- a/src/Operation/Implode.php
+++ b/src/Operation/Implode.php
@@ -42,10 +42,10 @@ final class Implode extends AbstractOperation
                     static fn (string $carry, $item): string => $carry .= $item;
 
                 /** @var Closure(Iterator<TKey, T>): Generator<TKey, string> $pipe */
-                $pipe = Pipe::of()(
-                    Intersperse::of()($glue)(1)(0),
-                    Drop::of()(1),
-                    Reduce::of()($reducer)('')
+                $pipe = (new Pipe())()(
+                    (new Intersperse())()($glue)(1)(0),
+                    (new Drop())()(1),
+                    (new Reduce())()($reducer)('')
                 );
 
                 // Point free style.

--- a/src/Operation/Key.php
+++ b/src/Operation/Key.php
@@ -34,9 +34,9 @@ final class Key extends AbstractOperation
              */
             static function (int $index): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<int, TKey> $pipe */
-                $pipe = Pipe::of()(
-                    Limit::of()(1)($index),
-                    Flip::of()
+                $pipe = (new Pipe())()(
+                    (new Limit())()(1)($index),
+                    (new Flip())()
                 );
 
                 // Point free style.

--- a/src/Operation/Map.php
+++ b/src/Operation/Map.php
@@ -28,7 +28,7 @@ final class Map extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): V): Closure(Iterator<TKey, T>): Generator<TKey, V>
+     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): mixed): Closure(Iterator<TKey, T>): Generator<TKey, mixed>
      */
     public function __invoke(): Closure
     {

--- a/src/Operation/MatchOne.php
+++ b/src/Operation/MatchOne.php
@@ -46,8 +46,8 @@ final class MatchOne extends AbstractOperation
                      */
                     static function (callable ...$callbacks) use ($matchers): Closure {
                         /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
-                        $pipe = Pipe::of()(
-                            Map::of()(
+                        $pipe = (new Pipe())()(
+                            (new Map())()(
                                 /**
                                  * @param T $value
                                  * @param TKey $key
@@ -55,9 +55,9 @@ final class MatchOne extends AbstractOperation
                                  */
                                 static fn ($value, $key, Iterator $iterator): bool => CallbacksArrayReducer::or()($callbacks, $value, $key, $iterator) === CallbacksArrayReducer::or()($matchers, $value, $key, $iterator)
                             ),
-                            DropWhile::of()(static fn (bool $value): bool => !$value),
-                            Append::of()(false),
-                            Head::of()
+                            (new DropWhile())()(static fn (bool $value): bool => !$value),
+                            (new Append())()(false),
+                            (new Head())()
                         );
 
                         // Point free style.

--- a/src/Operation/Nth.php
+++ b/src/Operation/Nth.php
@@ -44,10 +44,10 @@ final class Nth extends AbstractOperation
                         static fn (array $value, int $key): bool => (($key % $step) === $offset);
 
                     /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
-                    $pipe = Pipe::of()(
-                        Pack::of(),
+                    $pipe = (new Pipe())()(
+                        (new Pack())(),
                         (new Filter())()($filterCallback),
-                        Unpack::of()
+                        (new Unpack())()
                     );
 
                     // Point free style.

--- a/src/Operation/Product.php
+++ b/src/Operation/Product.php
@@ -39,7 +39,7 @@ final class Product extends AbstractOperation
              */
             static function (iterable ...$iterables): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<int, list<T|U>> $pipe */
-                $pipe = Pipe::of()(
+                $pipe = (new Pipe())()(
                     (
                         /**
                          * @param list<Iterator<UKey, U>> $iterables

--- a/src/Operation/Random.php
+++ b/src/Operation/Random.php
@@ -39,9 +39,9 @@ final class Random extends AbstractOperation
                      */
                     static function (int $size) use ($seed): Closure {
                         /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
-                        $pipe = Pipe::of()(
-                            Shuffle::of()($seed),
-                            Limit::of()($size)(0)
+                        $pipe = (new Pipe())()(
+                            (new Shuffle())()($seed),
+                            (new Limit())()($size)(0)
                         );
 
                         // Point free style.

--- a/src/Operation/Reduce.php
+++ b/src/Operation/Reduce.php
@@ -47,9 +47,9 @@ final class Reduce extends AbstractOperation
                  */
                 static function ($initial) use ($callback): Closure {
                     /** @var Closure(Iterator<TKey, T>): Generator<TKey, W> $pipe */
-                    $pipe = Pipe::of()(
+                    $pipe = (new Pipe())()(
                         (new Reduction())()($callback)($initial),
-                        Last::of(),
+                        (new Last())(),
                     );
 
                     // Point free style.

--- a/src/Operation/Scale.php
+++ b/src/Operation/Scale.php
@@ -56,7 +56,7 @@ final class Scale extends AbstractOperation
                                 $wantedLowerBound = (0.0 === $wantedLowerBound) ? (0.0 === $base ? 0.0 : 1.0) : $wantedLowerBound;
                                 $wantedUpperBound = (1.0 === $wantedUpperBound) ? (0.0 === $base ? 1.0 : $base) : $wantedUpperBound;
                                 /** @var callable(Generator<TKey, (float | int)>):Generator<TKey, float> $mapper */
-                                $mapper = Map::of()(
+                                $mapper = (new Map())()(
                                     /**
                                      * @param float|int $v
                                      */

--- a/src/Operation/ScanLeft.php
+++ b/src/Operation/ScanLeft.php
@@ -29,7 +29,7 @@ final class ScanLeft extends AbstractOperation
      * @template V
      * @template W
      *
-     * @return Closure(callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W): Closure(V): Closure(Iterator<TKey, T>): Generator<int|TKey, V|W>
+     * @return Closure(callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed): Closure(mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
@@ -47,9 +47,9 @@ final class ScanLeft extends AbstractOperation
                  */
                 static function ($initial) use ($callback): Closure {
                     /** @var Closure(Iterator<TKey, T>): Generator<int|TKey, V|W> $pipe */
-                    $pipe = Pipe::of()(
-                        Reduction::of()($callback)($initial),
-                        Prepend::of()($initial)
+                    $pipe = (new Pipe())()(
+                        (new Reduction())()($callback)($initial),
+                        (new Prepend())()($initial)
                     );
 
                     return $pipe;

--- a/src/Operation/ScanLeft1.php
+++ b/src/Operation/ScanLeft1.php
@@ -28,7 +28,7 @@ final class ScanLeft1 extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(callable(T|V, T, TKey, Iterator<TKey, T>): V): Closure(Iterator<TKey, T>): Generator<int|TKey, T|V>
+     * @return Closure(callable(mixed, T, TKey, Iterator<TKey, T>): mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
@@ -48,10 +48,10 @@ final class ScanLeft1 extends AbstractOperation
                     $initial = $iterator->current();
 
                     /** @var Closure(Iterator<TKey, T>): Generator<int|TKey, T|V> $pipe */
-                    $pipe = Pipe::of()(
-                        Tail::of(),
-                        Reduction::of()($callback)($initial),
-                        Prepend::of()($initial)
+                    $pipe = (new Pipe())()(
+                        (new Tail())(),
+                        (new Reduction())()($callback)($initial),
+                        (new Prepend())()($initial)
                     );
 
                     return $pipe($iterator);

--- a/src/Operation/ScanRight.php
+++ b/src/Operation/ScanRight.php
@@ -29,7 +29,7 @@ final class ScanRight extends AbstractOperation
      * @template V
      * @template W
      *
-     * @return Closure(callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W): Closure(V): Closure(Iterator<TKey, T>): Generator<int|TKey, V|W>
+     * @return Closure(callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed): Closure(mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
@@ -47,11 +47,11 @@ final class ScanRight extends AbstractOperation
                  */
                 static function ($initial) use ($callback): Closure {
                     /** @var Closure(Iterator<TKey, T>):(Generator<int|TKey, V|W>) $pipe */
-                    $pipe = Pipe::of()(
-                        Reverse::of(),
-                        Reduction::of()($callback)($initial),
-                        Reverse::of(),
-                        Append::of()($initial)
+                    $pipe = (new Pipe())()(
+                        (new Reverse())(),
+                        (new Reduction())()($callback)($initial),
+                        (new Reverse())(),
+                        (new Append())()($initial)
                     );
 
                     // Point free style.

--- a/src/Operation/ScanRight1.php
+++ b/src/Operation/ScanRight1.php
@@ -28,7 +28,7 @@ final class ScanRight1 extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(callable(T|V, T, TKey, Iterator<TKey, T>): V): Closure(Iterator<TKey, T>): Generator<int|TKey, T|V>
+     * @return Closure(callable(mixed, T, TKey, Iterator<TKey, T>): mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
@@ -40,10 +40,10 @@ final class ScanRight1 extends AbstractOperation
              */
             static function (callable $callback): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<TKey, T|V> $pipe */
-                $pipe = Pipe::of()(
-                    Reverse::of(),
-                    ScanLeft1::of()($callback),
-                    Reverse::of()
+                $pipe = (new Pipe())()(
+                    (new Reverse())(),
+                    (new ScanLeft1())()($callback),
+                    (new Reverse())()
                 );
 
                 // Point free style.

--- a/src/Operation/Slice.php
+++ b/src/Operation/Slice.php
@@ -38,16 +38,16 @@ final class Slice extends AbstractOperation
                  */
                 static function (int $length = -1) use ($offset): Closure {
                     /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $skip */
-                    $skip = Drop::of()($offset);
+                    $skip = (new Drop())()($offset);
 
                     if (-1 === $length) {
                         return $skip;
                     }
 
                     /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
-                    $pipe = Pipe::of()(
+                    $pipe = (new Pipe())()(
                         $skip,
-                        Limit::of()($length)(0)
+                        (new Limit())()($length)(0)
                     );
 
                     // Point free style.

--- a/src/Operation/Tails.php
+++ b/src/Operation/Tails.php
@@ -37,11 +37,11 @@ final class Tails extends AbstractOperation
              */
             static function (Iterator $iterator): Generator {
                 /** @var Iterator<int, array{0: TKey, 1: T}> $iterator */
-                $iterator = Pack::of()($iterator);
+                $iterator = (new Pack())()($iterator);
                 $data = [...$iterator];
 
                 while ([] !== $data) {
-                    yield [...Unpack::of()(new ArrayIterator($data))];
+                    yield [...(new Unpack())()(new ArrayIterator($data))];
 
                     array_shift($data);
                 }

--- a/src/Operation/Unpack.php
+++ b/src/Operation/Unpack.php
@@ -21,22 +21,19 @@ use Traversable;
 /**
  * @immutable
  *
- * @template NewTKey
- * @template NewT
- *
  * @template TKey
- * @template T of array{0: NewTKey, 1: NewT}
+ * @template T
  */
 final class Unpack extends AbstractOperation
 {
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
+     * @return Closure(Iterator<mixed, mixed>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, T>): Generator<NewTKey, NewT> $pipe */
+        /** @var Closure(Iterator<array-key, array{0: TKey, 1: T}>): Generator<TKey, T> $pipe */
         $pipe = Pipe::of()(
             Map::of()(static fn (iterable $iterable): Iterator => (new IterableIteratorAggregate($iterable))->getIterator()),
             Map::of()(Chunk::of()(2)),

--- a/src/Operation/Window.php
+++ b/src/Operation/Window.php
@@ -36,7 +36,7 @@ final class Window extends AbstractOperation
              */
             static function (int $size): Closure {
                 /** @var Closure(Iterator<TKey, T>): Generator<TKey, list<T>> $reduction */
-                $reduction = Reduction::of()(
+                $reduction = (new Reduction())()(
                     /**
                      * @param list<T> $stack
                      * @param T $current

--- a/tests/static-analysis/map.php
+++ b/tests/static-analysis/map.php
@@ -65,7 +65,15 @@ map_checkListString(Collection::fromIterable([1, 2, 3])->map($square)->map($toSt
 
 // VALID failures due to usage with wrong types
 
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/**
+ * @psalm-suppress InvalidArgument
+ * @psalm-suppress InvalidScalarArgument
+ * @phpstan-ignore-next-line
+ */
 map_checkListInt(Collection::fromIterable(['foo' => 'bar'])->map($square));
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/**
+ * @psalm-suppress InvalidArgument
+ * @psalm-suppress InvalidScalarArgument
+ * @phpstan-ignore-next-line
+ */
 map_checkMapString(Collection::fromIterable([1, 2, 3])->map($appendBar));


### PR DESCRIPTION
## Motivation

There are multiple goals behind this PR.

First, is to get rid of `AbstractOperation`. Its sole purpose is to provide the static method `of`, which is just syntactic sugar.
Syntactic sugar is cool, but it's not needed in Collection. We could gain some performance by completely removing them.

Then, by removing it and instantiating operation using `new` could also be a good thing for static analysis and types inference.

## Note

When dealing with methods having the `@pure` annotation, using the keyword `new` to create operation will trigger an `ImpureFunctionCall` in PSalm.

However, when having nested functions in those methods, using the `new` keyword, will not trigger an `ImpureFunctionCall` in PSalm.


This PR:

* [x] Use the `new` keyword instead of using the static method `of()`.
* [x] PSalm score is now 97% :tada: 

