### PR TITLE
Simplify `every` operation

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -361,7 +361,7 @@ final class Collection implements CollectionInterface
 
     public function every(callable ...$callbacks): bool
     {
-        return (new Every())()(static fn (int $index, $value, $key, iterable $iterable) => CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable))(static fn (bool $r): bool => $r)($this)
+        return (new Every())()(static fn (int $index, $value, $key, iterable $iterable) => CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable))($this)
             ->current();
     }
 

--- a/src/Operation/Column.php
+++ b/src/Operation/Column.php
@@ -34,19 +34,15 @@ final class Column extends AbstractOperation
             static function ($column): Closure {
                 $filterCallbackBuilder =
                     /**
-                     * @param mixed $column
+                     * @param T $value
+                     * @param TKey $key
                      */
-                    static fn ($column): Closure =>
-                        /**
-                         * @param T $value
-                         * @param TKey $key
-                         */
-                        static fn ($value, $key): bool => $key === $column;
+                    static fn ($value, $key): bool => $key === $column;
 
                 /** @var Closure(iterable<TKey, T>): Generator<int, mixed> $pipe */
                 $pipe = (new Pipe())()(
                     (new Transpose())(),
-                    (new Filter())()($filterCallbackBuilder($column)),
+                    (new Filter())()($filterCallbackBuilder),
                     (new Head())(),
                     (new Flatten())()(1)
                 );

--- a/src/Operation/DropWhile.php
+++ b/src/Operation/DropWhile.php
@@ -52,9 +52,9 @@ final class DropWhile extends AbstractOperation
                      * @param iterable<TKey, T> $iterable
                      */
                     static fn (int $index, $value, $key, iterable $iterable): bool => CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable)
-                )(static fn (bool $r, int $index): int => $index)($iteratorAggregate);
+                )($iteratorAggregate);
 
-                $offset = (true === $current = $every->current()) ? 0 : $current;
+                $offset = (true === $every->current()) ? 0 : $every->key();
 
                 yield from (new Limit())()(-1)($offset)($iteratorAggregate);
             };

--- a/src/Operation/Equals.php
+++ b/src/Operation/Equals.php
@@ -62,7 +62,7 @@ final class Equals extends AbstractOperation
                          */
                         static fn (int $index, $current): bool => (new Contains())()($current)($otherAggregate)->current();
 
-                    yield from (new Every())()($containsCallback)(static fn (bool $i): bool => $i)($iteratorAggregate);
+                    yield from (new Every())()($containsCallback)($iteratorAggregate);
                 };
             };
     }

--- a/src/Operation/Every.php
+++ b/src/Operation/Every.php
@@ -24,41 +24,33 @@ use loophp\collection\Utils\CallbacksArrayReducer;
 final class Every extends AbstractOperation
 {
     /**
-     * @return Closure(callable(int=, T=, TKey=, iterable<TKey, T>=): bool): Closure(callable(bool, int, T, TKey, iterable<TKey, T>...): mixed): Closure(iterable<TKey, T>): Generator<int, mixed>
+     * @return Closure(...callable(int=, T=, TKey=, iterable<TKey, T>=): bool): Closure(iterable<TKey, T>): Generator<int, bool>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable(int=, T=, TKey=, iterable<TKey, T>=): bool $predicate
+             * @param callable(int=, T=, TKey=, iterable<TKey, T>=): bool ...$predicates
              *
-             * @return Closure(callable(bool, int, T=, TKey=, iterable<TKey, T>=): mixed): Closure(iterable<TKey, T>): Generator<int, mixed>
+             * @return Closure(iterable<TKey, T>): Generator<int, bool>
              */
             static function (callable ...$predicates): Closure {
                 return
                     /**
-                     * @param callable(bool, int, T=, TKey=, iterable<TKey, T>=): mixed $return
+                     * @param iterable<TKey, T> $iterable
                      *
-                     * @return Closure(iterable<TKey, T>): Generator<int, mixed>
+                     * @return Generator<int, bool>
                      */
-                    static function (callable $return) use ($predicates): Closure {
-                        return
-                            /**
-                             * @param iterable<TKey, T> $iterable
-                             *
-                             * @return Generator<int, mixed>
-                             */
-                            static function (iterable $iterable) use ($return, $predicates): Generator {
-                                $predicate = CallbacksArrayReducer::or()($predicates);
+                    static function (iterable $iterable) use ($predicates): Generator {
+                        $predicate = CallbacksArrayReducer::or()($predicates);
 
-                                foreach ((new Pack())()($iterable) as $index => [$key, $value]) {
-                                    if (false === $predicate($index, $value, $key, $iterable)) {
-                                        return yield $return(false, $index, $value, $key, $iterable);
-                                    }
-                                }
+                        foreach ((new Pack())()($iterable) as $index => [$key, $value]) {
+                            if (false === $predicate($index, $value, $key, $iterable)) {
+                                return yield $index => false;
+                            }
+                        }
 
-                                return yield true;
-                            };
+                        yield true;
                     };
             };
     }

--- a/src/Operation/MatchOne.php
+++ b/src/Operation/MatchOne.php
@@ -53,8 +53,6 @@ final class MatchOne extends AbstractOperation
                                  * @param TKey $key
                                  */
                                 static fn (int $index, $value, $key, iterable $iterable): bool => $callback($value, $key, $iterable) !== $matcher($value, $key, $iterable)
-                            )(
-                                static fn (bool $i): bool => $i
                             ),
                             (new Head())(),
                             (new Map())()(

--- a/src/Operation/ScanLeft1.php
+++ b/src/Operation/ScanLeft1.php
@@ -58,7 +58,7 @@ final class ScanLeft1 extends AbstractOperation
                         (new Prepend())()($initial)
                     );
 
-                    yield from $pipe($iteratorAggregate->getIterator());
+                    yield from $pipe($iteratorAggregate);
                 };
     }
 }

--- a/src/Operation/TakeWhile.php
+++ b/src/Operation/TakeWhile.php
@@ -52,9 +52,9 @@ final class TakeWhile extends AbstractOperation
                          * @param iterable<TKey, T> $iterable
                          */
                         static fn (int $index, $value, $key, iterable $iterable): bool => CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable)
-                    )(static fn (bool $r, int $index): int => $index)($iteratorAggregate);
+                    )($iteratorAggregate);
 
-                    $size = (true === $current = $every->current()) ? -1 : $current;
+                    $size = (true === $every->current()) ? -1 : $every->key();
 
                     yield from (new Limit())()($size)(0)($iteratorAggregate);
                 };

--- a/src/Operation/Until.php
+++ b/src/Operation/Until.php
@@ -52,9 +52,9 @@ final class Until extends AbstractOperation
                          * @param iterable<TKey, T> $iterable
                          */
                         static fn (int $index, $value, $key, iterable $iterable): bool => !CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable)
-                    )(static fn (bool $r, int $index): int => $index)($iteratorAggregate);
+                    )($iteratorAggregate);
 
-                    $size = (true === $current = $every->current()) ? -1 : $current + 1;
+                    $size = (true === $every->current()) ? -1 : $every->key() + 1;
 
                     yield from (new Limit())()($size)(0)($iteratorAggregate);
                 };


### PR DESCRIPTION
This PR:

* [x] Simplify `Every` - Remove obsolete callback.
