### PR TITLE
Performance improvements using iterator aggregates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "loophp/iterators": "^1.5.13"
+        "loophp/iterators": "^1.5"
     },
     "require-dev": {
         "amphp/parallel-functions": "^1",

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Contract;
 
 use Countable;
-use Iterator;
 use IteratorAggregate;
 use JsonSerializable;
 use loophp\collection\Contract\Operation\Allable;
@@ -129,6 +128,7 @@ use loophp\collection\Contract\Operation\Windowable;
 use loophp\collection\Contract\Operation\Wordsable;
 use loophp\collection\Contract\Operation\Wrapable;
 use loophp\collection\Contract\Operation\Zipable;
+use Traversable;
 
 /**
  * @immutable
@@ -374,7 +374,7 @@ interface Collection extends
     Zipable
 {
     /**
-     * @return Iterator<TKey, T>
+     * @return Traversable<TKey, T>
      */
-    public function getIterator(): Iterator;
+    public function getIterator(): Traversable;
 }

--- a/src/Contract/Operation/Applyable.php
+++ b/src/Contract/Operation/Applyable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -25,7 +24,7 @@ interface Applyable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#apply
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
      *
      * @return Collection<TKey, T>
      */

--- a/src/Contract/Operation/Equalsable.php
+++ b/src/Contract/Operation/Equalsable.php
@@ -27,7 +27,7 @@ interface Equalsable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#equals
      *
-     * @param Collection<TKey, T> $other
+     * @param iterable<TKey, T> $other
      */
-    public function equals(Collection $other): bool;
+    public function equals(iterable $other): bool;
 }

--- a/src/Contract/Operation/Everyable.php
+++ b/src/Contract/Operation/Everyable.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
-
 /**
  * @template TKey
  * @template T
@@ -22,7 +20,7 @@ interface Everyable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#every
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
      */
     public function every(callable ...$callbacks): bool;
 }

--- a/src/Contract/Operation/Filterable.php
+++ b/src/Contract/Operation/Filterable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -23,7 +22,7 @@ interface Filterable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#filter
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
      *
      * @return Collection<TKey, T>
      */

--- a/src/Contract/Operation/Findable.php
+++ b/src/Contract/Operation/Findable.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
-
 /**
  * @template TKey
  * @template T
@@ -26,7 +24,7 @@ interface Findable
      * @template V
      *
      * @param V $default
-     * @param (callable(T=, TKey=, Iterator<TKey, T>=): bool) ...$callbacks
+     * @param (callable(T=, TKey=, iterable<TKey, T>=): bool) ...$callbacks
      *
      * @return T|V
      */

--- a/src/Contract/Operation/FlatMapable.php
+++ b/src/Contract/Operation/FlatMapable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -27,7 +26,7 @@ interface FlatMapable
      * @template IKey
      * @template IValue
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): iterable<IKey, IValue> $callback
+     * @param callable(T=, TKey=, iterable<TKey, T>=): iterable<IKey, IValue> $callback
      *
      * @return Collection<IKey, IValue>
      */

--- a/src/Contract/Operation/FoldLeftable.php
+++ b/src/Contract/Operation/FoldLeftable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -24,7 +23,7 @@ interface FoldLeftable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#foldleft
      *
-     * @param callable(T, T, TKey, Iterator<TKey, T>): T $callback
+     * @param callable(T, T, TKey, iterable<TKey, T>): T $callback
      * @param T|null $initial
      *
      * @return Collection<TKey, T|null>

--- a/src/Contract/Operation/FoldRightable.php
+++ b/src/Contract/Operation/FoldRightable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -24,7 +23,7 @@ interface FoldRightable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#foldright
      *
-     * @param callable(T, T, TKey, Iterator<TKey, T>): T $callback
+     * @param callable(T, T, TKey, iterable<TKey, T>): T $callback
      * @param T|null $initial
      *
      * @return Collection<TKey, T|null>

--- a/src/Contract/Operation/Hasable.php
+++ b/src/Contract/Operation/Hasable.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
-
 /**
  * @template TKey
  * @template T
@@ -22,7 +20,7 @@ interface Hasable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#has
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): T ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): T ...$callbacks
      */
     public function has(callable ...$callbacks): bool;
 }

--- a/src/Contract/Operation/MapNable.php
+++ b/src/Contract/Operation/MapNable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -23,7 +22,7 @@ interface MapNable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#mapn
      *
-     * @param callable(mixed, mixed, Iterator<TKey, T>): mixed ...$callbacks
+     * @param callable(mixed, mixed, iterable<TKey, T>): mixed ...$callbacks
      *
      * @return Collection<mixed, mixed>
      */

--- a/src/Contract/Operation/Matchable.php
+++ b/src/Contract/Operation/Matchable.php
@@ -30,8 +30,8 @@ interface Matchable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#match
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool $callback
-     * @param null|callable(T=, TKey=, Iterator<TKey, T>=): bool $matcher
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool $callback
+     * @param null|callable(T=, TKey=, iterable<TKey, T>=): bool $matcher
      */
     public function match(callable $callback, ?callable $matcher = null): bool;
 }

--- a/src/Contract/Operation/Partitionable.php
+++ b/src/Contract/Operation/Partitionable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -26,7 +25,7 @@ interface Partitionable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#partition
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
      *
      * @return Collection<int, Collection<TKey, T>>
      */

--- a/src/Contract/Operation/Reduceable.php
+++ b/src/Contract/Operation/Reduceable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -26,7 +25,7 @@ interface Reduceable
      * @template V
      * @template W
      *
-     * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
+     * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
      * @param V $initial
      *
      * @return Collection<TKey, W>

--- a/src/Contract/Operation/Reductionable.php
+++ b/src/Contract/Operation/Reductionable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -26,7 +25,7 @@ interface Reductionable
      * @template V
      * @template W
      *
-     * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
+     * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
      * @param V $initial
      *
      * @return Collection<TKey, W>

--- a/src/Contract/Operation/Rejectable.php
+++ b/src/Contract/Operation/Rejectable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -23,7 +22,7 @@ interface Rejectable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#reject
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
      *
      * @return Collection<TKey, T>
      */

--- a/src/Contract/Operation/Sameable.php
+++ b/src/Contract/Operation/Sameable.php
@@ -32,8 +32,8 @@ interface Sameable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#same
      *
-     * @param Collection<TKey, T> $other
+     * @param iterable<TKey, T> $other
      * @param null|callable(T, TKey): (Closure(T, TKey): bool) $comparatorCallback
      */
-    public function same(Collection $other, ?callable $comparatorCallback = null): bool;
+    public function same(iterable $other, ?callable $comparatorCallback = null): bool;
 }

--- a/src/Contract/Operation/ScanLeftable.php
+++ b/src/Contract/Operation/ScanLeftable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -25,7 +24,7 @@ interface ScanLeftable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanleft
      *
-     * @param callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed $callback
+     * @param callable(mixed=, T=, TKey=, iterable<TKey, T>=): mixed $callback
      * @param mixed $initial
      *
      * @return Collection<int|TKey, mixed>

--- a/src/Contract/Operation/ScanRightable.php
+++ b/src/Contract/Operation/ScanRightable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -25,7 +24,7 @@ interface ScanRightable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanright
      *
-     * @param callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed $callback
+     * @param callable(mixed=, T=, TKey=, iterable<TKey, T>=): mixed $callback
      * @param mixed $initial
      *
      * @return Collection<int|TKey, mixed>

--- a/src/Contract/Operation/Spanable.php
+++ b/src/Contract/Operation/Spanable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -27,7 +26,7 @@ interface Spanable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#span
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
      *
      * @return Collection<int, Collection<TKey, T>>
      */

--- a/src/Contract/Operation/TakeWhileable.php
+++ b/src/Contract/Operation/TakeWhileable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -24,7 +23,7 @@ interface TakeWhileable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#takewhile
      *
-     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
      *
      * @return Collection<TKey, T>
      */

--- a/src/Contract/Operation/Whenable.php
+++ b/src/Contract/Operation/Whenable.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Contract\Operation;
 
-use Iterator;
 use loophp\collection\Contract\Collection;
 
 /**
@@ -27,9 +26,9 @@ interface Whenable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#when
      *
-     * @param callable(Iterator<TKey, T>): bool $predicate
-     * @param callable(Iterator<TKey, T>): iterable<TKey, T> $whenTrue
-     * @param callable(Iterator<TKey, T>): iterable<TKey, T> $whenFalse
+     * @param callable(iterable<TKey, T>): bool $predicate
+     * @param callable(iterable<TKey, T>): iterable<TKey, T> $whenTrue
+     * @param callable(iterable<TKey, T>): iterable<TKey, T> $whenFalse
      *
      * @return Collection<TKey, T>
      */

--- a/src/Operation/All.php
+++ b/src/Operation/All.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
 
 /**
  * @immutable
@@ -23,20 +22,20 @@ final class All extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(bool): Closure(Iterator<TKey, T>): Iterator<int, T>|Iterator<TKey, T>
+     * @return Closure(bool): Closure(iterable<TKey, T>): iterable<int, T>|iterable<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Iterator<int, T>|Iterator<TKey, T>
+             * @return Closure(iterable<TKey, T>): iterable<int, T>|iterable<TKey, T>
              */
             static fn (bool $normalize): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
-                 * @return Iterator<int, T>|Iterator<TKey, T>
+                 * @return iterable<int, T>|iterable<TKey, T>
                  */
-                static fn (Iterator $iterator): Iterator => $normalize ? (new Normalize())()($iterator) : $iterator;
+                static fn (iterable $iterable): iterable => $normalize ? (new Normalize())()($iterable) : $iterable;
     }
 }

--- a/src/Operation/Append.php
+++ b/src/Operation/Append.php
@@ -38,7 +38,7 @@ final class Append extends AbstractOperation
              */
             static fn (...$items): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<int|TKey, T>
                  */

