### PR TITLE
refactor: Update `every` operation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     ],
     "require": {
         "php": ">= 7.4",
-        "loophp/iterators": "^1.5"
+        "loophp/iterators": "^1.6"
     },
     "require-dev": {
         "amphp/parallel-functions": "^1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,7 +121,7 @@ parameters:
 			path: src/Operation/GroupBy.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$ of closure expects callable\\(mixed, mixed, iterable\\)\\: bool, Closure\\(mixed, mixed, CachingIterator\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$ of closure expects callable\\(mixed, mixed, iterable\\)\\: bool, Closure\\(mixed, mixed, loophp\\\\iterators\\\\CachingIteratorAggregate\\)\\: bool given\\.$#"
 			count: 1
 			path: src/Operation/Init.php
 

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -130,6 +130,7 @@ use loophp\collection\Operation\Window;
 use loophp\collection\Operation\Words;
 use loophp\collection\Operation\Wrap;
 use loophp\collection\Operation\Zip;
+use loophp\collection\Utils\CallbacksArrayReducer;
 use loophp\iterators\ClosureIteratorAggregate;
 use loophp\iterators\IterableIteratorAggregate;
 use loophp\iterators\ResourceIteratorAggregate;
@@ -360,7 +361,8 @@ final class Collection implements CollectionInterface
 
     public function every(callable ...$callbacks): bool
     {
-        return (new Every())()(static fn (): bool => false)(...$callbacks)($this)->current();
+        return (new Every())()(static fn (int $index, $value, $key, iterable $iterable) => CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable))(static fn (bool $r): bool => $r)($this)
+            ->current();
     }
 
     public function explode(...$explodes): CollectionInterface

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -41,7 +41,7 @@ final class Equals extends AbstractOperation
                  * @return Generator<int|TKey, bool>
                  */
                 return static function (iterable $iterable) use ($other): Generator {
-                    $otherAggregate = (new IterableIteratorAggregate($other));
+                    $otherAggregate = new IterableIteratorAggregate($other);
                     $iteratorAggregate = new IterableIteratorAggregate($iterable);
 
                     $iterator = $iteratorAggregate->getIterator();
@@ -60,9 +60,9 @@ final class Equals extends AbstractOperation
                         /**
                          * @param T $current
                          */
-                        static fn ($current): bool => (new Contains())()($current)($otherAggregate)->current();
+                        static fn (int $index, $current): bool => (new Contains())()($current)($otherAggregate)->current();
 
-                    yield from (new Every())()(static fn (): bool => false)($containsCallback)($iteratorAggregate);
+                    yield from (new Every())()($containsCallback)(static fn (bool $i): bool => $i)($iteratorAggregate);
                 };
             };
     }

--- a/src/Operation/Init.php
+++ b/src/Operation/Init.php
@@ -9,10 +9,9 @@ declare(strict_types=1);
 
 namespace loophp\collection\Operation;
 
-use CachingIterator;
 use Closure;
 use Generator;
-use loophp\iterators\IterableIteratorAggregate;
+use loophp\iterators\CachingIteratorAggregate;
 
 /**
  * @immutable
@@ -30,25 +29,14 @@ final class Init extends AbstractOperation
      */
     public function __invoke(): Closure
     {
-        $buildCachingIterator =
-            /**
-             * @param iterable<TKey, T> $iterable
-             *
-             * @return CachingIterator<TKey, T>
-             */
-            static fn (iterable $iterator): CachingIterator => new CachingIterator((new IterableIteratorAggregate($iterator))->getIterator(), CachingIterator::FULL_CACHE);
-
         /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $takeWhile */
-        $takeWhile = (new Pipe())()(
-            $buildCachingIterator,
-            (new TakeWhile())()(
-                /**
-                 * @param T $value
-                 * @param TKey $key
-                 * @param CachingIterator<TKey, T> $iterator
-                 */
-                static fn ($value, $key, CachingIterator $iterator): bool => $iterator->hasNext()
-            )
+        $takeWhile = (new TakeWhile())()(
+            /**
+             * @param T $value
+             * @param TKey $key
+             * @param CachingIteratorAggregate<TKey, T> $iterator
+             */
+            static fn ($value, $key, CachingIteratorAggregate $iterator): bool => $iterator->hasNext()
         );
 
         // Point free style.

--- a/src/Operation/MatchOne.php
+++ b/src/Operation/MatchOne.php
@@ -47,17 +47,19 @@ final class MatchOne extends AbstractOperation
 
                         /** @var Closure(iterable<TKey, T>): Generator<TKey, bool> $pipe */
                         $pipe = (new Pipe())()(
-                            (new Map())()(
+                            (new Every())()(
                                 /**
                                  * @param T $value
                                  * @param TKey $key
-                                 * @param iterable<TKey, T> $iterable
                                  */
-                                static fn ($value, $key, iterable $iterable): bool => $callback($value, $key, $iterable) === $matcher($value, $key, $iterable)
+                                static fn (int $index, $value, $key, iterable $iterable): bool => $callback($value, $key, $iterable) !== $matcher($value, $key, $iterable)
+                            )(
+                                static fn (bool $i): bool => $i
                             ),
-                            (new DropWhile())()(static fn (bool $value): bool => !$value),
-                            (new Append())()(false),
-                            (new Head())()
+                            (new Head())(),
+                            (new Map())()(
+                                static fn (bool $i): bool => !$i
+                            )
                         );
 
                         // Point free style.

--- a/src/Operation/Until.php
+++ b/src/Operation/Until.php
@@ -12,6 +12,8 @@ namespace loophp\collection\Operation;
 use Closure;
 use Generator;
 use loophp\collection\Utils\CallbacksArrayReducer;
+use loophp\iterators\CachingIteratorAggregate;
+use loophp\iterators\IterableIteratorAggregate;
 
 /**
  * @immutable
@@ -41,15 +43,20 @@ final class Until extends AbstractOperation
                  * @return Generator<TKey, T>
                  */
                 static function (iterable $iterable) use ($callbacks): Generator {
-                    $callback = CallbacksArrayReducer::or()($callbacks);
+                    $iteratorAggregate = (new CachingIteratorAggregate((new IterableIteratorAggregate($iterable))->getIterator()));
 
-                    foreach ($iterable as $key => $current) {
-                        yield $key => $current;
+                    $every = (new Every())()(
+                        /**
+                         * @param T $value
+                         * @param TKey $key
+                         * @param iterable<TKey, T> $iterable
+                         */
+                        static fn (int $index, $value, $key, iterable $iterable): bool => !CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable)
+                    )(static fn (bool $r, int $index): int => $index)($iteratorAggregate);
 
-                        if ($callback($current, $key, $iterable)) {
-                            break;
-                        }
-                    }
+                    $size = (true === $current = $every->current()) ? -1 : $current + 1;
+
+                    yield from (new Limit())()($size)(0)($iteratorAggregate);
                 };
     }
 }


### PR DESCRIPTION
Make it more flexible and fast.

This PR:

* [x] Update `every` operation
* [x] Need to update `TakeWhile` and `DropWhile`
* [ ] It breaks backward compatibility
* [x] Is covered by unit tests
* [x] Has static analysis tests (psalm, phpstan)
* [ ] Has documentation
