### PR TITLE
misc: Update `CallbackArrayReducer`.

### DIFF
--- a/src/Operation/DropWhile.php
+++ b/src/Operation/DropWhile.php
@@ -42,10 +42,11 @@ final class DropWhile extends AbstractOperation
              */
             static function (iterable $iterable) use ($callbacks): Generator {
                 $skip = false;
+                $callback = CallbacksArrayReducer::or()($callbacks);
 
                 foreach ($iterable as $key => $current) {
                     if (false === $skip) {
-                        if (false === CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
+                        if (false === $callback($current, $key, $iterable)) {
                             $skip = true;
 
                             yield $key => $current;

--- a/src/Operation/Filter.php
+++ b/src/Operation/Filter.php
@@ -51,8 +51,10 @@ final class Filter extends AbstractOperation
                         [$defaultCallback] :
                         $callbacks;
 
+                    $callback = CallbacksArrayReducer::or()($callbacks);
+
                     foreach ($iterable as $key => $current) {
-                        if (CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
+                        if ($callback($current, $key, $iterable)) {
                             yield $key => $current;
                         }
                     }

--- a/src/Operation/Get.php
+++ b/src/Operation/Get.php
@@ -40,16 +40,15 @@ final class Get extends AbstractOperation
                  * @return Closure(iterable<TKey, T>): Generator<TKey, T|V>
                  */
                 static function ($default) use ($keyToGet): Closure {
-                    $filterCallback =
-                        /**
-                         * @param T $value
-                         * @param TKey $key
-                         */
-                        static fn ($value, $key): bool => $key === $keyToGet;
-
                     /** @var Closure(iterable<TKey, T>): (Generator<TKey, T|V>) $pipe */
                     $pipe = (new Pipe())()(
-                        (new Filter())()($filterCallback),
+                        (new Filter())()(
+                            /**
+                             * @param T $value
+                             * @param TKey $key
+                             */
+                            static fn ($value, $key): bool => $key === $keyToGet
+                        ),
                         (new Append())()($default),
                         (new Head())()
                     );

--- a/src/Operation/Implode.php
+++ b/src/Operation/Implode.php
@@ -32,17 +32,16 @@ final class Implode extends AbstractOperation
              * @return Closure(iterable<TKey, T>): Generator<TKey, string>
              */
             static function (string $glue): Closure {
-                $reducer =
-                    /**
-                     * @param string|T $item
-                     */
-                    static fn (string $carry, $item): string => $carry .= $item;
-
                 /** @var Closure(iterable<TKey, T>): Generator<TKey, string> $pipe */
                 $pipe = (new Pipe())()(
                     (new Intersperse())()($glue)(1)(0),
                     (new Drop())()(1),
-                    (new Reduce())()($reducer)('')
+                    (new Reduce())()(
+                        /**
+                         * @param string|T $item
+                         */
+                        static fn (string $carry, $item): string => $carry .= $item
+                    )('')
                 );
 
                 // Point free style.

--- a/src/Operation/Init.php
+++ b/src/Operation/Init.php
@@ -30,14 +30,6 @@ final class Init extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $callback =
-            /**
-             * @param T $value
-             * @param TKey $key
-             * @param CachingIterator<TKey, T> $iterator
-             */
-            static fn ($value, $key, CachingIterator $iterator): bool => $iterator->hasNext();
-
         $buildCachingIterator =
             /**
              * @param iterable<TKey, T> $iterable
@@ -49,7 +41,14 @@ final class Init extends AbstractOperation
         /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $takeWhile */
         $takeWhile = (new Pipe())()(
             $buildCachingIterator,
-            (new TakeWhile())()($callback)
+            (new TakeWhile())()(
+                /**
+                 * @param T $value
+                 * @param TKey $key
+                 * @param CachingIterator<TKey, T> $iterator
+                 */
+                static fn ($value, $key, CachingIterator $iterator): bool => $iterator->hasNext()
+            )
         );
 
         // Point free style.

--- a/src/Operation/Inits.php
+++ b/src/Operation/Inits.php
@@ -25,23 +25,22 @@ final class Inits extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $scanLeftCallback =
-            /**
-             * @param list<array{0: TKey, 1: T}> $carry
-             * @param array{0: TKey, 1: T} $value
-             *
-             * @return list<array{0: TKey, 1: T}>
-             */
-            static function (array $carry, array $value): array {
-                $carry[] = $value;
-
-                return $carry;
-            };
-
         /** @var Closure(iterable<TKey, T>): Generator<int, list<array{0: TKey, 1: T}>> $inits */
         $inits = (new Pipe())()(
             (new Pack())(),
-            (new ScanLeft())()($scanLeftCallback)([]),
+            (new ScanLeft())()(
+                /**
+                 * @param list<array{0: TKey, 1: T}> $carry
+                 * @param array{0: TKey, 1: T} $value
+                 *
+                 * @return list<array{0: TKey, 1: T}>
+                 */
+                static function (array $carry, array $value): array {
+                    $carry[] = $value;
+
+                    return $carry;
+                }
+            )([]),
             (new Normalize())()
         );
 

--- a/src/Operation/Intersect.php
+++ b/src/Operation/Intersect.php
@@ -34,17 +34,12 @@ final class Intersect extends AbstractOperation
              * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$values): Closure {
-                $filterCallbackFactory =
+                $filter = (new Filter())()(
                     /**
-                     * @param list<T> $values
+                     * @param T $value
                      */
-                    static fn (array $values): Closure =>
-                        /**
-                         * @param T $value
-                         */
-                        static fn ($value): bool => in_array($value, $values, true);
-
-                $filter = (new Filter())()($filterCallbackFactory($values));
+                    static fn ($value): bool => in_array($value, $values, true)
+                );
 
                 // Point free style.
                 return $filter;

--- a/src/Operation/IntersectKeys.php
+++ b/src/Operation/IntersectKeys.php
@@ -34,18 +34,13 @@ final class IntersectKeys extends AbstractOperation
              * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
             static function (...$keys): Closure {
-                $filterCallbackFactory =
+                $filter = (new Filter())()(
                     /**
-                     * @param list<TKey> $keys
+                     * @param T $value
+                     * @param TKey $key
                      */
-                    static fn (array $keys): Closure =>
-                        /**
-                         * @param T $value
-                         * @param TKey $key
-                         */
-                        static fn ($value, $key): bool => in_array($key, $keys, true);
-
-                $filter = (new Filter())()($filterCallbackFactory($keys));
+                    static fn ($value, $key): bool => in_array($key, $keys, true)
+                );
 
                 // Point free style.
                 return $filter;

--- a/src/Operation/Lines.php
+++ b/src/Operation/Lines.php
@@ -27,16 +27,15 @@ final class Lines extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $mapCallback =
-            /**
-             * @param list<T> $value
-             */
-            static fn (array $value): string => implode('', $value);
-
         /** @var Closure(iterable<TKey, T>): Generator<int, string> $pipe */
         $pipe = (new Pipe())()(
             (new Explode())()(PHP_EOL, "\n", "\r\n"),
-            (new Map())()($mapCallback)
+            (new Map())()(
+                /**
+                 * @param list<T> $value
+                 */
+                static fn (array $value): string => implode('', $value)
+            )
         );
 
         // Point free style.

--- a/src/Operation/MatchOne.php
+++ b/src/Operation/MatchOne.php
@@ -42,6 +42,9 @@ final class MatchOne extends AbstractOperation
                      * @return Closure(iterable<TKey, T>): Generator<TKey, bool>
                      */
                     static function (callable ...$callbacks) use ($matchers): Closure {
+                        $callback = CallbacksArrayReducer::or()($callbacks);
+                        $matcher = CallbacksArrayReducer::or()($matchers);
+
                         /** @var Closure(iterable<TKey, T>): Generator<TKey, bool> $pipe */
                         $pipe = (new Pipe())()(
                             (new Map())()(
@@ -50,7 +53,7 @@ final class MatchOne extends AbstractOperation
                                  * @param TKey $key
                                  * @param iterable<TKey, T> $iterable
                                  */
-                                static fn ($value, $key, iterable $iterable): bool => CallbacksArrayReducer::or()($callbacks, $value, $key, $iterable) === CallbacksArrayReducer::or()($matchers, $value, $key, $iterable)
+                                static fn ($value, $key, iterable $iterable): bool => $callback($value, $key, $iterable) === $matcher($value, $key, $iterable)
                             ),
                             (new DropWhile())()(static fn (bool $value): bool => !$value),
                             (new Append())()(false),

--- a/src/Operation/Nth.php
+++ b/src/Operation/Nth.php
@@ -34,16 +34,15 @@ final class Nth extends AbstractOperation
                  * @return Closure(iterable<TKey, T>): Generator<TKey, T>
                  */
                 static function (int $offset) use ($step): Closure {
-                    $filterCallback =
-                        /**
-                         * @param array{0: TKey, 1: T} $value
-                         */
-                        static fn (array $value, int $key): bool => (($key % $step) === $offset);
-
                     /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
                     $pipe = (new Pipe())()(
                         (new Pack())(),
-                        (new Filter())()($filterCallback),
+                        (new Filter())()(
+                            /**
+                             * @param array{0: TKey, 1: T} $value
+                             */
+                            static fn (array $value, int $key): bool => (($key % $step) === $offset)
+                        ),
                         (new Unpack())()
                     );
 

--- a/src/Operation/Pair.php
+++ b/src/Operation/Pair.php
@@ -25,28 +25,26 @@ final class Pair extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $callbackForKeys =
-            /**
-             * @param TKey $key
-             * @param array{0: TKey, 1: T} $value
-             *
-             * @return TKey|null
-             */
-            static fn ($key, array $value) => $value[0] ?? null;
-
-        $callbackForValues =
-            /**
-             * @param array{0: TKey, 1: T} $value
-             *
-             * @return T|null
-             */
-            static fn (array $value) => $value[1] ?? null;
-
         /** @var Closure(iterable<TKey, T>): Generator<T, T|null> $pipe */
         $pipe = (new Pipe())()(
             (new Chunk())()(2),
             (new Map())()(static fn (array $value): array => array_values($value)),
-            (new Associate())()($callbackForKeys)($callbackForValues)
+            (new Associate())()(
+                /**
+                 * @param TKey $key
+                 * @param array{0: TKey, 1: T} $value
+                 *
+                 * @return TKey|null
+                 */
+                static fn ($key, array $value) => $value[0] ?? null
+            )(
+                /**
+                 * @param array{0: TKey, 1: T} $value
+                 *
+                 * @return T|null
+                 */
+                static fn (array $value) => $value[1] ?? null
+            )
         );
 
         // Point free style.

--- a/src/Operation/Reject.php
+++ b/src/Operation/Reject.php
@@ -41,9 +41,9 @@ final class Reject extends AbstractOperation
                      */
                     static fn ($value): bool => (bool) $value;
 
-                $callbacks = [] === $callbacks ?
-                    [$defaultCallback] :
-                    $callbacks;
+                $callback = CallbacksArrayReducer::or()(
+                    [] === $callbacks ? [$defaultCallback] : $callbacks
+                );
 
                 $reject = (new Filter())()(
                     /**
@@ -51,7 +51,7 @@ final class Reject extends AbstractOperation
                      * @param TKey $key
                      * @param iterable<TKey, T> $iterable
                      */
-                    static fn ($current, $key, iterable $iterable): bool => !CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)
+                    static fn ($current, $key, iterable $iterable): bool => !$callback($current, $key, $iterable)
                 );
 
                 // Point free style.

--- a/src/Operation/Since.php
+++ b/src/Operation/Since.php
@@ -42,10 +42,11 @@ final class Since extends AbstractOperation
                  */
                 static function (iterable $iterable) use ($callbacks): Generator {
                     $skip = false;
+                    $callback = CallbacksArrayReducer::or()($callbacks);
 
                     foreach ($iterable as $key => $current) {
                         if (false === $skip) {
-                            if (true === CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
+                            if (true === $callback($current, $key, $iterable)) {
                                 $skip = true;
 
                                 yield $key => $current;

--- a/src/Operation/Split.php
+++ b/src/Operation/Split.php
@@ -47,9 +47,10 @@ final class Split extends AbstractOperation
                      */
                     static function (iterable $iterable) use ($type, $callbacks): Generator {
                         $carry = [];
+                        $callback = CallbacksArrayReducer::or()($callbacks);
 
                         foreach ($iterable as $key => $current) {
-                            $callbackReturn = CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable);
+                            $callbackReturn = $callback($current, $key, $iterable);
 
                             if (Splitable::AFTER === $type) {
                                 $carry[] = $current;

--- a/src/Operation/TakeWhile.php
+++ b/src/Operation/TakeWhile.php
@@ -41,8 +41,10 @@ final class TakeWhile extends AbstractOperation
                  * @return Generator<TKey, T>
                  */
                 static function (iterable $iterable) use ($callbacks): Generator {
+                    $callback = CallbacksArrayReducer::or()($callbacks);
+
                     foreach ($iterable as $key => $current) {
-                        if (!CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
+                        if (false === $callback($current, $key, $iterable)) {
                             break;
                         }
 

--- a/src/Operation/Until.php
+++ b/src/Operation/Until.php
@@ -41,10 +41,12 @@ final class Until extends AbstractOperation
                  * @return Generator<TKey, T>
                  */
                 static function (iterable $iterable) use ($callbacks): Generator {
+                    $callback = CallbacksArrayReducer::or()($callbacks);
+
                     foreach ($iterable as $key => $current) {
                         yield $key => $current;
 
-                        if (CallbacksArrayReducer::or()($callbacks, $current, $key, $iterable)) {
+                        if ($callback($current, $key, $iterable)) {
                             break;
                         }
                     }

--- a/src/Operation/Wrap.php
+++ b/src/Operation/Wrap.php
@@ -25,18 +25,17 @@ final class Wrap extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $mapCallback =
-            /**
-             * @param T $value
-             * @param TKey $key
-             *
-             * @return array<TKey, T>
-             */
-            static fn ($value, $key): array => [$key => $value];
-
         /** @var Closure(iterable<TKey, T>): Generator<int, array<TKey, T>> $pipe */
         $pipe = (new Pipe())()(
-            (new Map())()($mapCallback),
+            (new Map())()(
+                /**
+                 * @param T $value
+                 * @param TKey $key
+                 *
+                 * @return array<TKey, T>
+                 */
+                static fn ($value, $key): array => [$key => $value]
+            ),
             (new Normalize())()
         );
 

--- a/src/Utils/CallbacksArrayReducer.php
+++ b/src/Utils/CallbacksArrayReducer.php
@@ -12,35 +12,37 @@ namespace loophp\collection\Utils;
 use Closure;
 
 /**
- * @immutable
+ * @internal
  *
- * @template TKey
- * @template T
+ * @immutable
  *
  * phpcs:disable Generic.Files.LineLength.TooLong
  */
 final class CallbacksArrayReducer
 {
     /**
-     * @return Closure(array<array-key, callable(T=, TKey=, iterable<TKey, T>=): bool>, T, TKey, iterable<TKey, T>): bool
+     * @return Closure(array<array-key, callable(mixed...): bool>): Closure(mixed...): bool
      */
     public static function or(): Closure
     {
         return
             /**
-             * @param array<array-key, callable(T=, TKey=, iterable<TKey, T>=): bool> $callbacks
-             * @param T $current
-             * @param TKey $key
-             * @param iterable<TKey, T> $iterable
+             * @param array<array-key, callable(mixed...): bool> $callbacks
+             *
+             * @return Closure(mixed...): bool
              */
-            static fn (array $callbacks, $current, $key, iterable $iterable): bool => array_reduce(
-                $callbacks,
+            static fn (array $callbacks): Closure =>
                 /**
-                 * @param bool $carry
-                 * @param callable(T=, TKey=, iterable<TKey, T>=): bool $callable
+                 * @param mixed ...$parameters
                  */
-                static fn (bool $carry, callable $callable): bool => $carry || $callable($current, $key, $iterable),
-                false
-            );
+                static fn (...$parameters): bool => array_reduce(
+                    $callbacks,
+                    /**
+                     * @param bool $carry
+                     * @param callable(mixed...): bool $callable
+                     */
+                    static fn (bool $carry, callable $callable): bool => $carry || $callable(...$parameters),
+                    false
+                );
     }
 }

--- a/tests/unit/Utils/CallbacksArrayReducerTest.php
+++ b/tests/unit/Utils/CallbacksArrayReducerTest.php
@@ -109,6 +109,6 @@ final class CallbacksArrayReducerTest extends TestCase
         array $iterator,
         bool $expected
     ): void {
-        self::assertSame($expected, CallbacksArrayReducer::or()($callbacks, $current, $key, $iterator));
+        self::assertSame($expected, CallbacksArrayReducer::or()($callbacks)($current, $key, $iterator));
     }
 }


### PR DESCRIPTION
Paving the way for upcoming and updated operations.

This PR:

* [x] Update the signature of `CallbackArrayReducer::or()`
* [x] It does not break backward compatibility
* [x] Mark the class as `@internal`