--- a/src/Operation/Apply.php
+++ b/src/Operation/Apply.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,26 +25,26 @@ final class Apply extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=):bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=):bool ...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable ...$callbacks): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<TKey, T>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
-                    foreach ($iterator as $key => $value) {
+                static function (iterable $iterable) use ($callbacks): Generator {
+                    foreach ($iterable as $key => $value) {
                         foreach ($callbacks as $cKey => $callback) {
-                            $result = $callback($value, $key, $iterator);
+                            $result = $callback($value, $key, $iterable);
 
                             if (false === $result) {
                                 unset($callbacks[$cKey]);

--- a/src/Operation/Associate.php
+++ b/src/Operation/Associate.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,31 +28,31 @@ final class Associate extends AbstractOperation
      * @template NewTKey
      * @template NewT
      *
-     * @return Closure(callable(mixed=, mixed=, Iterator<mixed, mixed>=): mixed): Closure(callable(mixed=, mixed=, Iterator<mixed, mixed>=): mixed): Closure(Iterator<mixed, mixed>): Generator<mixed, mixed>
+     * @return Closure(callable(mixed=, mixed=, iterable<mixed, mixed>=): mixed): Closure(callable(mixed=, mixed=, iterable<mixed, mixed>=): mixed): Closure(iterable<mixed, mixed>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(TKey=, T=, Iterator<TKey, T>=): NewTKey $callbackForKeys
+             * @param callable(TKey=, T=, iterable<TKey, T>=): NewTKey $callbackForKeys
              *
-             * @return Closure((callable(T=, TKey=, Iterator<TKey, T>=): NewT)): Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
+             * @return Closure((callable(T=, TKey=, iterable<TKey, T>=): NewT)): Closure(iterable<TKey, T>): Generator<NewTKey, NewT>
              */
             static fn (callable $callbackForKeys): Closure =>
                 /**
-                 * @param callable(T=, TKey=, Iterator<TKey, T>=): NewT $callbackForValues
+                 * @param callable(T=, TKey=, iterable<TKey, T>=): NewT $callbackForValues
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<NewTKey, NewT>
+                 * @return Closure(iterable<TKey, T>): Generator<NewTKey, NewT>
                  */
                 static fn (callable $callbackForValues): Closure =>
                     /**
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      *
                      * @return Generator<NewTKey, NewT>
                      */
-                    static function (Iterator $iterator) use ($callbackForKeys, $callbackForValues): Generator {
-                        foreach ($iterator as $key => $value) {
-                            yield $callbackForKeys($key, $value, $iterator) => $callbackForValues($value, $key, $iterator);
+                    static function (iterable $iterable) use ($callbackForKeys, $callbackForValues): Generator {
+                        foreach ($iterable as $key => $value) {
+                            yield $callbackForKeys($key, $value, $iterable) => $callbackForValues($value, $key, $iterable);
                         }
                     };
     }

--- a/src/Operation/AsyncMapN.php
+++ b/src/Operation/AsyncMapN.php
@@ -13,7 +13,6 @@ use Amp\Sync\LocalSemaphore;
 use Closure;
 use Exception;
 use Generator;
-use Iterator;
 
 use function Amp\Iterator\fromIterable;
 use function Amp\ParallelFunctions\parallel;
@@ -39,7 +38,7 @@ final class AsyncMapN extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(mixed, mixed): mixed ...): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
+     * @return Closure(callable(mixed, mixed): mixed ...): Closure(iterable<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure
     {
@@ -49,11 +48,11 @@ final class AsyncMapN extends AbstractOperation
              */
             static fn (callable ...$callbacks): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<mixed, mixed>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
+                static function (iterable $iterable) use ($callbacks): Generator {
                     $callbackFactory =
                         /**
                          * @param mixed $key
@@ -77,7 +76,7 @@ final class AsyncMapN extends AbstractOperation
                          */
                         static fn (array $value): array => [$value[0], array_reduce($callbacks, $callbackFactory($value[0]), $value[1])];
 
-                    $iter = map(fromIterable((new Pack())()($iterator)), new LocalSemaphore(32), parallel($callback));
+                    $iter = map(fromIterable((new Pack())()($iterable)), new LocalSemaphore(32), parallel($callback));
 
                     while (wait($iter->advance())) {
                         /** @var array{0: mixed, 1: mixed} $item */

--- a/src/Operation/Cache.php
+++ b/src/Operation/Cache.php
@@ -10,8 +10,9 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
+use Generator;
 use loophp\collection\Iterator\PsrCacheIterator;
+use loophp\iterators\IterableIteratorAggregate;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -27,20 +28,20 @@ final class Cache extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(CacheItemPoolInterface): Closure(Iterator<TKey, T>): Iterator<TKey, T>
+     * @return Closure(CacheItemPoolInterface): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (CacheItemPoolInterface $cache): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
-                 * @return Iterator<TKey, T>
+                 * @return Generator<TKey, T>
                  */
-                static fn (Iterator $iterator): Iterator => new PsrCacheIterator($iterator, $cache);
+                static fn (iterable $iterable): Generator => yield from new PsrCacheIterator((new IterableIteratorAggregate($iterable))->getIterator(), $cache);
     }
 }

--- a/src/Operation/Chunk.php
+++ b/src/Operation/Chunk.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace loophp\collection\Operation;
 
-use ArrayIterator;
 use Closure;
 use Generator;
 use Iterator;
@@ -27,27 +26,27 @@ final class Chunk extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int...): Closure(Iterator<TKey, T>): Generator<int, list<T>>
+     * @return Closure(int...): Closure(iterable<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<int, list<T>>
+             * @return Closure(iterable<TKey, T>): Generator<int, list<T>>
              */
             static fn (int ...$sizes): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<int, list<T>>
                  */
-                static function (Iterator $iterator) use ($sizes): Generator {
+                static function (iterable $iterable) use ($sizes): Generator {
                     /** @var Iterator<int, int> $sizesIterator */
-                    $sizesIterator = (new Cycle())()(new ArrayIterator($sizes));
+                    $sizesIterator = (new Cycle())()($sizes);
 
                     $values = [];
 
-                    foreach ($iterator as $value) {
+                    foreach ($iterable as $value) {
                         $size = $sizesIterator->current();
 
                         if (0 >= $size) {

--- a/src/Operation/Coalesce.php
+++ b/src/Operation/Coalesce.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,11 +23,11 @@ final class Coalesce extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
         $pipe = Pipe::of()(
             Compact::of()(),
             Head::of(),

--- a/src/Operation/Collapse.php
+++ b/src/Operation/Collapse.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,7 +25,7 @@ final class Collapse extends AbstractOperation
      *
      * @psalm-suppress ImpureFunctionCall - using Filter and Flatten as an internal tools, not returned.
      *
-     * @return Closure(Iterator<TKey, (T|iterable<TKey, T>)>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, (T|iterable<TKey, T>)>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -36,7 +35,7 @@ final class Collapse extends AbstractOperation
              */
             static fn ($value): bool => is_iterable($value);
 
-        /** @var Closure(Iterator<TKey, (T|iterable<TKey, T>)>): Generator<TKey, T> $pipe */
+        /** @var Closure(iterable<TKey, (T|iterable<TKey, T>)>): Generator<TKey, T> $pipe */
         $pipe = (new Pipe())()(
             (new Filter())()($filterCallback),
             (new Flatten())()(1),

--- a/src/Operation/Column.php
+++ b/src/Operation/Column.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Column extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(mixed): Closure(Iterator<TKey, T>): Generator<int, mixed>
+     * @return Closure(mixed): Closure(iterable<TKey, T>): Generator<int, mixed>
      */
     public function __invoke(): Closure
     {
@@ -32,7 +31,7 @@ final class Column extends AbstractOperation
             /**
              * @param mixed $column
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int, mixed>
+             * @return Closure(iterable<TKey, T>): Generator<int, mixed>
              */
             static function ($column): Closure {
                 $filterCallbackBuilder =
@@ -43,11 +42,10 @@ final class Column extends AbstractOperation
                         /**
                          * @param T $value
                          * @param TKey $key
-                         * @param Iterator<TKey, T> $iterator
                          */
-                        static fn ($value, $key, Iterator $iterator): bool => $key === $column;
+                        static fn ($value, $key): bool => $key === $column;
 
-                /** @var Closure(Iterator<TKey, T>): Generator<int, mixed> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<int, mixed> $pipe */
                 $pipe = (new Pipe())()(
                     (new Transpose())(),
                     (new Filter())()($filterCallbackBuilder($column)),

--- a/src/Operation/Combinate.php
+++ b/src/Operation/Combinate.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function array_slice;
 use function count;
@@ -55,12 +54,12 @@ final class Combinate extends AbstractOperation
 
             return
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<int, array<int, T>>
                  */
-                static function (Iterator $iterator) use ($length, $getCombinations): Generator {
-                    $dataset = [...$iterator];
+                static function (iterable $iterable) use ($length, $getCombinations): Generator {
+                    $dataset = [...$iterable];
 
                     if (0 < $length) {
                         return yield from $getCombinations($dataset, $length);

--- a/src/Operation/Combine.php
+++ b/src/Operation/Combine.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\iterators\MultipleIterableAggregate;
 use MultipleIterator;
 
@@ -30,7 +29,7 @@ final class Combine extends AbstractOperation
      *
      * @template U
      *
-     * @return Closure(U...): Closure(Iterator<TKey, T>): Generator<null|U, null|T>
+     * @return Closure(U...): Closure(iterable<TKey, T>): Generator<null|U, null|T>
      */
     public function __invoke(): Closure
     {
@@ -38,7 +37,7 @@ final class Combine extends AbstractOperation
             /**
              * @param U ...$keys
              *
-             * @return Closure(Iterator<TKey, T>): Generator<null|U, null|T>
+             * @return Closure(iterable<TKey, T>): Generator<null|U, null|T>
              */
             static function (...$keys): Closure {
                 $buildMultipleIterable =
@@ -47,14 +46,14 @@ final class Combine extends AbstractOperation
                      */
                     static fn (array $keys): Closure =>
                         /**
-                         * @param Iterator<TKey, T> $iterator
+                         * @param iterable<TKey, T> $iterable
                          *
-                         * @return iterable
+                         * @return Generator
                          */
-                        static fn (Iterator $iterator): iterable => yield from new MultipleIterableAggregate([$keys, $iterator], MultipleIterator::MIT_NEED_ANY);
+                        static fn (iterable $iterable): Generator => yield from new MultipleIterableAggregate([$keys, $iterable], MultipleIterator::MIT_NEED_ANY);
 
-                /** @var Closure(Iterator<TKey, T>): Generator<null|U, null|T> $pipe */
-                $pipe = Pipe::of()(
+                /** @var Closure(iterable<TKey, T>): Generator<null|U, null|T> $pipe */
+                $pipe = (new Pipe())()(
                     $buildMultipleIterable($keys),
                     (new Flatten())()(1),
                     (new Pair())(),

--- a/src/Operation/Compact.php
+++ b/src/Operation/Compact.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function in_array;
 
@@ -28,7 +27,7 @@ final class Compact extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(T...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -36,7 +35,7 @@ final class Compact extends AbstractOperation
             /**
              * @param T ...$values
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$values): Closure {
                 $filterCallback =

--- a/src/Operation/Contains.php
+++ b/src/Operation/Contains.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Contains extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T ...$values): Closure(Iterator<TKey, T>): Generator<TKey, bool>
+     * @return Closure(T ...$values): Closure(iterable<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
@@ -32,7 +31,7 @@ final class Contains extends AbstractOperation
             /**
              * @param T ...$values
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, bool>
              */
             static function (...$values): Closure {
                 $callback =
@@ -45,7 +44,7 @@ final class Contains extends AbstractOperation
                          */
                         static fn ($right): bool => $left === $right;
 
-                /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $matchOne */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, bool> $matchOne */
                 $matchOne = (new MatchOne())()(static fn (): bool => true)(...array_map($callback, $values));
 
                 // Point free style.

--- a/src/Operation/Current.php
+++ b/src/Operation/Current.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,7 +25,7 @@ final class Current extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(TKey): Closure(V): Closure(Iterator<TKey, T>): Generator<int, T|V>
+     * @return Closure(TKey): Closure(V): Closure(iterable<TKey, T>): Generator<int, T|V>
      */
     public function __invoke(): Closure
     {
@@ -34,16 +33,16 @@ final class Current extends AbstractOperation
             /**
              * @param TKey $index
              *
-             * @return Closure(V): Closure(Iterator<TKey, T>): Generator<int, T|V>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<int, T|V>
              */
             static fn (int $index): Closure =>
             /**
              * @param V $default
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int, T|V>
+             * @return Closure(iterable<TKey, T>): Generator<int, T|V>
              */
             static function ($default) use ($index): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<int, T|V> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<int, T|V> $pipe */
                 $pipe = (new Pipe())()(
                     (new Normalize())(),
                     (new Get())()($index)($default)

--- a/src/Operation/Cycle.php
+++ b/src/Operation/Cycle.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
 use loophp\iterators\InfiniteIteratorAggregate;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
@@ -24,16 +24,18 @@ final class Cycle extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
+     * @return Closure(iterable<TKey, T>): iterable<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
-             * @return Iterator<TKey, T>
+             * @return iterable<TKey, T>
              */
-            static fn (Iterator $iterator): Iterator => yield from new InfiniteIteratorAggregate($iterator);
+            static function (iterable $iterable): iterable {
+                yield from new InfiniteIteratorAggregate((new IterableIteratorAggregate($iterable))->getIterator());
+            };
     }
 }

--- a/src/Operation/Diff.php
+++ b/src/Operation/Diff.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function in_array;
 
@@ -26,7 +25,7 @@ final class Diff extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(T...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -34,7 +33,7 @@ final class Diff extends AbstractOperation
             /**
              * @param T ...$values
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$values): Closure {
                 $filterCallbackFactory =

--- a/src/Operation/DiffKeys.php
+++ b/src/Operation/DiffKeys.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function in_array;
 
@@ -26,7 +25,7 @@ final class DiffKeys extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(TKey...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(TKey...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -34,7 +33,7 @@ final class DiffKeys extends AbstractOperation
             /**
              * @param TKey ...$keys
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$keys): Closure {
                 $filterCallbackFactory =

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace loophp\collection\Operation;
 
-use ArrayIterator;
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,7 +27,7 @@ final class Distinct extends AbstractOperation
      *
      * @template U
      *
-     * @return Closure(callable(U): Closure(U): bool): Closure(callable(T, TKey): U): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(U): Closure(U): bool): Closure(callable(T, TKey): U): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -37,24 +35,24 @@ final class Distinct extends AbstractOperation
             /**
              * @param callable(U): (Closure(U): bool) $comparatorCallback
              *
-             * @return Closure(callable(T, TKey): U): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(callable(T, TKey): U): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable $comparatorCallback): Closure =>
                 /**
                  * @param callable(T, TKey): U $accessorCallback
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static function (callable $accessorCallback) use ($comparatorCallback): Closure {
-                    /** @var ArrayIterator<int, array{0: TKey, 1: T}> $stack */
-                    $stack = new ArrayIterator();
+                    /** @var array<int, array{0: TKey, 1: T}> $stack */
+                    $stack = [];
 
                     $filter = (new Filter())()(
                         /**
                          * @param T $value
                          * @param TKey $key
                          */
-                        static function ($value, $key) use ($comparatorCallback, $accessorCallback, $stack): bool {
+                        static function ($value, $key) use ($comparatorCallback, $accessorCallback, &$stack): bool {
                             $matchWhenNot = static fn (): bool => true;
                             $matcher =
                                 /**
@@ -68,7 +66,7 @@ final class Distinct extends AbstractOperation
                                 return false;
                             }
 
-                            $stack->append([$key, $value]);
+                            $stack[] = [$key, $value];
 
                             return true;
                         }

--- a/src/Operation/Drop.php
+++ b/src/Operation/Drop.php
@@ -10,20 +10,22 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
+use Generator;
 
 /**
  * @immutable
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class Drop extends AbstractOperation
 {
     /**
      * @pure
      *
-     * @return Closure(int): Closure(Iterator<TKey, T>): Iterator<TKey, T>
+     * @return Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {

--- a/src/Operation/DropWhile.php
+++ b/src/Operation/DropWhile.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,28 +26,28 @@ final class DropWhile extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=):bool ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=):bool ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable ...$callbacks): Closure =>
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<TKey, T>
              */
-            static function (Iterator $iterator) use ($callbacks): Generator {
+            static function (iterable $iterable) use ($callbacks): Generator {
                 $skip = false;
 
-                foreach ($iterator as $key => $current) {
+                foreach ($iterable as $key => $current) {
                     if (false === $skip) {
-                        if (false === CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator)) {
+                        if (false === CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
                             $skip = true;
 
                             yield $key => $current;

--- a/src/Operation/Dump.php
+++ b/src/Operation/Dump.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use Symfony\Component\VarDumper\VarDumper;
 
 /**
@@ -27,27 +26,27 @@ final class Dump extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(string): Closure(int): Closure(?Closure): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(string): Closure(int): Closure(?Closure): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(int): Closure(?Closure): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(int): Closure(?Closure): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (string $name = ''): Closure =>
                 /**
-                 * @return Closure(?Closure): Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(?Closure): Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static fn (int $size = -1): Closure =>
                     /**
-                     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                      */
                     static fn (?Closure $callback = null): Closure =>
                         /**
                          * @return Generator<TKey, T>
                          */
-                        static function (Iterator $iterator) use ($name, $size, $callback): Generator {
+                        static function (iterable $iterable) use ($name, $size, $callback): Generator {
                             $j = 0;
 
                             /** @var callable $debugFunction */
@@ -62,7 +61,7 @@ final class Dump extends AbstractOperation
                                  */
                                 static fn (string $name, $key, $value) => $debugFunction(['name' => $name, 'key' => $key, 'value' => $value]);
 
-                            foreach ($iterator as $key => $value) {
+                            foreach ($iterable as $key => $value) {
                                 yield $key => $value;
 
                                 if (-1 === $size) {

--- a/src/Operation/Duplicate.php
+++ b/src/Operation/Duplicate.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace loophp\collection\Operation;
 
-use ArrayIterator;
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,7 +27,7 @@ final class Duplicate extends AbstractOperation
      *
      * @template U
      *
-     * @return Closure(callable(U): Closure(U): bool): Closure(callable(T, TKey): U): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(U): Closure(U): bool): Closure(callable(T, TKey): U): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -37,24 +35,24 @@ final class Duplicate extends AbstractOperation
             /**
              * @param callable(U): (Closure(U): bool) $comparatorCallback
              *
-             * @return Closure(callable(T, TKey): U): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(callable(T, TKey): U): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable $comparatorCallback): Closure =>
                 /**
                  * @param callable(T, TKey): U $accessorCallback
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static function (callable $accessorCallback) use ($comparatorCallback): Closure {
-                    /** @var ArrayIterator<int, array{0: TKey, 1: T}> $stack */
-                    $stack = new ArrayIterator();
+                    /** @var array<int, array{0: TKey, 1: T}> $stack */
+                    $stack = [];
 
                     $filter = (new Filter())()(
                         /**
                          * @param T $value
                          * @param TKey $key
                          */
-                        static function ($value, $key) use ($comparatorCallback, $accessorCallback, $stack): bool {
+                        static function ($value, $key) use ($comparatorCallback, $accessorCallback, &$stack): bool {
                             $matchWhenNot = static fn (): bool => true;
                             $matcher =
                                 /**
@@ -68,7 +66,7 @@ final class Duplicate extends AbstractOperation
                                 return true;
                             }
 
-                            $stack->append([$key, $value]);
+                            $stack[] = [$key, $value];
 
                             return false;
                         }

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -11,36 +11,44 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class Equals extends AbstractOperation
 {
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Closure(Iterator<TKey, T>): Generator<int|TKey, bool>
+     * @return Closure(iterable<TKey, T>): Closure(iterable<TKey, T>): Generator<int|TKey, bool>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $other
+             * @param iterable<TKey, T> $other
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int|TKey, bool>
+             * @return Closure(iterable<TKey, T>): Generator<int|TKey, bool>
              */
-            static function (Iterator $other): Closure {
+            static function (iterable $other): Closure {
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<int|TKey, bool>
                  */
-                return static function (Iterator $iterator) use ($other): Generator {
+                return static function (iterable $iterable) use ($other): Generator {
+                    $otherAggregate = (new IterableIteratorAggregate($other));
+                    $iteratorAggregate = new IterableIteratorAggregate($iterable);
+
+                    $iterator = $iteratorAggregate->getIterator();
+                    $other = $otherAggregate->getIterator();
+
                     while ($other->valid() && $iterator->valid()) {
                         $iterator->next();
                         $other->next();
@@ -54,9 +62,9 @@ final class Equals extends AbstractOperation
                         /**
                          * @param T $current
                          */
-                        static fn ($current): bool => (new Contains())()($current)($other)->current();
+                        static fn ($current): bool => (new Contains())()($current)($otherAggregate)->current();
 
-                    yield from (new Every())()(static fn (): bool => false)($containsCallback)($iterator);
+                    yield from (new Every())()(static fn (): bool => false)($containsCallback)($iteratorAggregate);
                 };
             };
     }

--- a/src/Operation/Every.php
+++ b/src/Operation/Every.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,59 +26,59 @@ final class Every extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(callable(T, TKey, Iterator<TKey, T>...): bool): Closure(Iterator<TKey, T>): Generator<TKey, bool>
+     * @return Closure(callable(T, TKey, iterable<TKey, T>...): bool): Closure(callable(T, TKey, iterable<TKey, T>...): bool): Closure(iterable<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$matchers
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$matchers
              *
-             * @return Closure(...callable(T=, TKey=, Iterator<TKey, T>=): bool): Closure(Iterator<TKey, T>): Generator<TKey, bool>
+             * @return Closure(...callable(T=, TKey=, iterable<TKey, T>=): bool): Closure(iterable<TKey, T>): Generator<TKey, bool>
              */
             static function (callable ...$matchers): Closure {
                 return
                     /**
-                     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+                     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
                      *
-                     * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
+                     * @return Closure(iterable<TKey, T>): Generator<TKey, bool>
                      */
                     static function (callable ...$callbacks) use ($matchers): Closure {
                         $callbackReducer =
                             /**
-                             * @param list<callable(T=, TKey=, Iterator<TKey, T>=): bool> $callbacks
+                             * @param list<callable(T=, TKey=, iterable<TKey, T>=): bool> $callbacks
                              *
-                             * @return Closure(T, TKey, Iterator<TKey, T>): bool
+                             * @return Closure(T, TKey, iterable<TKey, T>): bool
                              */
                             static fn (array $callbacks): Closure =>
                                 /**
                                  * @param T $current
                                  * @param TKey $key
-                                 * @param Iterator<TKey, T> $iterator
+                                 * @param iterable<TKey, T> $iterable
                                  */
-                                static fn ($current, $key, Iterator $iterator): bool => CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator);
+                                static fn ($current, $key, iterable $iterable): bool => CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable);
 
                         $mapCallback =
                             /**
-                             * @param callable(T=, TKey=, Iterator<TKey, T>=): mixed $reducer1
+                             * @param callable(T=, TKey=, iterable<TKey, T>=): mixed $reducer1
                              *
-                             * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=)): Closure(T, TKey, Iterator<TKey, T>): bool
+                             * @return Closure(callable(T=, TKey=, iterable<TKey, T>=)): Closure(T, TKey, iterable<TKey, T>): bool
                              */
                             static fn (callable $reducer1): Closure =>
                                 /**
-                                 * @param callable(T=, TKey=, Iterator<TKey, T>=): mixed $reducer2
+                                 * @param callable(T=, TKey=, iterable<TKey, T>=): mixed $reducer2
                                  *
-                                 * @return Closure(T, TKey, Iterator<TKey, T>): bool
+                                 * @return Closure(T, TKey, iterable<TKey, T>): bool
                                  */
                                 static fn (callable $reducer2): Closure =>
                                     /**
                                      * @param T $value
                                      * @param TKey $key
-                                     * @param Iterator<TKey, T> $iterator
+                                     * @param iterable<TKey, T> $iterable
                                      */
-                                    static fn ($value, $key, Iterator $iterator): bool => $reducer1($value, $key, $iterator) !== $reducer2($value, $key, $iterator);
+                                    static fn ($value, $key, iterable $iterable): bool => $reducer1($value, $key, $iterable) !== $reducer2($value, $key, $iterable);
 
-                        /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
+                        /** @var Closure(iterable<TKey, T>): Generator<TKey, bool> $pipe */
                         $pipe = (new Pipe())()(
                             (new Map())()($mapCallback($callbackReducer($callbacks))($callbackReducer($matchers))),
                             (new DropWhile())()(static fn (bool $value): bool => $value),

--- a/src/Operation/Explode.php
+++ b/src/Operation/Explode.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Contract\Operation\Splitable;
 
 /**
@@ -25,7 +24,7 @@ final class Explode extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<int, list<T>>
+     * @return Closure(T...): Closure(iterable<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure
     {
@@ -33,10 +32,10 @@ final class Explode extends AbstractOperation
             /**
              * @param T ...$explodes
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int, list<T>>
+             * @return Closure(iterable<TKey, T>): Generator<int, list<T>>
              */
             static function (...$explodes): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<int, list<T>> $split */
+                /** @var Closure(iterable<TKey, T>): Generator<int, list<T>> $split */
                 $split = (new Split())()(Splitable::REMOVE)(
                     ...array_map(
                         /**

--- a/src/Operation/Falsy.php
+++ b/src/Operation/Falsy.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Falsy extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+     * @return Closure(iterable<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure
     {
@@ -35,7 +34,7 @@ final class Falsy extends AbstractOperation
              */
             static fn (bool $value): bool => $value;
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, bool> $pipe */
         $pipe = Pipe::of()(
             Map::of()(
                 /**

--- a/src/Operation/Filter.php
+++ b/src/Operation/Filter.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,23 +26,23 @@ final class Filter extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable ...$callbacks): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<TKey, T>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
+                static function (iterable $iterable) use ($callbacks): Generator {
                     $defaultCallback =
                         /**
                          * @param T $value
@@ -54,8 +53,8 @@ final class Filter extends AbstractOperation
                         [$defaultCallback] :
                         $callbacks;
 
-                    foreach ($iterator as $key => $current) {
-                        if (CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator)) {
+                    foreach ($iterable as $key => $current) {
+                        if (CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
                             yield $key => $current;
                         }
                     }

--- a/src/Operation/Find.php
+++ b/src/Operation/Find.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -28,7 +27,7 @@ final class Find extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(V): Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T|V>
+     * @return Closure(V): Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, T|V>
      */
     public function __invoke(): Closure
     {
@@ -36,16 +35,16 @@ final class Find extends AbstractOperation
             /**
              * @param V $default
              *
-             * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T|V>
+             * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, T|V>
              */
             static fn ($default): Closure =>
                 /**
-                 * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+                 * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T|V>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T|V>
                  */
                 static function (callable ...$callbacks) use ($default): Closure {
-                    /** @var Closure(Iterator<TKey, T>): Generator<TKey, T|V> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey, T|V> $pipe */
                     $pipe = (new Pipe())()(
                         (new Filter())()(...$callbacks),
                         (new Append())()($default),

--- a/src/Operation/First.php
+++ b/src/Operation/First.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,11 +23,11 @@ final class First extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $head */
+        /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $head */
         $head = Head::of();
 
         // Point free style.

--- a/src/Operation/FlatMap.php
+++ b/src/Operation/FlatMap.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,19 +28,19 @@ final class FlatMap extends AbstractOperation
      * @template IKey
      * @template IValue
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): iterable<mixed, mixed>): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): iterable<mixed, mixed>): Closure(iterable<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): iterable<mixed, mixed> $callback
+             * @param callable(T=, TKey=, iterable<TKey, T>=): iterable<mixed, mixed> $callback
              */
             static function (callable $callback): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<IKey, IValue> $flatMap */
+                /** @var Closure(iterable<TKey, T>): Generator<IKey, IValue> $flatMap */
                 $flatMap = (new Pipe())()(
                     (new Map())()($callback),
-                    (new Flatten())()(1)
+                    (new Flatten())()(1),
                 );
 
                 // Point free style

--- a/src/Operation/Flatten.php
+++ b/src/Operation/Flatten.php
@@ -11,8 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
-use loophp\iterators\IterableIterator;
 
 /**
  * @immutable
@@ -25,20 +23,20 @@ final class Flatten extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
+     * @return Closure(int): Closure(iterable<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<mixed, mixed>
+             * @return Closure(iterable<TKey, T>): Generator<mixed, mixed>
              */
             static fn (int $depth): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  */
-                static function (Iterator $iterator) use ($depth): Generator {
-                    foreach ($iterator as $key => $value) {
+                static function (iterable $iterable) use ($depth): Generator {
+                    foreach ($iterable as $key => $value) {
                         if (!is_iterable($value)) {
                             yield $key => $value;
 
@@ -46,7 +44,7 @@ final class Flatten extends AbstractOperation
                         }
 
                         yield from (1 !== $depth)
-                            ? (new Flatten())()($depth - 1)(new IterableIterator($value))
+                            ? (new Flatten())()($depth - 1)($value)
                             : $value;
                     }
                 };

--- a/src/Operation/Flip.php
+++ b/src/Operation/Flip.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Flip extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<T, TKey>
+     * @return Closure(iterable<TKey, T>): Generator<T, TKey>
      */
     public function __invoke(): Closure
     {
@@ -46,7 +45,7 @@ final class Flip extends AbstractOperation
              */
             static fn ($value, $key) => $key;
 
-        /** @var Closure(Iterator<TKey, T>): Generator<T, TKey> $associate */
+        /** @var Closure(iterable<TKey, T>): Generator<T, TKey> $associate */
         $associate = Associate::of()($callbackForKeys)($callbackForValues);
 
         // Point free style.

--- a/src/Operation/FoldLeft.php
+++ b/src/Operation/FoldLeft.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,24 +25,24 @@ final class FoldLeft extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>):(T|null)): Closure(T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable((T|null), T, TKey, iterable<TKey, T>):(T|null)): Closure(T): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T|null, T, TKey, Iterator<TKey, T>):(T|null) $callback
+             * @param callable(T|null, T, TKey, iterable<TKey, T>):(T|null) $callback
              *
-             * @return Closure(T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(T): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param T|null $initial
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static function ($initial = null) use ($callback): Closure {
-                    /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
                     $pipe = (new Pipe())()(
                         (new ScanLeft())()($callback)($initial),
                         (new Last())()

--- a/src/Operation/FoldLeft1.php
+++ b/src/Operation/FoldLeft1.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,18 +25,18 @@ final class FoldLeft1 extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>):(T|null)): Closure(Iterator<TKey, T>): Generator<int|TKey, null|T>
+     * @return Closure(callable((T|null), T, TKey, iterable<TKey, T>):(T|null)): Closure(iterable<TKey, T>): Generator<int|TKey, null|T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T|null, T, TKey, Iterator<TKey, T>):(T|null) $callback
+             * @param callable(T|null, T, TKey, iterable<TKey, T>):(T|null) $callback
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int|TKey, null|T>
+             * @return Closure(iterable<TKey, T>): Generator<int|TKey, null|T>
              */
             static function (callable $callback): Closure {
-                /** @var Closure(Iterator<TKey, T>):(Generator<int|TKey, T|null>) $pipe */
+                /** @var Closure(iterable<TKey, T>):(Generator<int|TKey, T|null>) $pipe */
                 $pipe = (new Pipe())()(
                     (new ScanLeft1())()($callback),
                     (new Last())()

--- a/src/Operation/FoldRight.php
+++ b/src/Operation/FoldRight.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,18 +25,18 @@ final class FoldRight extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>):(T|null)): Closure(T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable((T|null), T, TKey, iterable<TKey, T>):(T|null)): Closure(T): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T|null, T, TKey, Iterator<TKey, T>):(T|null) $callback
+             * @param callable(T|null, T, TKey, iterable<TKey, T>):(T|null) $callback
              *
-             * @return Closure(T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(T): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable $callback): Closure => static function ($initial = null) use ($callback): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
                 $pipe = (new Pipe())()(
                     (new ScanRight())()($callback)($initial),
                     (new Head())()

--- a/src/Operation/FoldRight1.php
+++ b/src/Operation/FoldRight1.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,18 +25,18 @@ final class FoldRight1 extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable((T|null), T, TKey, Iterator<TKey, T>): (T|null)):Closure (Iterator<TKey, T>): Generator<int|TKey, T|null>
+     * @return Closure(callable((T|null), T, TKey, iterable<TKey, T>): (T|null)):Closure (iterable<TKey, T>): Generator<int|TKey, T|null>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T|null, T, TKey, Iterator<TKey, T>):(T|null) $callback
+             * @param callable(T|null, T, TKey, iterable<TKey, T>):(T|null) $callback
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int|TKey, T|null>
+             * @return Closure(iterable<TKey, T>): Generator<int|TKey, T|null>
              */
             static function (callable $callback): Closure {
-                /** @var Closure(Iterator<TKey, T>):(Generator<int|TKey, T|null>) $pipe */
+                /** @var Closure(iterable<TKey, T>):(Generator<int|TKey, T|null>) $pipe */
                 $pipe = (new Pipe())()(
                     (new ScanRight1())()($callback),
                     (new Head())()

--- a/src/Operation/Forget.php
+++ b/src/Operation/Forget.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function in_array;
 
@@ -26,7 +25,7 @@ final class Forget extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(TKey...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(TKey...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -34,7 +33,7 @@ final class Forget extends AbstractOperation
             /**
              * @param TKey ...$keys
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$keys): Closure {
                 $filterCallbackFactory =

--- a/src/Operation/Frequency.php
+++ b/src/Operation/Frequency.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Frequency extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, T>
+     * @return Closure(iterable<TKey, T>): Generator<int, T>
      */
     public function __invoke(): Closure
     {
@@ -56,7 +55,7 @@ final class Frequency extends AbstractOperation
                 return $storage;
             };
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, T> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, T> $pipe */
         $pipe = Pipe::of()(
             Reduce::of()($reduceCallback)([]),
             Flatten::of()(1),

--- a/src/Operation/Get.php
+++ b/src/Operation/Get.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,7 +25,7 @@ final class Get extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(TKey): Closure(V): Closure(Iterator<TKey, T>): Generator<TKey, T|V>
+     * @return Closure(TKey): Closure(V): Closure(iterable<TKey, T>): Generator<TKey, T|V>
      */
     public function __invoke(): Closure
     {
@@ -34,13 +33,13 @@ final class Get extends AbstractOperation
             /**
              * @param TKey $keyToGet
              *
-             * @return Closure(V): Closure(Iterator<TKey, T>): Generator<TKey, T|V>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, T|V>
              */
             static fn ($keyToGet): Closure =>
                 /**
                  * @param V $default
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T|V>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T|V>
                  */
                 static function ($default) use ($keyToGet): Closure {
                     $filterCallback =
@@ -50,7 +49,7 @@ final class Get extends AbstractOperation
                          */
                         static fn ($value, $key): bool => $key === $keyToGet;
 
-                    /** @var Closure(Iterator<TKey, T>): (Generator<TKey, T|V>) $pipe */
+                    /** @var Closure(iterable<TKey, T>): (Generator<TKey, T|V>) $pipe */
                     $pipe = (new Pipe())()(
                         (new Filter())()($filterCallback),
                         (new Append())()($default),

--- a/src/Operation/Group.php
+++ b/src/Operation/Group.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,20 +23,20 @@ final class Group extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, list<T>>
+     * @return Closure(iterable<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<int, list<T>>
              */
-            static function (Iterator $iterator): Generator {
+            static function (iterable $iterable): Generator {
                 $last = [];
 
-                foreach ($iterator as $current) {
+                foreach ($iterable as $current) {
                     if ([] === $last) {
                         $last = [$current];
 

--- a/src/Operation/GroupBy.php
+++ b/src/Operation/GroupBy.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -28,7 +27,7 @@ final class GroupBy extends AbstractOperation
      *
      * @template NewTKey of array-key
      *
-     * @return Closure(callable(T=, TKey=): NewTKey):Closure(Iterator<TKey, T>): Generator<NewTKey, non-empty-list<T>>
+     * @return Closure(callable(T=, TKey=): NewTKey): Closure(iterable<TKey, T>): Generator<NewTKey, non-empty-list<T>>
      */
     public function __invoke(): Closure
     {
@@ -36,7 +35,7 @@ final class GroupBy extends AbstractOperation
             /**
              * @param callable(T=, TKey=): NewTKey $callable
              *
-             * @return Closure(Iterator<TKey, T>): Generator<NewTKey, non-empty-list<T>>
+             * @return Closure(iterable<TKey, T>): Generator<NewTKey, non-empty-list<T>>
              */
             static function (callable $callable): Closure {
                 $reducerFactory =
@@ -59,7 +58,7 @@ final class GroupBy extends AbstractOperation
                             return $collect;
                         };
 
-                /** @var Closure(Iterator<TKey, T>): Generator<NewTKey, non-empty-list<T>> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<NewTKey, non-empty-list<T>> $pipe */
                 $pipe = (new Pipe())()(
                     (new Reduce())()($reducerFactory($callable))([]),
                     (new Flatten())()(1)

--- a/src/Operation/Has.php
+++ b/src/Operation/Has.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,27 +25,27 @@ final class Has extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): T ...): Closure(Iterator<TKey, T>): Generator<TKey, bool>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): T ...): Closure(iterable<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): T ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=): T ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, bool>
              */
             static function (callable ...$callbacks): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, bool> $pipe */
                 $pipe = (new MatchOne())()(static fn (): bool => true)(
                     ...array_map(
                         static fn (callable $callback): callable =>
                             /**
                              * @param T $value
                              * @param TKey $key
-                             * @param Iterator<TKey, T> $iterator
+                             * @param iterable<TKey, T> $iterable
                              */
-                            static fn ($value, $key, Iterator $iterator): bool => $callback($value, $key, $iterator) === $value,
+                            static fn ($value, $key, iterable $iterable): bool => $callback($value, $key, $iterable) === $value,
                         $callbacks
                     )
                 );

--- a/src/Operation/Head.php
+++ b/src/Operation/Head.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,22 +23,22 @@ final class Head extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, T, mixed, void>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T, mixed, void>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<TKey, T, mixed, void>
              */
-            static function (Iterator $iterator): Generator {
+            static function (iterable $iterable): Generator {
                 $isEmpty = true;
 
                 $key = $current = null;
 
-                foreach ($iterator as $key => $current) {
+                foreach ($iterable as $key => $current) {
                     $isEmpty = false;
 
                     break;

--- a/src/Operation/IfThenElse.php
+++ b/src/Operation/IfThenElse.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,39 +25,39 @@ final class IfThenElse extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool): Closure(callable(T=, TKey=, Iterator<TKey, T>=): T): Closure(callable(T=, TKey=, Iterator<TKey, T>=): T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool): Closure(callable(T=, TKey=, iterable<TKey, T>=): T): Closure(callable(T=, TKey=, iterable<TKey, T>=): T): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool $condition
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool $condition
              *
-             * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): T): Closure(callable(T=, TKey=, Iterator<TKey, T>=): T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): T): Closure(callable(T=, TKey=, iterable<TKey, T>=): T): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable $condition): Closure =>
                 /**
-                 * @param callable(T=, TKey=, Iterator<TKey, T>=): T $then
+                 * @param callable(T=, TKey=, iterable<TKey, T>=): T $then
                  *
-                 * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): T): Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): T): Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static fn (callable $then): Closure =>
                     /**
-                     * @param callable(T=, TKey=, Iterator<TKey, T>=):T $else
+                     * @param callable(T=, TKey=, iterable<TKey, T>=):T $else
                      *
-                     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                      */
                     static function (callable $else) use ($condition, $then): Closure {
-                        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $map */
+                        /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $map */
                         $map = (new Map())()(
                             /**
                              * @param T $value
                              * @param TKey $key
-                             * @param Iterator<TKey, T> $iterator
+                             * @param iterable<TKey, T> $iterable
                              *
                              * @return T
                              */
-                            static fn ($value, $key, Iterator $iterator) => $condition($value, $key, $iterator) ? $then($value, $key, $iterator) : $else($value, $key, $iterator)
+                            static fn ($value, $key, iterable $iterable) => $condition($value, $key, $iterable) ? $then($value, $key, $iterable) : $else($value, $key, $iterable)
                         );
 
                         // Point free style.

--- a/src/Operation/Implode.php
+++ b/src/Operation/Implode.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,13 +25,13 @@ final class Implode extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(string): Closure(Iterator<TKey, T>): Generator<TKey, string>
+     * @return Closure(string): Closure(iterable<TKey, T>): Generator<TKey, string>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, string>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, string>
              */
             static function (string $glue): Closure {
                 $reducer =
@@ -41,7 +40,7 @@ final class Implode extends AbstractOperation
                      */
                     static fn (string $carry, $item): string => $carry .= $item;
 
-                /** @var Closure(Iterator<TKey, T>): Generator<TKey, string> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, string> $pipe */
                 $pipe = (new Pipe())()(
                     (new Intersperse())()($glue)(1)(0),
                     (new Drop())()(1),

--- a/src/Operation/Init.php
+++ b/src/Operation/Init.php
@@ -12,7 +12,7 @@ namespace loophp\collection\Operation;
 use CachingIterator;
 use Closure;
 use Generator;
-use Iterator;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
@@ -27,7 +27,7 @@ final class Init extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -41,13 +41,13 @@ final class Init extends AbstractOperation
 
         $buildCachingIterator =
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return CachingIterator<TKey, T>
              */
-            static fn (Iterator $iterator): CachingIterator => new CachingIterator($iterator, CachingIterator::FULL_CACHE);
+            static fn (iterable $iterator): CachingIterator => new CachingIterator((new IterableIteratorAggregate($iterator))->getIterator(), CachingIterator::FULL_CACHE);
 
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $takeWhile */
+        /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $takeWhile */
         $takeWhile = Pipe::of()(
             $buildCachingIterator,
             TakeWhile::of()($callback)

--- a/src/Operation/Inits.php
+++ b/src/Operation/Inits.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Inits extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>>
+     * @return Closure(iterable<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>>
      */
     public function __invoke(): Closure
     {
@@ -41,7 +40,7 @@ final class Inits extends AbstractOperation
                 return $carry;
             };
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>> $inits */
+        /** @var Closure(iterable<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>> $inits */
         $inits = Pipe::of()(
             Pack::of(),
             ScanLeft::of()($scanLeftCallback)([]),

--- a/src/Operation/Intersect.php
+++ b/src/Operation/Intersect.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function in_array;
 
@@ -26,7 +25,7 @@ final class Intersect extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(T...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -34,7 +33,7 @@ final class Intersect extends AbstractOperation
             /**
              * @param T ...$values
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$values): Closure {
                 $filterCallbackFactory =

--- a/src/Operation/IntersectKeys.php
+++ b/src/Operation/IntersectKeys.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function in_array;
 
@@ -26,7 +25,7 @@ final class IntersectKeys extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(TKey...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(TKey...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -34,7 +33,7 @@ final class IntersectKeys extends AbstractOperation
             /**
              * @param TKey ...$keys
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$keys): Closure {
                 $filterCallbackFactory =

--- a/src/Operation/Intersperse.php
+++ b/src/Operation/Intersperse.php
@@ -14,7 +14,6 @@ use ArrayIterator;
 use Closure;
 use Generator;
 use InfiniteIterator;
-use Iterator;
 
 /**
  * @immutable
@@ -27,7 +26,7 @@ final class Intersperse extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T): Closure(int): Closure(int): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+     * @return Closure(T): Closure(int): Closure(int): Closure(iterable<TKey, T>): Generator<int|TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -35,23 +34,23 @@ final class Intersperse extends AbstractOperation
             /**
              * @param T $element
              *
-             * @return Closure(int): Closure(int): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+             * @return Closure(int): Closure(int): Closure(iterable<TKey, T>): Generator<int|TKey, T>
              */
             static fn ($element): Closure =>
                 /**
-                 * @return Closure(int): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+                 * @return Closure(int): Closure(iterable<TKey, T>): Generator<int|TKey, T>
                  */
                 static fn (int $atEvery): Closure =>
                     /**
-                     * @return Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+                     * @return Closure(iterable<TKey, T>): Generator<int|TKey, T>
                      */
                     static fn (int $startAt): Closure =>
                         /**
-                         * @param Iterator<TKey, T> $iterator
+                         * @param iterable<TKey, T> $iterable
                          *
                          * @return Generator<int|TKey, T>
                          */
-                        static function (Iterator $iterator) use ($element, $atEvery, $startAt): Generator {
+                        static function (iterable $iterable) use ($element, $atEvery, $startAt): Generator {
                             $intersperse = new AppendIterator();
                             $intersperse->append(
                                 new ArrayIterator(array_fill(0, $startAt, 1))
@@ -61,7 +60,7 @@ final class Intersperse extends AbstractOperation
                             );
                             $intersperse->rewind();
 
-                            foreach ($iterator as $key => $value) {
+                            foreach ($iterable as $key => $value) {
                                 if (0 === $intersperse->current()) {
                                     yield $element;
                                 }

--- a/src/Operation/IsEmpty.php
+++ b/src/Operation/IsEmpty.php
@@ -11,23 +11,25 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class IsEmpty extends AbstractOperation
 {
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+     * @return Closure(iterable<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure
     {
-        return static fn (Iterator $iterator): Generator => yield !$iterator->valid();
+        return static fn (iterable $iterable): Generator => yield !(new IterableIteratorAggregate($iterable))->getIterator()->valid();
     }
 }

--- a/src/Operation/Key.php
+++ b/src/Operation/Key.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,16 +23,16 @@ final class Key extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(Iterator<TKey, T>): Generator<int, TKey>
+     * @return Closure(int): Closure(iterable<TKey, T>): Generator<int, TKey>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<int, TKey>
+             * @return Closure(iterable<TKey, T>): Generator<int, TKey>
              */
             static function (int $index): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<int, TKey> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<int, TKey> $pipe */
                 $pipe = (new Pipe())()(
                     (new Limit())()(1)($index),
                     (new Flip())()

--- a/src/Operation/Keys.php
+++ b/src/Operation/Keys.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,11 +23,11 @@ final class Keys extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, TKey>
+     * @return Closure(iterable<TKey, T>): Generator<int, TKey>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, T>): Generator<int, TKey> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, TKey> $pipe */
         $pipe = Pipe::of()(
             Flip::of(),
             (new Normalize())()

--- a/src/Operation/Last.php
+++ b/src/Operation/Last.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,22 +23,22 @@ final class Last extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<TKey, T>
              */
-            static function (Iterator $iterator): Generator {
+            static function (iterable $iterable): Generator {
                 $isEmpty = true;
 
                 $key = $current = null;
 
-                foreach ($iterator as $key => $current) {
+                foreach ($iterable as $key => $current) {
                     $isEmpty = false;
                 }
 

--- a/src/Operation/Limit.php
+++ b/src/Operation/Limit.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
-use LimitIterator;
+use Generator;
+use loophp\iterators\LimitIterableAggregate;
 
 /**
  * @immutable
@@ -26,24 +26,24 @@ final class Limit extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(int): Closure(Iterator<TKey, T>): Iterator<TKey, T>
+     * @return Closure(int): Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(int): Closure(Iterator<TKey, T>): Iterator<TKey, T>
+             * @return Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (int $count = -1): Closure =>
                 /**
-                 * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static fn (int $offset = 0): Closure =>
                     /**
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      *
-                     * @return Iterator<TKey, T>
+                     * @return Generator<TKey, T>
                      */
-                    static fn (Iterator $iterator): Iterator => new LimitIterator($iterator, $offset, $count);
+                    static fn (iterable $iterable): Generator => yield from new LimitIterableAggregate($iterable, $offset, $count);
     }
 }

--- a/src/Operation/Lines.php
+++ b/src/Operation/Lines.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use const PHP_EOL;
 
@@ -26,7 +25,7 @@ final class Lines extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, string>
+     * @return Closure(iterable<TKey, T>): Generator<int, string>
      */
     public function __invoke(): Closure
     {
@@ -36,7 +35,7 @@ final class Lines extends AbstractOperation
              */
             static fn (array $value): string => implode('', $value);
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, string> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, string> $pipe */
         $pipe = Pipe::of()(
             Explode::of()(PHP_EOL, "\n", "\r\n"),
             Map::of()($mapCallback)

--- a/src/Operation/Map.php
+++ b/src/Operation/Map.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -28,23 +27,23 @@ final class Map extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): mixed): Closure(Iterator<TKey, T>): Generator<TKey, mixed>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): mixed): Closure(iterable<TKey, T>): Generator<TKey, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): V $callback
+             * @param callable(T=, TKey=, iterable<TKey, T>=): V $callback
              */
             static fn (callable $callback): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<TKey, V>
                  */
-                static function (Iterator $iterator) use ($callback): Generator {
-                    foreach ($iterator as $key => $value) {
-                        yield $key => $callback($value, $key, $iterator);
+                static function (iterable $iterable) use ($callback): Generator {
+                    foreach ($iterable as $key => $value) {
+                        yield $key => $callback($value, $key, $iterable);
                     }
                 };
     }

--- a/src/Operation/MapN.php
+++ b/src/Operation/MapN.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,37 +25,37 @@ final class MapN extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(mixed, mixed, Iterator<TKey, T>): mixed ...): Closure(Iterator<TKey, T>): Generator<mixed, mixed>
+     * @return Closure(callable(mixed, mixed, iterable<TKey, T>): mixed ...): Closure(iterable<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(mixed, mixed, Iterator<TKey, T>): mixed ...$callbacks
+             * @param callable(mixed, mixed, iterable<TKey, T>): mixed ...$callbacks
              */
             static fn (callable ...$callbacks): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<mixed, mixed>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
+                static function (iterable $iterable) use ($callbacks): Generator {
                     $callbackFactory =
                         /**
                          * @param mixed $key
                          *
-                         * @return Closure(mixed, callable(mixed, mixed, Iterator<TKey, T>): mixed): mixed
+                         * @return Closure(mixed, callable(mixed, mixed, iterable<TKey, T>): mixed): mixed
                          */
                         static fn ($key): Closure =>
                             /**
                              * @param mixed $carry
-                             * @param callable(mixed, mixed, Iterator<TKey, T>): mixed $callback
+                             * @param callable(mixed, mixed, iterable<TKey, T>): mixed $callback
                              *
                              * @return mixed
                              */
-                            static fn ($carry, callable $callback) => $callback($carry, $key, $iterator);
+                            static fn ($carry, callable $callback) => $callback($carry, $key, $iterable);
 
-                    foreach ($iterator as $key => $value) {
+                    foreach ($iterable as $key => $value) {
                         yield $key => array_reduce($callbacks, $callbackFactory($key), $value);
                     }
                 };

--- a/src/Operation/MatchOne.php
+++ b/src/Operation/MatchOne.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,33 +26,33 @@ final class MatchOne extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, bool>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, bool>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$matchers
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$matchers
              *
-             * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, bool>
+             * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, bool>
              */
             static function (callable ...$matchers): Closure {
                 return
                     /**
-                     * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+                     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
                      *
-                     * @return Closure(Iterator<TKey, T>): Generator<TKey, bool>
+                     * @return Closure(iterable<TKey, T>): Generator<TKey, bool>
                      */
                     static function (callable ...$callbacks) use ($matchers): Closure {
-                        /** @var Closure(Iterator<TKey, T>): Generator<TKey, bool> $pipe */
+                        /** @var Closure(iterable<TKey, T>): Generator<TKey, bool> $pipe */
                         $pipe = (new Pipe())()(
                             (new Map())()(
                                 /**
                                  * @param T $value
                                  * @param TKey $key
-                                 * @param Iterator<TKey, T> $iterator
+                                 * @param iterable<TKey, T> $iterable
                                  */
-                                static fn ($value, $key, Iterator $iterator): bool => CallbacksArrayReducer::or()($callbacks, $value, $key, $iterator) === CallbacksArrayReducer::or()($matchers, $value, $key, $iterator)
+                                static fn ($value, $key, iterable $iterable): bool => CallbacksArrayReducer::or()($callbacks, $value, $key, $iterable) === CallbacksArrayReducer::or()($matchers, $value, $key, $iterable)
                             ),
                             (new DropWhile())()(static fn (bool $value): bool => !$value),
                             (new Append())()(false),

--- a/src/Operation/Matching.php
+++ b/src/Operation/Matching.php
@@ -13,7 +13,6 @@ use Closure;
 use Doctrine\Common\Collections\Criteria;
 use Doctrine\Common\Collections\Expr\ClosureExpressionVisitor;
 use Generator;
-use Iterator;
 use loophp\collection\Contract\Operation\Sortable;
 
 /**
@@ -29,13 +28,13 @@ final class Matching extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Criteria): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(Criteria): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (Criteria $criteria): Closure {
                 $expr = $criteria->getWhereExpression();
@@ -64,7 +63,7 @@ final class Matching extends AbstractOperation
                     $pipes[] = Limit::of()($length)((int) $offset);
                 }
 
-                /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
                 $pipe = Pipe::of()(...$pipes);
 
                 // Point free style.

--- a/src/Operation/Merge.php
+++ b/src/Operation/Merge.php
@@ -36,7 +36,7 @@ final class Merge extends AbstractOperation
              */
             static fn (iterable ...$sources): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<TKey, T>
                  */

--- a/src/Operation/Nth.php
+++ b/src/Operation/Nth.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,17 +23,17 @@ final class Nth extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(int): Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (int $step): Closure =>
                 /**
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static function (int $offset) use ($step): Closure {
                     $filterCallback =
@@ -43,7 +42,7 @@ final class Nth extends AbstractOperation
                          */
                         static fn (array $value, int $key): bool => (($key % $step) === $offset);
 
-                    /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
                     $pipe = (new Pipe())()(
                         (new Pack())(),
                         (new Filter())()($filterCallback),

--- a/src/Operation/Nullsy.php
+++ b/src/Operation/Nullsy.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function in_array;
 
@@ -33,7 +32,7 @@ final class Nullsy extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+     * @return Closure(iterable<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure
     {
@@ -44,7 +43,7 @@ final class Nullsy extends AbstractOperation
              */
             static fn (bool $value): bool => in_array($value, self::VALUES, true);
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, bool> $pipe */
         $pipe = Pipe::of()(
             Map::of()(
                 /**

--- a/src/Operation/Pack.php
+++ b/src/Operation/Pack.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\iterators\PackIterableAggregate;
 
 /**
@@ -25,21 +24,21 @@ final class Pack extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, array{0: TKey, 1: T}>
+     * @return Closure(iterable<TKey, T>): Generator<int, array{0: TKey, 1: T}>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<int, array{0: TKey, 1: T}>
              */
-            static function (Iterator $iterator): Generator {
-                /** @var PackIterableAggregate<TKey, T> $packIterableAggregate */
-                $packIterableAggregate = new PackIterableAggregate($iterator);
+            static function (iterable $iterable): Generator {
+                /** @var PackIterableAggregate<TKey, T> $iterable */
+                $iterable = new PackIterableAggregate($iterable);
 
-                yield from $packIterableAggregate->getIterator();
+                yield from $iterable->getIterator();
             };
     }
 }

--- a/src/Operation/Pad.php
+++ b/src/Operation/Pad.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,30 +23,30 @@ final class Pad extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(T): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+     * @return Closure(int): Closure(T): Closure(iterable<TKey, T>): Generator<int|TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(T): Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+             * @return Closure(T): Closure(iterable<TKey, T>): Generator<int|TKey, T>
              */
             static fn (int $size): Closure =>
                 /**
                  * @param T $padValue
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<int|TKey, T>
+                 * @return Closure(iterable<TKey, T>): Generator<int|TKey, T>
                  */
                 static fn ($padValue): Closure =>
                     /**
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      *
                      * @return Generator<int|TKey, T>
                      */
-                    static function (Iterator $iterator) use ($size, $padValue): Generator {
+                    static function (iterable $iterable) use ($size, $padValue): Generator {
                         $y = 0;
 
-                        foreach ($iterator as $key => $value) {
+                        foreach ($iterable as $key => $value) {
                             ++$y;
 
                             yield $key => $value;

--- a/src/Operation/Pair.php
+++ b/src/Operation/Pair.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Pair extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<T, T|null>
+     * @return Closure(iterable<TKey, T>): Generator<T, T|null>
      */
     public function __invoke(): Closure
     {
@@ -45,7 +44,7 @@ final class Pair extends AbstractOperation
              */
             static fn (array $value) => $value[1] ?? null;
 
-        /** @var Closure(Iterator<TKey, T>): Generator<T, T|null> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<T, T|null> $pipe */
         $pipe = Pipe::of()(
             Chunk::of()(2),
             Map::of()(static fn (array $value): array => array_values($value)),

--- a/src/Operation/Partition.php
+++ b/src/Operation/Partition.php
@@ -11,9 +11,9 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
-use IteratorAggregate;
+use loophp\iterators\CachingIteratorAggregate;
 use loophp\iterators\ClosureIteratorAggregate;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
@@ -28,25 +28,27 @@ final class Partition extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(IteratorAggregate<TKey, T>): Generator<int, IteratorAggregate<TKey, T>>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<int, iterable<TKey, T>>
      */
     public function __invoke(): Closure
     {
         /**
-         * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+         * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
          *
-         * @return Closure(IteratorAggregate<TKey, T>): Generator<int, IteratorAggregate<TKey, T>>
+         * @return Closure(iterable<TKey, T>): Generator<int, iterable<TKey, T>>
          */
         return static fn (callable ...$callbacks): Closure =>
             /**
-             * @param IteratorAggregate<TKey, T> $iteratorAggregate
+             * @param iterable<TKey, T> $iterable
              *
-             * @return Generator<int, IteratorAggregate<TKey, T>>
+             * @return Generator<int, iterable<TKey, T>>
              */
-            static function (IteratorAggregate $iteratorAggregate) use ($callbacks): Generator {
-                yield new ClosureIteratorAggregate((new Filter())()(...$callbacks), [$iteratorAggregate->getIterator()]);
+            static function (iterable $iterable) use ($callbacks): Generator {
+                $iteratorAggregate = (new CachingIteratorAggregate((new IterableIteratorAggregate($iterable))->getIterator()));
 
-                yield new ClosureIteratorAggregate((new Reject())()(...$callbacks), [$iteratorAggregate->getIterator()]);
+                yield new ClosureIteratorAggregate((new Filter())()(...$callbacks), [$iteratorAggregate]);
+
+                yield new ClosureIteratorAggregate((new Reject())()(...$callbacks), [$iteratorAggregate]);
             };
     }
 }

--- a/src/Operation/Permutate.php
+++ b/src/Operation/Permutate.php
@@ -11,13 +11,15 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class Permutate extends AbstractOperation
 {
@@ -36,11 +38,11 @@ final class Permutate extends AbstractOperation
 
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<int, list<T>>
              */
-            static fn (Iterator $iterator): Iterator => $getPermutations([...$iterator]);
+            static fn (iterable $iterable): Generator => $getPermutations([...(new IterableIteratorAggregate($iterable))]);
     }
 
     /**

--- a/src/Operation/Pipe.php
+++ b/src/Operation/Pipe.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
 
 /**
  * @immutable
@@ -25,32 +24,32 @@ final class Pipe extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(Iterator<TKey, T>): Iterator<TKey, T> ...): Closure(Iterator<TKey, T>): Iterator<TKey, T>
+     * @return Closure(callable(iterable<TKey, T>): iterable<TKey, T> ...): Closure(iterable<TKey, T>): iterable<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(Iterator<TKey, T>): Iterator<TKey, T> ...$operations
+             * @param callable(iterable<TKey, T>): iterable<TKey, T> ...$operations
              *
-             * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
+             * @return Closure(iterable<TKey, T>): iterable<TKey, T>
              */
             static fn (callable ...$operations): Closure => array_reduce(
                 $operations,
                 /**
-                 * @param callable(Iterator<TKey, T>): Iterator<TKey, T> $f
-                 * @param callable(Iterator<TKey, T>): Iterator<TKey, T> $g
+                 * @param callable(iterable<TKey, T>): iterable<TKey, T> $f
+                 * @param callable(iterable<TKey, T>): iterable<TKey, T> $g
                  *
-                 * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
+                 * @return Closure(iterable<TKey, T>): iterable<TKey, T>
                  */
                 static fn (callable $f, callable $g): Closure =>
                     /**
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      *
-                     * @return Iterator<TKey, T>
+                     * @return iterable<TKey, T>
                      */
-                    static fn (Iterator $iterator): Iterator => $g($f($iterator)),
-                static fn (Iterator $iterator): Iterator => $iterator
+                    static fn (iterable $iterable): iterable => $g($f($iterable)),
+                static fn (iterable $iterable): iterable => $iterable
             );
     }
 }

--- a/src/Operation/Prepend.php
+++ b/src/Operation/Prepend.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\iterators\ConcatIterableAggregate;
 
 /**
@@ -27,7 +26,7 @@ final class Prepend extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(T...): Closure(Iterator<TKey, T>): Iterator<int|TKey, T>
+     * @return Closure(T...): Closure(iterable<TKey, T>): iterable<int|TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -35,14 +34,14 @@ final class Prepend extends AbstractOperation
             /**
              * @param T ...$items
              *
-             * @return Closure(Iterator<TKey, T>): Iterator<int|TKey, T>
+             * @return Closure(iterable<TKey, T>): iterable<int|TKey, T>
              */
             static fn (...$items): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<int|TKey, T>
                  */
-                static fn (Iterator $iterator): Generator => yield from new ConcatIterableAggregate([$items, $iterator]);
+                static fn (iterable $iterable): Generator => yield from new ConcatIterableAggregate([$items, $iterable]);
     }
 }

--- a/src/Operation/Product.php
+++ b/src/Operation/Product.php
@@ -9,17 +9,18 @@ declare(strict_types=1);
 
 namespace loophp\collection\Operation;
 
-use ArrayIterator;
 use Closure;
 use Generator;
-use Iterator;
-use loophp\iterators\IterableIterator;
+use loophp\iterators\IterableIteratorAggregate;
+use Traversable;
 
 /**
  * @immutable
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class Product extends AbstractOperation
 {
@@ -35,60 +36,60 @@ final class Product extends AbstractOperation
             /**
              * @param iterable<UKey, U> ...$iterables
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int, list<T|U>>
+             * @return Closure(iterable<TKey, T>): Generator<int, array<array-key, T|U>>
              */
             static function (iterable ...$iterables): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<int, list<T|U>> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<int, list<T|U>> $pipe */
                 $pipe = (new Pipe())()(
                     (
                         /**
-                         * @param list<Iterator<UKey, U>> $iterables
+                         * @param array<int, Traversable<UKey, U>> $iterables
                          */
                         static fn (array $iterables): Closure =>
                         /**
-                         * @param Iterator<TKey, T> $iterator
+                         * @param iterable<TKey, T> $iterable
                          */
-                        static fn (Iterator $iterator): Generator => (
+                        static fn (iterable $iterable): Generator => (
                             /**
-                             * @param Closure(Iterator<TKey, T>): (Closure(Iterator<UKey, U>): Generator<list<T|U>>) $f
+                             * @param Closure(iterable<TKey, T>): (Closure(iterable<UKey, U>): Generator<array<array-key, T|U>>) $f
                              */
                             static fn (Closure $f): Closure => (new FoldLeft())()(
                                 /**
-                                 * @param Iterator<UKey, U> $a
-                                 * @param Iterator<TKey, T> $x
+                                 * @param iterable<UKey, U> $a
+                                 * @param iterable<TKey, T> $x
                                  */
-                                static fn (Iterator $a, Iterator $x): Generator => $f($x)($a)
+                                static fn (iterable $a, iterable $x): Generator => $f($x)($a)
                             )
                         )(
                             /**
-                             * @param (Iterator<TKey, T>|Iterator<UKey, U>) $xs
+                             * @param (iterable<TKey, T>|iterable<UKey, U>) $xs
                              */
-                            static fn (Iterator $xs): Closure =>
-                            /**
-                             * @param Iterator<int, list<T>> $as
-                             */
-                            static fn (Iterator $as): Generator => (new FlatMap())()(
+                            static fn (iterable $xs): Closure =>
                                 /**
-                                 * @param list<T> $a
+                                 * @param iterable<int, array<array-key, T>> $as
                                  */
-                                static fn (array $a): Generator => (new FlatMap())()(
+                                static fn (iterable $as): Generator => (new FlatMap())()(
                                     /**
-                                     * @param T|U $x
-                                     *
-                                     * @return Generator<int, list<T|U>>
+                                     * @param array<int, T> $a
                                      */
-                                    static fn ($x): Generator => yield [...$a, $x]
-                                )($xs)
-                            )($as)
-                        )(new ArrayIterator([[]]))(new ArrayIterator([$iterator, ...$iterables]))
+                                    static fn (array $a): Generator => (new FlatMap())()(
+                                        /**
+                                         * @param T|U $x
+                                         *
+                                         * @return Generator<int, array<array-key, T|U>>
+                                         */
+                                        static fn ($x): Generator => yield [...$a, $x]
+                                    )($xs)
+                                )($as)
+                        )([[]])([$iterable, ...$iterables])
                     )(
                         array_map(
                             /**
                              * @param iterable<UKey, U> $iterable
                              *
-                             * @return Iterator<UKey, U>
+                             * @return IterableIteratorAggregate<UKey, U>
                              */
-                            static fn (iterable $iterable): Iterator => new IterableIterator($iterable),
+                            static fn (iterable $iterable): IterableIteratorAggregate => new IterableIteratorAggregate($iterable),
                             $iterables
                         )
                     ),

--- a/src/Operation/RSample.php
+++ b/src/Operation/RSample.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,13 +25,13 @@ final class RSample extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(float): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(float): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (float $probability): Closure {
                 $filter = (new Filter())()(

--- a/src/Operation/Random.php
+++ b/src/Operation/Random.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,21 +23,21 @@ final class Random extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(int): Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (int $seed): Closure {
                 return
                     /**
-                     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                      */
                     static function (int $size) use ($seed): Closure {
-                        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+                        /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
                         $pipe = (new Pipe())()(
                             (new Shuffle())()($seed),
                             (new Limit())()($size)(0)

--- a/src/Operation/Range.php
+++ b/src/Operation/Range.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use const INF;
 
@@ -28,29 +27,27 @@ final class Range extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(float  = default):Closure (float=): Closure(float=): Closure(null|Iterator<TKey, T>): Generator<int, float>
+     * @return Closure(float=): Closure(float=): Closure(float=): Closure(): Generator<int, float>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(float=): Closure(float=): Closure(null|Iterator<TKey, T>): Generator<int, float>
+             * @return Closure(float=): Closure(float=): Closure(): Generator<int, float>
              */
             static fn (float $start = 0.0): Closure =>
                 /**
-                 * @return Closure(float=): Closure(null|Iterator<TKey, T>): Generator<int, float>
+                 * @return Closure(float=): Closure(): Generator<int, float>
                  */
                 static fn (float $end = INF): Closure =>
                     /**
-                     * @return Closure(null|Iterator<TKey, T>): Generator<int, float>
+                     * @return Closure(): Generator<int, float>
                      */
                     static fn (float $step = 1.0): Closure =>
                         /**
-                         * @param Iterator<TKey, T>|null $iterator
-                         *
                          * @return Generator<int, float>
                          */
-                        static function (?Iterator $iterator = null) use ($start, $end, $step): Generator {
+                        static function () use ($start, $end, $step): Generator {
                             for ($current = $start; $current < $end; $current += $step) {
                                 yield $current;
                             }

--- a/src/Operation/Reduce.php
+++ b/src/Operation/Reduce.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,24 +28,24 @@ final class Reduce extends AbstractOperation
      * @template V
      * @template W
      *
-     * @return Closure(callable(mixed=, mixed=, mixed=, Iterator<mixed, mixed>=): mixed): Closure(mixed): Closure(Iterator<TKey, T>): Generator<TKey, mixed>
+     * @return Closure(callable(mixed=, mixed=, mixed=, iterable<mixed, mixed>=): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<TKey, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
+             * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
              *
-             * @return Closure(V): Closure(Iterator<TKey, T>): Generator<TKey, W>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, W>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, W>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, W>
                  */
                 static function ($initial) use ($callback): Closure {
-                    /** @var Closure(Iterator<TKey, T>): Generator<TKey, W> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey, W> $pipe */
                     $pipe = (new Pipe())()(
                         (new Reduction())()($callback)($initial),
                         (new Last())(),

--- a/src/Operation/Reduction.php
+++ b/src/Operation/Reduction.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,31 +28,34 @@ final class Reduction extends AbstractOperation
      * @template V
      * @template W
      *
-     * @return Closure(callable(mixed=, mixed=, mixed=, Iterator<mixed, mixed>=): mixed): Closure(mixed): Closure(Iterator<TKey, T>): Generator<TKey, mixed>
+     * @return Closure(callable(mixed=, mixed=, mixed=, iterable<mixed, mixed>=): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<TKey, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
+             * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
              *
-             * @return Closure(V): Closure(Iterator<TKey, T>): Generator<TKey, W>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, W>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, W>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, W>
                  */
                 static fn ($initial): Closure =>
                     /**
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      *
                      * @return Generator<TKey, W>
                      */
-                    static function (Iterator $iterator) use ($callback, $initial): Generator {
-                        foreach ($iterator as $key => $value) {
-                            yield $key => ($initial = $callback($initial, $value, $key, $iterator));
+                    static function (iterable $iterable) use ($callback, $initial): Generator {
+                        foreach ($iterable as $key => $value) {
+                            /** @var W $initial */
+                            $initial = $callback($initial, $value, $key, $iterable);
+
+                            yield $key => $initial;
                         }
                     };
     }

--- a/src/Operation/Reject.php
+++ b/src/Operation/Reject.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,15 +26,15 @@ final class Reject extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (callable ...$callbacks): Closure {
                 $defaultCallback =
@@ -52,9 +51,9 @@ final class Reject extends AbstractOperation
                     /**
                      * @param T $current
                      * @param TKey $key
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      */
-                    static fn ($current, $key, Iterator $iterator): bool => !CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator)
+                    static fn ($current, $key, iterable $iterable): bool => !CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)
                 );
 
                 // Point free style.

--- a/src/Operation/Reverse.php
+++ b/src/Operation/Reverse.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Reverse extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, T, mixed, void>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -37,7 +36,7 @@ final class Reverse extends AbstractOperation
              */
             static fn (array $carry, array $value): array => [...$value, ...$carry];
 
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T, mixed, void> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
         $pipe = Pipe::of()(
             (new Pack())(),
             Reduce::of()($callback)([]),

--- a/src/Operation/Same.php
+++ b/src/Operation/Same.php
@@ -11,7 +11,7 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
@@ -26,29 +26,35 @@ final class Same extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Closure(callable(T, TKey): Closure(T, TKey): bool): Closure(Iterator<TKey, T>): Generator<int, bool>
+     * @return Closure(iterable<TKey, T>): Closure(callable(T, TKey): Closure(T, TKey): bool): Closure(iterable<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $other
+             * @param iterable<TKey, T> $other
              *
-             * @return Closure(callable(T, TKey): Closure(T, TKey): bool): Closure(Iterator<TKey, T>): Generator<int, bool>
+             * @return Closure(callable(T, TKey): Closure(T, TKey): bool): Closure(iterable<TKey, T>): Generator<int, bool>
              */
-            static fn (Iterator $other): Closure =>
+            static fn (iterable $other): Closure =>
                 /**
                  * @param callable(T, TKey): (Closure(T, TKey): bool) $comparatorCallback
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+                 * @return Closure(iterable<TKey, T>): Generator<int, bool>
                  */
                 static fn (callable $comparatorCallback): Closure =>
                     /**
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      *
                      * @return Generator<int, bool>
                      */
-                    static function (Iterator $iterator) use ($other, $comparatorCallback): Generator {
+                    static function (iterable $iterable) use ($other, $comparatorCallback): Generator {
+                        $otherAggregate = (new IterableIteratorAggregate($other));
+                        $iteratorAggregate = new IterableIteratorAggregate($iterable);
+
+                        $iterator = $iteratorAggregate->getIterator();
+                        $other = $otherAggregate->getIterator();
+
                         while ($iterator->valid() && $other->valid()) {
                             if (!$comparatorCallback($iterator->current(), $iterator->key())($other->current(), $other->key())) {
                                 return yield false;

--- a/src/Operation/Scale.php
+++ b/src/Operation/Scale.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use const INF;
 
@@ -28,29 +27,29 @@ final class Scale extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(float): Closure(float): Closure(float): Closure(float): Closure(float): Closure(Iterator<TKey, float|int>): Generator<TKey, float|int>
+     * @return Closure(float): Closure(float): Closure(float): Closure(float): Closure(float): Closure(iterable<TKey, float|int>): Generator<TKey, float|int>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(float): Closure(float): Closure(float): Closure(float): Closure(Iterator<TKey, float|int>): Generator<TKey, float|int>
+             * @return Closure(float): Closure(float): Closure(float): Closure(float): Closure(iterable<TKey, float|int>): Generator<TKey, float|int>
              */
             static fn (float $lowerBound): Closure =>
                 /**
-                 * @return Closure(float): Closure(float): Closure(float): Closure(Iterator<TKey, float|int>): Generator<TKey, float|int>
+                 * @return Closure(float): Closure(float): Closure(float): Closure(iterable<TKey, float|int>): Generator<TKey, float|int>
                  */
                 static fn (float $upperBound): Closure =>
                     /**
-                     * @return Closure(float): Closure(float): Closure(Iterator<TKey, float|int>): Generator<TKey, float|int>
+                     * @return Closure(float): Closure(float): Closure(iterable<TKey, float|int>): Generator<TKey, float|int>
                      */
                     static fn (float $wantedLowerBound = 0.0): Closure =>
                         /**
-                         * @return Closure(float): Closure(Iterator<TKey, float|int>): Generator<TKey, float|int>
+                         * @return Closure(float): Closure(iterable<TKey, float|int>): Generator<TKey, float|int>
                          */
                         static fn (float $wantedUpperBound = 1.0): Closure =>
                             /**
-                             * @return Closure(Iterator<TKey, float|int>): Generator<TKey, float|int>
+                             * @return Closure(iterable<TKey, float|int>): Generator<TKey, float|int>
                              */
                             static function (float $base = 0.0) use ($lowerBound, $upperBound, $wantedLowerBound, $wantedUpperBound): Closure {
                                 $wantedLowerBound = (0.0 === $wantedLowerBound) ? (0.0 === $base ? 0.0 : 1.0) : $wantedLowerBound;
@@ -82,7 +81,7 @@ final class Scale extends AbstractOperation
                                     static fn ($item): bool => $item <= $upperBound
                                 );
 
-                                /** @var Closure(Iterator<TKey, (float | int)>):(Generator<TKey, float|int>) $pipe */
+                                /** @var Closure(iterable<TKey, (float|int)>):(Generator<TKey, float|int>) $pipe */
                                 $pipe = Pipe::of()($filter, $mapper);
 
                                 // Point free style.

--- a/src/Operation/ScanLeft.php
+++ b/src/Operation/ScanLeft.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,24 +28,24 @@ final class ScanLeft extends AbstractOperation
      * @template V
      * @template W
      *
-     * @return Closure(callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed): Closure(mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
+     * @return Closure(callable(mixed=, T=, TKey=, iterable<TKey, T>=): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
+             * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
              *
-             * @return Closure(V): Closure(Iterator<TKey, T>): Generator<int|TKey, V|W>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<int|TKey, V|W>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<int|TKey, V|W>
+                 * @return Closure(iterable<TKey, T>): Generator<int|TKey, V|W>
                  */
                 static function ($initial) use ($callback): Closure {
-                    /** @var Closure(Iterator<TKey, T>): Generator<int|TKey, V|W> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<int|TKey, V|W> $pipe */
                     $pipe = (new Pipe())()(
                         (new Reduction())()($callback)($initial),
                         (new Prepend())()($initial)

--- a/src/Operation/ScanLeft1.php
+++ b/src/Operation/ScanLeft1.php
@@ -11,7 +11,7 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
@@ -28,33 +28,31 @@ final class ScanLeft1 extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(callable(mixed, T, TKey, Iterator<TKey, T>): mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
+     * @return Closure(callable(mixed, T, TKey, iterable<TKey, T>): mixed): Closure(iterable<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T|V, T, TKey, Iterator<TKey, T>): V $callback
+             * @param callable(T|V, T, TKey, iterable<TKey, T>): V $callback
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int|TKey, T|V>
+             * @return Closure(iterable<TKey, T>): Generator<int|TKey, T|V>
              */
             static fn (callable $callback): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
-                 *
                  * @return Generator<int|TKey, T|V>
                  */
-                static function (Iterator $iterator) use ($callback): Iterator {
-                    $initial = $iterator->current();
+                static function (iterable $iterable) use ($callback): Generator {
+                    $initial = (new IterableIteratorAggregate($iterable))->getIterator()->current();
 
-                    /** @var Closure(Iterator<TKey, T>): Generator<int|TKey, T|V> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<int|TKey, T|V> $pipe */
                     $pipe = (new Pipe())()(
                         (new Tail())(),
                         (new Reduction())()($callback)($initial),
                         (new Prepend())()($initial)
                     );
 
-                    return $pipe($iterator);
+                    return $pipe($iterable);
                 };
     }
 }

--- a/src/Operation/ScanRight.php
+++ b/src/Operation/ScanRight.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -29,24 +28,24 @@ final class ScanRight extends AbstractOperation
      * @template V
      * @template W
      *
-     * @return Closure(callable(mixed=, T=, TKey=, Iterator<TKey, T>=): mixed): Closure(mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
+     * @return Closure(callable(mixed=, T=, TKey=, iterable<TKey, T>=): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable((V|W)=, T=, TKey=, Iterator<TKey, T>=): W $callback
+             * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
              *
-             * @return Closure(V): Closure(Iterator<TKey, T>): Generator<int|TKey, V|W>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<int|TKey, V|W>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<int|TKey, V|W>
+                 * @return Closure(iterable<TKey, T>): Generator<int|TKey, V|W>
                  */
                 static function ($initial) use ($callback): Closure {
-                    /** @var Closure(Iterator<TKey, T>):(Generator<int|TKey, V|W>) $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<int|TKey, V|W> $pipe */
                     $pipe = (new Pipe())()(
                         (new Reverse())(),
                         (new Reduction())()($callback)($initial),

--- a/src/Operation/ScanRight1.php
+++ b/src/Operation/ScanRight1.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -28,18 +27,18 @@ final class ScanRight1 extends AbstractOperation
      *
      * @template V
      *
-     * @return Closure(callable(mixed, T, TKey, Iterator<TKey, T>): mixed): Closure(Iterator<TKey, T>): Generator<int|TKey, mixed>
+     * @return Closure(callable(mixed, T, TKey, iterable<TKey, T>): mixed): Closure(iterable<TKey, T>): Generator<int|TKey, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T|V, T, TKey, Iterator<TKey, T>): V $callback
+             * @param callable(T|V, T, TKey, iterable<TKey, T>): V $callback
              *
-             * @return Closure(Iterator<TKey, T>): Generator<int|TKey, T|V>
+             * @return Closure(iterable<TKey, T>): Generator<int|TKey, T|V>
              */
             static function (callable $callback): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<TKey, T|V> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, T|V> $pipe */
                 $pipe = (new Pipe())()(
                     (new Reverse())(),
                     (new ScanLeft1())()($callback),

--- a/src/Operation/Shuffle.php
+++ b/src/Operation/Shuffle.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
+use Generator;
 use loophp\iterators\RandomIterableAggregate;
 
 /**
@@ -26,20 +26,20 @@ final class Shuffle extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(Iterator<TKey, T>): Iterator<TKey, T>
+     * @return Closure(int): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Iterator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (int $seed): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
-                 * @return Iterator<TKey, T>
+                 * @return Generator<TKey, T>
                  */
-                static fn (Iterator $iterator): Iterator => (new RandomIterableAggregate($iterator, $seed))->getIterator();
+                static fn (iterable $iterable): Generator => yield from new RandomIterableAggregate($iterable, $seed);
     }
 }

--- a/src/Operation/Since.php
+++ b/src/Operation/Since.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,28 +26,28 @@ final class Since extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=):bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=):bool ...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=):bool ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=):bool ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable ...$callbacks): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<TKey, T>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
+                static function (iterable $iterable) use ($callbacks): Generator {
                     $skip = false;
 
-                    foreach ($iterator as $key => $current) {
+                    foreach ($iterable as $key => $current) {
                         if (false === $skip) {
-                            if (true === CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator)) {
+                            if (true === CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
                                 $skip = true;
 
                                 yield $key => $current;

--- a/src/Operation/Slice.php
+++ b/src/Operation/Slice.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,27 +23,27 @@ final class Slice extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(int=): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(int): Closure(int=): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(int=): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(int=): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (int $offset): Closure =>
                 /**
-                 * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static function (int $length = -1) use ($offset): Closure {
-                    /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $skip */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $skip */
                     $skip = (new Drop())()($offset);
 
                     if (-1 === $length) {
                         return $skip;
                     }
 
-                    /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
                     $pipe = (new Pipe())()(
                         $skip,
                         (new Limit())()($length)(0)

--- a/src/Operation/Span.php
+++ b/src/Operation/Span.php
@@ -11,9 +11,9 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
-use IteratorAggregate;
+use loophp\iterators\CachingIteratorAggregate;
 use loophp\iterators\ClosureIteratorAggregate;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
@@ -28,25 +28,27 @@ final class Span extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(IteratorAggregate<TKey, T>): Generator<int, IteratorAggregate<TKey, T>>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<int, iterable<TKey, T>>
      */
     public function __invoke(): Closure
     {
         /**
-         * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+         * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
          *
-         * @return Closure(IteratorAggregate<TKey, T>): Generator<int, IteratorAggregate<TKey, T>>
+         * @return Closure(iterable<TKey, T>): Generator<int, iterable<TKey, T>>
          */
         return static fn (callable ...$callbacks): Closure =>
             /**
-             * @param IteratorAggregate<TKey, T> $iteratorAggregate
+             * @param iterable<TKey, T> $iterable
              *
-             * @return Generator<int, IteratorAggregate<TKey, T>>
+             * @return Generator<int, iterable<TKey, T>>
              */
-            static function (IteratorAggregate $iteratorAggregate) use ($callbacks): Generator {
-                yield new ClosureIteratorAggregate((new TakeWhile())()(...$callbacks), [$iteratorAggregate->getIterator()]);
+            static function (iterable $iterable) use ($callbacks): Generator {
+                $iteratorAggregate = (new CachingIteratorAggregate((new IterableIteratorAggregate($iterable))->getIterator()));
 
-                yield new ClosureIteratorAggregate((new DropWhile())()(...$callbacks), [$iteratorAggregate->getIterator()]);
+                yield new ClosureIteratorAggregate((new TakeWhile())()(...$callbacks), [$iteratorAggregate]);
+
+                yield new ClosureIteratorAggregate((new DropWhile())()(...$callbacks), [$iteratorAggregate]);
             };
     }
 }

--- a/src/Operation/Split.php
+++ b/src/Operation/Split.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Contract\Operation\Splitable;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
@@ -28,31 +27,31 @@ final class Split extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure((callable(T, TKey): bool)...): Closure(Iterator<TKey, T>): Generator<int, list<T>>
+     * @return Closure(int): Closure((callable(T, TKey): bool)...): Closure(iterable<TKey, T>): Generator<int, list<T>>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure((callable(T, TKey): bool)...): Closure(Iterator<TKey, T>): Generator<int, list<T>>
+             * @return Closure((callable(T, TKey): bool)...): Closure(iterable<TKey, T>): Generator<int, list<T>>
              */
             static fn (int $type = Splitable::BEFORE): Closure =>
                 /**
                  * @param callable(T, TKey): bool ...$callbacks
                  *
-                 * @return Closure(Iterator<TKey, T>): Generator<int, list<T>>
+                 * @return Closure(iterable<TKey, T>): Generator<int, list<T>>
                  */
                 static fn (callable ...$callbacks): Closure =>
                     /**
-                     * @param Iterator<TKey, T> $iterator
+                     * @param iterable<TKey, T> $iterable
                      *
                      * @return Generator<int, list<T>>
                      */
-                    static function (Iterator $iterator) use ($type, $callbacks): Generator {
+                    static function (iterable $iterable) use ($type, $callbacks): Generator {
                         $carry = [];
 
-                        foreach ($iterator as $key => $current) {
-                            $callbackReturn = CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator);
+                        foreach ($iterable as $key => $current) {
+                            $callbackReturn = CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable);
 
                             if (Splitable::AFTER === $type) {
                                 $carry[] = $current;

--- a/src/Operation/Strict.php
+++ b/src/Operation/Strict.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
 namespace loophp\collection\Operation;
 
 use Closure;
-use Iterator;
-use IteratorAggregate;
+use Generator;
+use loophp\iterators\IterableIteratorAggregate;
 use loophp\iterators\TypedIteratorAggregate;
 
 /**
@@ -19,13 +19,15 @@ use loophp\iterators\TypedIteratorAggregate;
  *
  * @template TKey
  * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class Strict extends AbstractOperation
 {
     /**
      * @pure
      *
-     * @return Closure(null|callable(mixed): string): Closure(Iterator<TKey, T>): IteratorAggregate<TKey, T>
+     * @return Closure(null|callable(mixed): string): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
@@ -33,14 +35,14 @@ final class Strict extends AbstractOperation
             /**
              * @param null|callable(mixed): string $callback
              *
-             * @return Closure(Iterator<TKey, T>): IteratorAggregate<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (?callable $callback = null): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
-                 * @return IteratorAggregate<TKey, T>
+                 * @return Generator<TKey, T>
                  */
-                static fn (Iterator $iterator): IteratorAggregate => new TypedIteratorAggregate($iterator, $callback);
+                static fn (iterable $iterator): Generator => yield from new TypedIteratorAggregate((new IterableIteratorAggregate($iterator))->getIterator(), $callback);
     }
 }

--- a/src/Operation/Tail.php
+++ b/src/Operation/Tail.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,11 +23,11 @@ final class Tail extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, T> $drop */
+        /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $drop */
         $drop = Drop::of()(1);
 
         // Point free style.

--- a/src/Operation/Tails.php
+++ b/src/Operation/Tails.php
@@ -9,10 +9,8 @@ declare(strict_types=1);
 
 namespace loophp\collection\Operation;
 
-use ArrayIterator;
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -25,23 +23,23 @@ final class Tails extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, list<T>, mixed, void>
+     * @return Closure(iterable<TKey, T>): Generator<int, list<T>, mixed, void>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<int, list<T>, mixed, void>
              */
-            static function (Iterator $iterator): Generator {
-                /** @var Iterator<int, array{0: TKey, 1: T}> $iterator */
-                $iterator = (new Pack())()($iterator);
-                $data = [...$iterator];
+            static function (iterable $iterable): Generator {
+                /** @var Generator<int, array{0: TKey, 1: T}> $generator */
+                $generator = Pack::of()($iterable);
+                $data = [...$generator];
 
                 while ([] !== $data) {
-                    yield [...(new Unpack())()(new ArrayIterator($data))];
+                    yield [...Unpack::of()($data)];
 
                     array_shift($data);
                 }

--- a/src/Operation/TakeWhile.php
+++ b/src/Operation/TakeWhile.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,30 +26,30 @@ final class TakeWhile extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable ...$callbacks): Closure =>
-            /**
-             * @param Iterator<TKey, T> $iterator
-             *
-             * @return Generator<TKey, T>
-             */
-            static function (Iterator $iterator) use ($callbacks): Generator {
-                foreach ($iterator as $key => $current) {
-                    if (!CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator)) {
-                        break;
-                    }
+                /**
+                 * @param iterable<TKey, T> $iterable
+                 *
+                 * @return Generator<TKey, T>
+                 */
+                static function (iterable $iterable) use ($callbacks): Generator {
+                    foreach ($iterable as $key => $current) {
+                        if (!CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
+                            break;
+                        }
 
-                    yield $key => $current;
-                }
-            };
+                        yield $key => $current;
+                    }
+                };
     }
 }

--- a/src/Operation/Times.php
+++ b/src/Operation/Times.php
@@ -32,19 +32,17 @@ final class Times extends AbstractOperation
     {
         return
             /**
-             * @return Closure(null|callable(int): (int|T)): Closure(null|Iterator<TKey, T>): Generator<int, int|T>
+             * @return Closure(null|callable(int): (int|T)): Closure(): Generator<int, int|T>
              */
             static fn (int $number = 0): Closure =>
                 /**
-                 * @return Closure(null|Iterator<TKey, T>): Generator<int, int|T>
+                 * @return Closure(): Generator<int, int|T>
                  */
                 static fn (?callable $callback = null): Closure =>
                     /**
-                     * @param Iterator<TKey, T>|null $iterator
-                     *
                      * @return Generator<int, int|T>
                      */
-                    static function (?Iterator $iterator = null) use ($number, $callback): Generator {
+                    static function () use ($number, $callback): Generator {
                         if (1 > $number) {
                             return;
                         }

--- a/src/Operation/Transpose.php
+++ b/src/Operation/Transpose.php
@@ -11,8 +11,7 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
-use loophp\iterators\IterableIterator;
+use loophp\iterators\IterableIteratorAggregate;
 use MultipleIterator;
 
 /**
@@ -28,7 +27,7 @@ final class Transpose extends AbstractOperation
      *
      * @psalm-suppress ImpureMethodCall - using MultipleIterator as an internal tool which is not returned
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, list<T>>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, list<T>>
      */
     public function __invoke(): Closure
     {
@@ -48,11 +47,11 @@ final class Transpose extends AbstractOperation
              */
             static fn (array $value): array => $value;
 
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, list<T>> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<TKey, list<T>> $pipe */
         $pipe = Pipe::of()(
             Reduce::of()(
                 static function (MultipleIterator $acc, iterable $iterable): MultipleIterator {
-                    $acc->attachIterator(new IterableIterator($iterable));
+                    $acc->attachIterator((new IterableIteratorAggregate($iterable))->getIterator());
 
                     return $acc;
                 }

--- a/src/Operation/Truthy.php
+++ b/src/Operation/Truthy.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Truthy extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, bool>
+     * @return Closure(iterable<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure
     {
@@ -35,7 +34,7 @@ final class Truthy extends AbstractOperation
              */
             static fn (bool $value): bool => !$value;
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, bool> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, bool> $pipe */
         $pipe = Pipe::of()(
             Map::of()(
                 /**

--- a/src/Operation/Unlines.php
+++ b/src/Operation/Unlines.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use const PHP_EOL;
 
@@ -26,11 +25,11 @@ final class Unlines extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, (T|string)>): Generator<TKey, string>
+     * @return Closure(iterable<TKey, (T|string)>): Generator<TKey, string>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, (T|string)>):Generator<TKey, string> $implode */
+        /** @var Closure(iterable<TKey, (T|string)>):Generator<TKey, string> $implode */
         $implode = Implode::of()(PHP_EOL);
 
         // Point free style.

--- a/src/Operation/Unpack.php
+++ b/src/Operation/Unpack.php
@@ -11,10 +11,9 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
+use IteratorAggregate;
 use loophp\iterators\IterableIteratorAggregate;
 use loophp\iterators\UnpackIterableAggregate;
-use Traversable;
 
 // phpcs:disable Generic.Files.LineLength.TooLong
 
@@ -29,16 +28,16 @@ final class Unpack extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<mixed, mixed>): Generator<TKey, T>
+     * @return Closure(iterable<mixed, mixed>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<array-key, array{0: TKey, 1: T}>): Generator<TKey, T> $pipe */
+        /** @var Closure(iterable<array-key, array{0: TKey, 1: T}>): Generator<TKey, T> $pipe */
         $pipe = Pipe::of()(
-            Map::of()(static fn (iterable $iterable): Iterator => (new IterableIteratorAggregate($iterable))->getIterator()),
+            Map::of()(static fn (iterable $iterable): iterable => new IterableIteratorAggregate($iterable)),
             Map::of()(Chunk::of()(2)),
             Flatten::of()(1),
-            static fn (Iterator $iterator): Traversable => (new UnpackIterableAggregate($iterator))->getIterator()
+            static fn (iterable $iterable): IteratorAggregate => new UnpackIterableAggregate($iterable)
         );
 
         // Point free style.

--- a/src/Operation/Unpair.php
+++ b/src/Operation/Unpair.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,18 +23,18 @@ final class Unpair extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, (TKey|T), mixed, void>
+     * @return Closure(iterable<TKey, T>): Generator<int, (TKey|T), mixed, void>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<int, (TKey|T), mixed, void>
              */
-            static function (Iterator $iterator): Generator {
-                foreach ($iterator as $key => $value) {
+            static function (iterable $iterable): Generator {
+                foreach ($iterable as $key => $value) {
                     yield $key;
 
                     yield $value;

--- a/src/Operation/Until.php
+++ b/src/Operation/Until.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 
 /**
@@ -27,27 +26,27 @@ final class Until extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(T=, TKey=, Iterator<TKey, T>=): bool ...): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(T=, TKey=, iterable<TKey, T>=): bool ...): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(T=, TKey=, Iterator<TKey, T>=): bool ...$callbacks
+             * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
              *
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable ...$callbacks): Closure =>
                 /**
-                 * @param Iterator<TKey, T> $iterator
+                 * @param iterable<TKey, T> $iterable
                  *
                  * @return Generator<TKey, T>
                  */
-                static function (Iterator $iterator) use ($callbacks): Generator {
-                    foreach ($iterator as $key => $current) {
+                static function (iterable $iterable) use ($callbacks): Generator {
+                    foreach ($iterable as $key => $current) {
                         yield $key => $current;
 
-                        if (CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator)) {
+                        if (CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
                             break;
                         }
                     }

--- a/src/Operation/Unwindow.php
+++ b/src/Operation/Unwindow.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,11 +23,11 @@ final class Unwindow extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, list<T>>): Generator<TKey, T|null>
+     * @return Closure(iterable<TKey, list<T>>): Generator<TKey, T|null>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, list<T>>): Generator<TKey, T|null> $unwindow */
+        /** @var Closure(iterable<TKey, list<T>>): Generator<TKey, T|null> $unwindow */
         $unwindow = Map::of()(
             /**
              * @param iterable<TKey, list<T>> $iterable

--- a/src/Operation/Unwords.php
+++ b/src/Operation/Unwords.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,11 +23,11 @@ final class Unwords extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, (T|string)>): Generator<TKey, string, mixed, void>
+     * @return Closure(iterable<TKey, (T|string)>): Generator<TKey, string>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, (T|string)>): Generator<TKey, string, mixed, void> $implode */
+        /** @var Closure(iterable<TKey, (T|string)>): Generator<TKey, string> $implode */
         $implode = Implode::of()(' ');
 
         // Point free style.

--- a/src/Operation/Unwrap.php
+++ b/src/Operation/Unwrap.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,11 +23,11 @@ final class Unwrap extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<mixed, mixed>
+     * @return Closure(iterable<TKey, T>): Generator<mixed, mixed>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(Iterator<TKey, T>): Generator<mixed, mixed> $flatten */
+        /** @var Closure(iterable<TKey, T>): Generator<mixed, mixed> $flatten */
         $flatten = Flatten::of()(1);
 
         // Point free style.

--- a/src/Operation/Unzip.php
+++ b/src/Operation/Unzip.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Unzip extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, list<T>>): Generator<int, list<T>>
+     * @return Closure(iterable<TKey, list<T>>): Generator<int, list<T>>
      */
     public function __invoke(): Closure
     {
@@ -45,7 +44,7 @@ final class Unzip extends AbstractOperation
                 return $carry;
             };
 
-        /** @var Closure(Iterator<TKey, list<T>>): Generator<int, list<T>> $pipe */
+        /** @var Closure(iterable<TKey, list<T>>): Generator<int, list<T>> $pipe */
         $pipe = Pipe::of()(
             Reduce::of()($reduceCallback)([]),
             Flatten::of()(1)

--- a/src/Operation/When.php
+++ b/src/Operation/When.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -26,34 +25,34 @@ final class When extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(callable(Iterator<TKey, T>): bool): Closure(callable(Iterator<TKey, T>): iterable<TKey, T>): Closure(callable(Iterator<TKey, T>): iterable<TKey, T>): Closure(Iterator<TKey, T>): Generator<TKey, T>
+     * @return Closure(callable(iterable<TKey, T>): bool): Closure(callable(iterable<TKey, T>): iterable<TKey, T>): Closure(callable(iterable<TKey, T>): iterable<TKey, T>): Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(Iterator<TKey, T>): bool $predicate
+             * @param callable(iterable<TKey, T>): bool $predicate
              *
-             * @return Closure(callable(Iterator<TKey, T>): iterable<TKey, T>): Closure(callable(Iterator<TKey, T>): iterable<TKey, T>): Closure(Iterator<TKey, T>): Generator<TKey, T>
+             * @return Closure(callable(iterable<TKey, T>): iterable<TKey, T>): Closure(callable(iterable<TKey, T>): iterable<TKey, T>): Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static fn (callable $predicate): Closure =>
                 /**
-                 * @param callable(Iterator<TKey, T>): iterable<TKey, T> $whenTrue
+                 * @param callable(iterable<TKey, T>): iterable<TKey, T> $whenTrue
                  *
-                 * @return Closure(callable(Iterator<TKey, T>): iterable<TKey, T>): Closure(Iterator<TKey, T>): Generator<TKey, T>
+                 * @return Closure(callable(iterable<TKey, T>): iterable<TKey, T>): Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static fn (callable $whenTrue): Closure =>
                     /**
-                     * @param callable(Iterator<TKey, T>): iterable<TKey, T> $whenFalse
+                     * @param callable(iterable<TKey, T>): iterable<TKey, T> $whenFalse
                      *
-                     * @return Closure(Iterator<TKey, T>): Generator<TKey, T>
+                     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                      */
                     static fn (callable $whenFalse): Closure =>
                         /**
-                         * @param Iterator<TKey, T> $iterator
+                         * @param iterable<TKey, T> $iterable
                          *
                          * @return Generator<TKey, T>
                          */
-                        static fn (Iterator $iterator): Generator => yield from ($predicate($iterator) ? $whenTrue($iterator) : $whenFalse($iterator));
+                        static fn (iterable $iterable): Generator => yield from $predicate($iterable) ? $whenTrue($iterable) : $whenFalse($iterable);
     }
 }

--- a/src/Operation/Window.php
+++ b/src/Operation/Window.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 use function array_slice;
 
@@ -26,16 +25,16 @@ final class Window extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(int): Closure(Iterator<TKey, T>): Generator<TKey, list<T>>
+     * @return Closure(int): Closure(iterable<TKey, T>): Generator<TKey, list<T>>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @return Closure(Iterator<TKey, T>): Generator<TKey, list<T>>
+             * @return Closure(iterable<TKey, T>): Generator<TKey, list<T>>
              */
             static function (int $size): Closure {
-                /** @var Closure(Iterator<TKey, T>): Generator<TKey, list<T>> $reduction */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, list<T>> $reduction */
                 $reduction = (new Reduction())()(
                     /**
                      * @param list<T> $stack

--- a/src/Operation/Words.php
+++ b/src/Operation/Words.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Words extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<TKey, string>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, string>
      */
     public function __invoke(): Closure
     {
@@ -34,7 +33,7 @@ final class Words extends AbstractOperation
              */
             static fn (array $value): string => implode('', $value);
 
-        /** @var Closure(Iterator<TKey, T>): Generator<TKey, string> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<TKey, string> $pipe */
         $pipe = Pipe::of()(
             Explode::of()("\t", "\n", ' '),
             Map::of()($mapCallback),

--- a/src/Operation/Wrap.php
+++ b/src/Operation/Wrap.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 
 /**
  * @immutable
@@ -24,7 +23,7 @@ final class Wrap extends AbstractOperation
     /**
      * @pure
      *
-     * @return Closure(Iterator<TKey, T>): Generator<int, array<TKey, T>>
+     * @return Closure(iterable<TKey, T>): Generator<int, array<TKey, T>>
      */
     public function __invoke(): Closure
     {
@@ -37,7 +36,7 @@ final class Wrap extends AbstractOperation
              */
             static fn ($value, $key): array => [$key => $value];
 
-        /** @var Closure(Iterator<TKey, T>): Generator<int, array<TKey, T>> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, array<TKey, T>> $pipe */
         $pipe = Pipe::of()(
             Map::of()($mapCallback),
             (new Normalize())()

--- a/src/Operation/Zip.php
+++ b/src/Operation/Zip.php
@@ -11,7 +11,6 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
-use Iterator;
 use loophp\iterators\MultipleIterableAggregate;
 use MultipleIterator;
 
@@ -31,7 +30,7 @@ final class Zip extends AbstractOperation
      * @template UKey
      * @template U
      *
-     * @return Closure(iterable<UKey, U>...): Closure(Iterator<TKey, T>): Generator<array<int, TKey|UKey|null>, array<int, T|U|null>>
+     * @return Closure(iterable<UKey, U>...): Closure(iterable<TKey, T>): Generator<array<int, TKey|UKey|null>, array<int, T|U|null>>
      */
     public function __invoke(): Closure
     {
@@ -39,7 +38,7 @@ final class Zip extends AbstractOperation
             /**
              * @param iterable<UKey, U> ...$iterables
              *
-             * @return Closure(Iterator<TKey, T>): Generator<array<int, TKey|UKey|null>, array<int, T|U|null>>
+             * @return Closure(iterable<TKey, T>): Generator<array<int, TKey|UKey|null>, array<int, T|U|null>>
              */
             static fn (iterable ...$iterables): Closure =>
                 /**

--- a/src/Utils/CallbacksArrayReducer.php
+++ b/src/Utils/CallbacksArrayReducer.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace loophp\collection\Utils;
 
 use Closure;
-use Iterator;
 
 /**
  * @immutable
@@ -25,24 +24,24 @@ final class CallbacksArrayReducer
     /**
      * @pure
      *
-     * @return Closure(array<array-key, callable(T=, TKey=, Iterator<TKey, T>=): bool>, T, TKey, Iterator<TKey, T>): bool
+     * @return Closure(array<array-key, callable(T=, TKey=, iterable<TKey, T>=): bool>, T, TKey, iterable<TKey, T>): bool
      */
     public static function or(): Closure
     {
         return
             /**
-             * @param array<array-key, callable(T=, TKey=, Iterator<TKey, T>=): bool> $callbacks
+             * @param array<array-key, callable(T=, TKey=, iterable<TKey, T>=): bool> $callbacks
              * @param T $current
              * @param TKey $key
-             * @param Iterator<TKey, T> $iterator
+             * @param iterable<TKey, T> $iterable
              */
-            static fn (array $callbacks, $current, $key, Iterator $iterator): bool => array_reduce(
+            static fn (array $callbacks, $current, $key, iterable $iterable): bool => array_reduce(
                 $callbacks,
                 /**
                  * @param bool $carry
-                 * @param callable(T=, TKey=, Iterator<TKey, T>=): bool $callable
+                 * @param callable(T=, TKey=, iterable<TKey, T>=): bool $callable
                  */
-                static fn (bool $carry, callable $callable): bool => $carry || $callable($current, $key, $iterator),
+                static fn (bool $carry, callable $callable): bool => $carry || $callable($current, $key, $iterable),
                 false
             );
     }

--- a/tests/unit/CollectionSpecificOperationTest.php
+++ b/tests/unit/CollectionSpecificOperationTest.php
@@ -467,13 +467,20 @@ final class CollectionSpecificOperationTest extends TestCase
             CollectionInterface::class,
             $subject->last()
         );
+
+        $first = $subject->first()->current();
+        $last = $subject->last()->current();
+
+        self::assertCount(3, $first);
+        self::assertCount(7, $last);
+
         self::assertIdenticalIterable(
             [1, 2, 3],
-            $subject->first()->current()
+            $first
         );
         self::assertIdenticalIterable(
             [3 => 4, 4 => 5, 5 => 6, 6 => 7, 7 => 8, 8 => 9, 9 => 10],
-            $subject->last()->current()
+            $last
         );
 
         $callbacks = [

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -14,11 +14,10 @@ use ArrayObject;
 use Closure;
 use Doctrine\Common\Collections\Criteria;
 use Generator;
-use Iterator;
+use IteratorAggregate;
 use loophp\collection\Collection;
 use loophp\collection\Contract\Operation;
 use loophp\collection\Operation\AbstractOperation;
-use loophp\iterators\ClosureIterator;
 use stdClass;
 
 use const PHP_EOL;
@@ -1146,7 +1145,7 @@ trait GenericCollectionProviders
         yield [
             $operation,
             [
-                static fn ($value, $key, Iterator $iterator): bool => $iterator instanceof ClosureIterator,
+                static fn ($value, $key, iterable $iterable): bool => $iterable instanceof IteratorAggregate,
             ],
             $input,
             true,
@@ -4280,7 +4279,7 @@ trait GenericCollectionProviders
             $operation,
             [
                 static fn (): bool => true,
-                static fn (Iterator $iterator) => new ArrayIterator(range('c', 'a')),
+                static fn (iterable $iterable) => range('c', 'a'),
             ],
             $input,
             [0 => 'c', 1 => 'b', 2 => 'a'],
@@ -4290,7 +4289,7 @@ trait GenericCollectionProviders
             $operation,
             [
                 static fn (): bool => false,
-                static fn (Iterator $iterator) => new ArrayIterator(range('c', 'a')),
+                static fn (iterable $iterable) => range('c', 'a'),
             ],
             $input,
             [0 => 'a', 1 => 'b', 2 => 'c'],

--- a/tests/unit/Utils/CallbacksArrayReducerTest.php
+++ b/tests/unit/Utils/CallbacksArrayReducerTest.php
@@ -9,8 +9,6 @@ declare(strict_types=1);
 
 namespace tests\loophp\collection\Utils;
 
-use ArrayIterator;
-use Iterator;
 use loophp\collection\Utils\CallbacksArrayReducer;
 use PHPUnit\Framework\TestCase;
 
@@ -25,7 +23,7 @@ final class CallbacksArrayReducerTest extends TestCase
         // Ensure Callbacks receive the needed arguments.
         yield [
             [
-                static fn (string $value, string $key, Iterator $iterator): bool => 'value_key_a_b_c' === sprintf('%s_%s_%s', $value, $key, implode('_', iterator_to_array($iterator))),
+                static fn (string $value, string $key, iterable $iterable): bool => 'value_key_a_b_c' === sprintf('%s_%s_%s', $value, $key, implode('_', $iterable)),
             ],
             'value',
             'key',
@@ -111,6 +109,6 @@ final class CallbacksArrayReducerTest extends TestCase
         array $iterator,
         bool $expected
     ): void {
-        self::assertSame($expected, CallbacksArrayReducer::or()($callbacks, $current, $key, new ArrayIterator($iterator)));
+        self::assertSame($expected, CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator));
     }
 }


### PR DESCRIPTION
This PR:

- [x] Replaces `IterableIterator` with `IterableIteratorAggregate` (4 occurences)
- [x] Changes the signature of a couple of operations. 
- [x] Update all the annotations where an `Iterator` is needed while now an `iterable` is enough.
- [x] Use `yield from` - align everything
- [x] Get rid of `ClosureIterator` and replace it with `ClosureIteratorAggregate`

Based on the benchmarks I did in `loophp/iterators`, it seems to be definitely, and it make sense.
`IteratorAggregates` are usually faster because the state of the `Iterator` is not built in _userland_ but directly handled by PHP internaly.


```
$ ./vendor/bin/phpbench run --profile=local --group=local --report=aggregate --stop-on-error tests/benchmarks/IterableIteratorAggregateBench.php tests/benchmarks/IterableIteratorBench.php
PHPBench (1.2.3) running benchmarks...
with configuration file: /home/pol/dev/git/iterators/phpbench.json
with PHP version 8.1.1, xdebug ❌, opcache ✔

\benchmarks\loophp\iterators\IterableIteratorAggregateBench

    bench # IterableIteratorAggregate.......I0 - Mo1.963ms (±0.00%)
    bench # IterableIteratorAggregate.......R1 I7 - Mo0.937ms (±1.97%)
    bench # IterableIteratorAggregate.......R1 I25 - Mo0.927ms (±1.60%)

\benchmarks\loophp\iterators\IterableIteratorBench

    bench # IterableIterator................R1 I0 - Mo2.188ms (±0.00%)
    bench # IterableIterator................R1 I6 - Mo1.765ms (±1.80%)
    bench # IterableIterator................R4 I49 - Mo1.741ms (±2.25%)

Subjects: 2, Assertions: 0, Failures: 0, Errors: 0
+--------------------------------+---------+---------------------------+------+-----+----------+---------+--------+
| benchmark                      | subject | set                       | revs | its | mem_peak | mode    | rstdev |
+--------------------------------+---------+---------------------------+------+-----+----------+---------+--------+
| IterableIteratorAggregateBench | bench   | IterableIteratorAggregate | 10   | 1   | 3.695mb  | 1.963ms | ±0.00% |
| IterableIteratorAggregateBench | bench   | IterableIteratorAggregate | 10   | 10  | 3.695mb  | 0.937ms | ±1.97% |
| IterableIteratorAggregateBench | bench   | IterableIteratorAggregate | 10   | 50  | 3.695mb  | 0.927ms | ±1.60% |
| IterableIteratorBench          | bench   | IterableIterator          | 10   | 1   | 3.695mb  | 2.188ms | ±0.00% |
| IterableIteratorBench          | bench   | IterableIterator          | 10   | 10  | 3.695mb  | 1.765ms | ±1.80% |
| IterableIteratorBench          | bench   | IterableIterator          | 10   | 50  | 3.695mb  | 1.741ms | ±2.25% |
+--------------------------------+---------+---------------------------+------+-----+----------+---------+--------+
```

@AlexandruGG WDYT of this? Are you ok with this?
