### PR TITLE
New Operations: `Compare`, `Max`, `Min`

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1472,6 +1472,22 @@ Signature: ``Collection::matching(Criteria $criteria): Collection;``
 .. literalinclude:: code/operations/matching.php
   :language: php
 
+max
+~~~
+
+Generate the maximum value of the collection by successively applying the PHP ``max`` function
+to each pair of two elements. This comparison can be redefined by providing a callback
+that takes two arguments and returns the "highest" value.
+
+.. tip:: This operation is a specialised application of ``foldLeft1``.
+
+Interface: `Maxable`_
+
+Signature: ``Collection::max(?callable $callback = null): Collection;``
+
+.. literalinclude:: code/operations/max.php
+  :language: php
+
 merge
 ~~~~~
 
@@ -1490,6 +1506,22 @@ Signature: ``Collection::merge(iterable ...$sources): Collection;``
         ->merge(Collection::fromIterable(['d', 'e']);
 
     $collection->all() // ['a', 'b', 'c', 'd', 'e']
+
+min
+~~~
+
+Generate the minimum value of the collection by successively applying the PHP ``min`` function
+to each pair of two elements. This comparison can be redefined by providing a callback
+that takes two arguments and returns the "lowest" value.
+
+.. tip:: This operation is a specialised application of ``foldLeft1``.
+
+Interface: `Minable`_
+
+Signature: ``Collection::min(?callable $callback = null): Collection;``
+
+.. literalinclude:: code/operations/min.php
+  :language: php
 
 normalize
 ~~~~~~~~~
@@ -2562,7 +2594,9 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _MapNable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/MapNable.php
 .. _Matchable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Matchable.php
 .. _Matchingable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Matchingable.php
+.. _Maxable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Maxable.php
 .. _Mergeable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Mergeable.php
+.. _Minable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Minable.php
 .. _Normalizeable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Normalizeable.php
 .. _Nthable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Nthable.php
 .. _Nullsyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Nullsyable.php

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -499,6 +499,25 @@ Signature: ``Collection::compact(...$values): Collection;``
     $collection = Collection::fromIterable(['a', 1 => 'b', null, false, 0, 'c'])
         ->compact(null, 0); // [0 => 'a', 1 => 'b', 3 => false, 5 => 'c']
 
+compare
+~~~~~~~
+
+Fold the collection through a comparison operation, yielding the "highest" or "lowest" 
+element as defined by the comparator callback. The callback takes a pair of two elements 
+and should return the "highest" or "lowest" one as desired.
+
+If no custom logic is required for the comparison, the simpler ``max`` or ``min`` operations 
+can be used instead.
+
+.. tip:: This operation is a specialised application of ``foldLeft1``.
+
+Interface: `Comparable`_
+
+Signature: ``Collection::compare(callable $comparator): Collection;``
+
+.. literalinclude:: code/operations/compare.php
+  :language: php
+
 contains
 ~~~~~~~~
 
@@ -1476,14 +1495,14 @@ max
 ~~~
 
 Generate the maximum value of the collection by successively applying the PHP ``max`` function
-to each pair of two elements. This comparison can be redefined by providing a callback
-that takes two arguments and returns the "highest" value.
+to each pair of two elements.
 
-.. tip:: This operation is a specialised application of ``foldLeft1``.
+If custom logic is required to determine the maximum, such as when comparing objects, 
+the ``compare`` operation can be used instead.
 
 Interface: `Maxable`_
 
-Signature: ``Collection::max(?callable $callback = null): Collection;``
+Signature: ``Collection::max(): Collection;``
 
 .. literalinclude:: code/operations/max.php
   :language: php
@@ -1511,14 +1530,14 @@ min
 ~~~
 
 Generate the minimum value of the collection by successively applying the PHP ``min`` function
-to each pair of two elements. This comparison can be redefined by providing a callback
-that takes two arguments and returns the "lowest" value.
+to each pair of two elements.
 
-.. tip:: This operation is a specialised application of ``foldLeft1``.
+If custom logic is required to determine the minimum, such as when comparing objects, 
+the ``compare`` operation can be used instead.
 
 Interface: `Minable`_
 
-Signature: ``Collection::min(?callable $callback = null): Collection;``
+Signature: ``Collection::min(): Collection;``
 
 .. literalinclude:: code/operations/min.php
   :language: php
@@ -2545,6 +2564,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Combinateable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Combinateable.php
 .. _Combineable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Combineable.php
 .. _Compactable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Compactable.php
+.. _Comparable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Comparable.php
 .. _Coalesceable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Coalesceable.php
 .. _Containsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Containsable.php
 .. _Currentable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Currentable.php

--- a/docs/pages/code/operations/compare.php
+++ b/docs/pages/code/operations/compare.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+use stdClass;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$callback = static fn (stdClass $left, stdClass $right): stdClass => $left->age > $right->age
+    ? $left
+    : $right;
+
+$result = Collection::fromIterable([(object) ['id' => 2, 'age' => 5], (object) ['id' => 1, 'age' => 10]])
+    ->compare($callback)
+    ->current(); // (object) ['id' => 1, 'age' => 10]

--- a/docs/pages/code/operations/max.php
+++ b/docs/pages/code/operations/max.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+use stdClass;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$callback = static fn (stdClass $left, stdClass $right): stdClass => max($left->age, $right->age);
+
+$result = Collection::fromIterable([1, 4, 3, 0, 2])
+    ->max()      // [1 => 4]
+    ->current(); // 4
+
+$result = Collection::fromIterable([1, 4, null, 0, 2])
+    ->max()
+    ->current(); // 4
+
+$result = Collection::fromIterable([(object) ['id' => 2, 'age' => 5], (object) ['id' => 1, 'age' => 10]])
+    ->max($callback)
+    ->current(); // (object) ['id' => 1, 'age' => 10]

--- a/docs/pages/code/operations/max.php
+++ b/docs/pages/code/operations/max.php
@@ -10,11 +10,8 @@ declare(strict_types=1);
 namespace App;
 
 use loophp\collection\Collection;
-use stdClass;
 
 include __DIR__ . '/../../../../vendor/autoload.php';
-
-$callback = static fn (stdClass $left, stdClass $right): stdClass => max($left->age, $right->age);
 
 $result = Collection::fromIterable([1, 4, 3, 0, 2])
     ->max()      // [1 => 4]
@@ -23,7 +20,3 @@ $result = Collection::fromIterable([1, 4, 3, 0, 2])
 $result = Collection::fromIterable([1, 4, null, 0, 2])
     ->max()
     ->current(); // 4
-
-$result = Collection::fromIterable([(object) ['id' => 2, 'age' => 5], (object) ['id' => 1, 'age' => 10]])
-    ->max($callback)
-    ->current(); // (object) ['id' => 1, 'age' => 10]

--- a/docs/pages/code/operations/min.php
+++ b/docs/pages/code/operations/min.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+use stdClass;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$callback = static fn (stdClass $left, stdClass $right): stdClass => min($left->age, $right->age);
+
+$result = Collection::fromIterable([1, 4, 3, 0, 2])
+    ->min()      // [4 => 0]
+    ->current(); // 0
+
+$result = Collection::fromIterable([1, 4, null, 0, 2])
+    ->min()
+    ->current(); // null
+
+$result = Collection::fromIterable([(object) ['id' => 2, 'age' => 5], (object) ['id' => 1, 'age' => 10]])
+    ->min($callback)
+    ->current(); // (object) ['id' => 2, 'age' => 5]

--- a/docs/pages/code/operations/min.php
+++ b/docs/pages/code/operations/min.php
@@ -10,11 +10,8 @@ declare(strict_types=1);
 namespace App;
 
 use loophp\collection\Collection;
-use stdClass;
 
 include __DIR__ . '/../../../../vendor/autoload.php';
-
-$callback = static fn (stdClass $left, stdClass $right): stdClass => min($left->age, $right->age);
 
 $result = Collection::fromIterable([1, 4, 3, 0, 2])
     ->min()      // [4 => 0]
@@ -23,7 +20,3 @@ $result = Collection::fromIterable([1, 4, 3, 0, 2])
 $result = Collection::fromIterable([1, 4, null, 0, 2])
     ->min()
     ->current(); // null
-
-$result = Collection::fromIterable([(object) ['id' => 2, 'age' => 5], (object) ['id' => 1, 'age' => 10]])
-    ->min($callback)
-    ->current(); // (object) ['id' => 2, 'age' => 5]

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -30,6 +30,7 @@ use loophp\collection\Operation\Column;
 use loophp\collection\Operation\Combinate;
 use loophp\collection\Operation\Combine;
 use loophp\collection\Operation\Compact;
+use loophp\collection\Operation\Compare;
 use loophp\collection\Operation\Contains;
 use loophp\collection\Operation\Current;
 use loophp\collection\Operation\Cycle;
@@ -255,6 +256,11 @@ final class Collection implements CollectionInterface
     public function compact(...$values): CollectionInterface
     {
         return new self((new Compact())()(...$values), [$this]);
+    }
+
+    public function compare(callable $comparator): CollectionInterface
+    {
+        return new self((new Compare())()($comparator), [$this]);
     }
 
     public function contains(...$values): bool
@@ -645,9 +651,9 @@ final class Collection implements CollectionInterface
         return new self((new Matching())()($criteria), [$this]);
     }
 
-    public function max(?callable $callback = null): CollectionInterface
+    public function max(): CollectionInterface
     {
-        return new self((new Max())()($callback), [$this]);
+        return new self((new Max())(), [$this]);
     }
 
     public function merge(iterable ...$sources): CollectionInterface
@@ -655,9 +661,9 @@ final class Collection implements CollectionInterface
         return new self((new Merge())()(...$sources), [$this]);
     }
 
-    public function min(?callable $callback = null): CollectionInterface
+    public function min(): CollectionInterface
     {
-        return new self((new Min())()($callback), [$this]);
+        return new self((new Min())(), [$this]);
     }
 
     public function normalize(): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -78,7 +78,9 @@ use loophp\collection\Operation\Map;
 use loophp\collection\Operation\MapN;
 use loophp\collection\Operation\Matching;
 use loophp\collection\Operation\MatchOne;
+use loophp\collection\Operation\Max;
 use loophp\collection\Operation\Merge;
+use loophp\collection\Operation\Min;
 use loophp\collection\Operation\Normalize;
 use loophp\collection\Operation\Nth;
 use loophp\collection\Operation\Nullsy;
@@ -643,9 +645,19 @@ final class Collection implements CollectionInterface
         return new self((new Matching())()($criteria), [$this]);
     }
 
+    public function max(?callable $callback = null): CollectionInterface
+    {
+        return new self((new Max())()($callback), [$this]);
+    }
+
     public function merge(iterable ...$sources): CollectionInterface
     {
         return new self((new Merge())()(...$sources), [$this]);
+    }
+
+    public function min(?callable $callback = null): CollectionInterface
+    {
+        return new self((new Min())()($callback), [$this]);
     }
 
     public function normalize(): CollectionInterface

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -75,7 +75,9 @@ use loophp\collection\Contract\Operation\Mapable;
 use loophp\collection\Contract\Operation\MapNable;
 use loophp\collection\Contract\Operation\Matchable;
 use loophp\collection\Contract\Operation\Matchingable;
+use loophp\collection\Contract\Operation\Maxable;
 use loophp\collection\Contract\Operation\Mergeable;
+use loophp\collection\Contract\Operation\Minable;
 use loophp\collection\Contract\Operation\Normalizeable;
 use loophp\collection\Contract\Operation\Nthable;
 use loophp\collection\Contract\Operation\Nullsyable;
@@ -200,7 +202,9 @@ use Traversable;
  * @template-extends MapNable<TKey, T>
  * @template-extends Matchable<TKey, T>
  * @template-extends Matchingable<TKey, T>
+ * @template-extends Maxable<TKey, T>
  * @template-extends Mergeable<TKey, T>
+ * @template-extends Minable<TKey, T>
  * @template-extends Normalizeable<TKey, T>
  * @template-extends Nthable<TKey, T>
  * @template-extends Nullsyable<TKey, T>
@@ -321,7 +325,9 @@ interface Collection extends
     MapNable,
     Matchable,
     Matchingable,
+    Maxable,
     Mergeable,
+    Minable,
     Normalizeable,
     Nthable,
     Nullsyable,

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -27,6 +27,7 @@ use loophp\collection\Contract\Operation\Columnable;
 use loophp\collection\Contract\Operation\Combinateable;
 use loophp\collection\Contract\Operation\Combineable;
 use loophp\collection\Contract\Operation\Compactable;
+use loophp\collection\Contract\Operation\Comparable;
 use loophp\collection\Contract\Operation\Containsable;
 use loophp\collection\Contract\Operation\Currentable;
 use loophp\collection\Contract\Operation\Cycleable;
@@ -154,6 +155,7 @@ use Traversable;
  * @template-extends Combinateable<TKey, T>
  * @template-extends Combineable<TKey, T>
  * @template-extends Compactable<TKey, T>
+ * @template-extends Comparable<TKey, T>
  * @template-extends Containsable<TKey, T>
  * @template-extends Currentable<TKey, T>
  * @template-extends Cycleable<TKey, T>
@@ -274,6 +276,7 @@ interface Collection extends
     Combinateable,
     Combineable,
     Compactable,
+    Comparable,
     Containsable,
     Countable,
     Currentable,

--- a/src/Contract/Operation/Comparable.php
+++ b/src/Contract/Operation/Comparable.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Comparable
+{
+    /**
+     * Fold the collection through a comparison operation, yielding the "highest" or "lowest"
+     * element as defined by the comparator callback. The callback takes a pair of two elements
+     * and should return the "highest" or "lowest" one as desired.
+     *
+     * If no custom logic is required for the comparison, the simpler `max` or `min` operations
+     * can be used instead.
+     *
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#compare
+     *
+     * @param callable(T, T): T $comparator
+     *
+     * @return Collection<TKey, T>
+     */
+    public function compare(callable $comparator): Collection;
+}

--- a/src/Contract/Operation/Maxable.php
+++ b/src/Contract/Operation/Maxable.php
@@ -19,15 +19,15 @@ interface Maxable
 {
     /**
      * Generate the maximum value of the collection by successively applying the PHP `max` function
-     * to each pair of two elements. This comparison can be redefined by providing a callback
-     * that takes two arguments and returns the "highest" value.
+     * to each pair of two elements.
+     *
+     * If custom logic is required to determine the maximum, such as when comparing objects,
+     * the `compare` operation can be used instead.
      *
      * @see https://www.php.net/manual/en/function.max.php
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#max
      *
-     * @param null|callable(T, T): T $callback
-     *
      * @return Collection<TKey, T>
      */
-    public function max(?callable $callback = null): Collection;
+    public function max(): Collection;
 }

--- a/src/Contract/Operation/Maxable.php
+++ b/src/Contract/Operation/Maxable.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Maxable
+{
+    /**
+     * Generate the maximum value of the collection by successively applying the PHP `max` function
+     * to each pair of two elements. This comparison can be redefined by providing a callback
+     * that takes two arguments and returns the "highest" value.
+     *
+     * @see https://www.php.net/manual/en/function.max.php
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#max
+     *
+     * @param null|callable(T, T): T $callback
+     *
+     * @return Collection<TKey, T>
+     */
+    public function max(?callable $callback = null): Collection;
+}

--- a/src/Contract/Operation/Minable.php
+++ b/src/Contract/Operation/Minable.php
@@ -19,15 +19,15 @@ interface Minable
 {
     /**
      * Generate the minimum value of the collection by successively applying the PHP `min` function
-     * to each pair of two elements. This comparison can be redefined by providing a callback
-     * that takes two arguments and returns the "lowest" value.
+     * to each pair of two elements.
+     *
+     * If custom logic is required to determine the minimum, such as when comparing objects,
+     * the `compare` operation can be used instead.
      *
      * @see https://www.php.net/manual/en/function.min.php
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#min
      *
-     * @param null|callable(T, T): T $callback
-     *
      * @return Collection<TKey, T>
      */
-    public function min(?callable $callback = null): Collection;
+    public function min(): Collection;
 }

--- a/src/Contract/Operation/Minable.php
+++ b/src/Contract/Operation/Minable.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Minable
+{
+    /**
+     * Generate the minimum value of the collection by successively applying the PHP `min` function
+     * to each pair of two elements. This comparison can be redefined by providing a callback
+     * that takes two arguments and returns the "lowest" value.
+     *
+     * @see https://www.php.net/manual/en/function.min.php
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#min
+     *
+     * @param null|callable(T, T): T $callback
+     *
+     * @return Collection<TKey, T>
+     */
+    public function min(?callable $callback = null): Collection;
+}

--- a/src/Operation/Compare.php
+++ b/src/Operation/Compare.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Compare extends AbstractOperation
+{
+    /**
+     * @return Closure(callable(T, T): T): Closure(iterable<TKey, T>): Generator<TKey, T>
+     */
+    public function __invoke(): Closure
+    {
+        return
+            /**
+             * @param callable(T, T): T $comparator
+             *
+             * @return Closure(iterable<TKey, T>): Generator<TKey,T>
+             */
+            static function (callable $comparator): Closure {
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
+                $pipe = (new Pipe())()(
+                    (new FoldLeft1())()($comparator),
+                    (new Last())(),
+                );
+
+                // Point free style.
+                return $pipe;
+            };
+    }
+}

--- a/src/Operation/Max.php
+++ b/src/Operation/Max.php
@@ -21,34 +21,19 @@ use Generator;
 final class Max extends AbstractOperation
 {
     /**
-     * @return Closure(null|callable(T, T): T): Closure(iterable<TKey, T>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
-        return
+        $comparator =
             /**
-             * @param null|callable(T, T): T $callback
+             * @param T $carry
+             * @param T $value
              *
-             * @return Closure(iterable<TKey, T>): Generator<TKey,T>
+             * @return T
              */
-            static function (?callable $callback = null): Closure {
-                $callback ??=
-                    /**
-                     * @param T $carry
-                     * @param T $value
-                     *
-                     * @return T
-                     */
-                    static fn ($carry, $value) => max($value, $carry);
+            static fn ($carry, $value) => max($value, $carry);
 
-                /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
-                $pipe = (new Pipe())()(
-                    (new FoldLeft1())()($callback),
-                    (new Last())(),
-                );
-
-                // Point free style.
-                return $pipe;
-            };
+        return (new Compare())()($comparator);
     }
 }

--- a/src/Operation/Max.php
+++ b/src/Operation/Max.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Max extends AbstractOperation
+{
+    /**
+     * @return Closure(null|callable(T, T): T): Closure(iterable<TKey, T>): Generator<TKey, T>
+     */
+    public function __invoke(): Closure
+    {
+        return
+            /**
+             * @param null|callable(T, T): T $callback
+             *
+             * @return Closure(iterable<TKey, T>): Generator<TKey,T>
+             */
+            static function (?callable $callback = null): Closure {
+                $callback ??=
+                    /**
+                     * @param T $carry
+                     * @param T $value
+                     *
+                     * @return T
+                     */
+                    static fn ($carry, $value) => max($value, $carry);
+
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
+                $pipe = (new Pipe())()(
+                    (new FoldLeft1())()($callback),
+                    (new Last())(),
+                );
+
+                // Point free style.
+                return $pipe;
+            };
+    }
+}

--- a/src/Operation/Min.php
+++ b/src/Operation/Min.php
@@ -21,34 +21,19 @@ use Generator;
 final class Min extends AbstractOperation
 {
     /**
-     * @return Closure(null|callable(T, T): T): Closure(iterable<TKey, T>): Generator<TKey, T>
+     * @return Closure(iterable<TKey, T>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
-        return
+        $comparator =
             /**
-             * @param null|callable(T, T): T $callback
+             * @param T $carry
+             * @param T $value
              *
-             * @return Closure(iterable<TKey, T>): Generator<TKey,T>
+             * @return T
              */
-            static function (?callable $callback = null): Closure {
-                $callback ??=
-                    /**
-                     * @param T $carry
-                     * @param T $value
-                     *
-                     * @return T
-                     */
-                    static fn ($carry, $value) => min($value, $carry);
+            static fn ($carry, $value) => min($value, $carry);
 
-                /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
-                $pipe = (new Pipe())()(
-                    (new FoldLeft1())()($callback),
-                    (new Last())(),
-                );
-
-                // Point free style.
-                return $pipe;
-            };
+        return (new Compare())()($comparator);
     }
 }

--- a/src/Operation/Min.php
+++ b/src/Operation/Min.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Min extends AbstractOperation
+{
+    /**
+     * @return Closure(null|callable(T, T): T): Closure(iterable<TKey, T>): Generator<TKey, T>
+     */
+    public function __invoke(): Closure
+    {
+        return
+            /**
+             * @param null|callable(T, T): T $callback
+             *
+             * @return Closure(iterable<TKey, T>): Generator<TKey,T>
+             */
+            static function (?callable $callback = null): Closure {
+                $callback ??=
+                    /**
+                     * @param T $carry
+                     * @param T $value
+                     *
+                     * @return T
+                     */
+                    static fn ($carry, $value) => min($value, $carry);
+
+                /** @var Closure(iterable<TKey, T>): Generator<TKey, T> $pipe */
+                $pipe = (new Pipe())()(
+                    (new FoldLeft1())()($callback),
+                    (new Last())(),
+                );
+
+                // Point free style.
+                return $pipe;
+            };
+    }
+}

--- a/tests/static-analysis/compare.php
+++ b/tests/static-analysis/compare.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function compare_checkListInt(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<int, int|null> $collection
+ */
+function compare_checkNullableListInt(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function compare_checkMapString(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, string|null> $collection
+ */
+function compare_checkMapNullableString(CollectionInterface $collection): void
+{
+}
+
+$compareInt = static fn (int $left, int $right): int => $right < $left ? $right : $left;
+$compareNullableInt = static fn (?int $left, ?int $right): ?int => $right < $left ? $right : $left;
+
+$compareString = static fn (string $left, string $right): string => $right < $left ? $right : $left;
+$compareNullableString = static fn (?string $left, ?string $right): ?string => $right < $left ? $right : $left;
+
+// These are valid and should work, however Psalm restricts the values that the callable
+// is allowed to accept to the list of values contained in the collection
+/** @psalm-suppress ArgumentTypeCoercion */
+compare_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->compare($compareInt));
+/** @psalm-suppress ArgumentTypeCoercion */
+compare_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->compare($compareString));
+/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
+compare_checkNullableListInt(Collection::fromIterable([1, 2, null, -2, 4])->compare($compareNullableInt));
+/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
+compare_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->compare($compareNullableString));
+
+// VALID failures
+// usage of callback with different types for `carry` and `value`
+/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+compare_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->compare($compareNullableInt));
+/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+compare_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->compare($compareNullableString));

--- a/tests/static-analysis/max.php
+++ b/tests/static-analysis/max.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function max_checkListInt(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<int, int|null> $collection
+ */
+function max_checkNullableListInt(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function max_checkMapString(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, string|null> $collection
+ */
+function max_checkMapNullableString(CollectionInterface $collection): void
+{
+}
+
+$compareInt = static fn (int $left, int $right): int => $right > $left ? $right : $left;
+$compareNullableInt = static fn (?int $left, ?int $right): ?int => $right > $left ? $right : $left;
+
+$compareString = static fn (string $left, string $right): string => $right > $left ? $right : $left;
+$compareNullableString = static fn (?string $left, ?string $right): ?string => $right > $left ? $right : $left;
+
+max_checkListInt(Collection::empty()->max());
+max_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->max());
+
+max_checkNullableListInt(Collection::empty()->max());
+max_checkNullableListInt(Collection::fromIterable([1, 2, null, -2, 4])->max());
+
+max_checkMapString(Collection::empty()->max());
+max_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max());
+
+max_checkMapNullableString(Collection::empty()->max());
+max_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->max());
+
+// These are valid and should work, however Psalm restricts the values that the callable
+// is allowed to accept to the list of values contained in the collection
+/** @psalm-suppress ArgumentTypeCoercion */
+max_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->max($compareInt));
+/** @psalm-suppress ArgumentTypeCoercion */
+max_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max($compareString));
+/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
+max_checkNullableListInt(Collection::fromIterable([1, 2, null, -2, 4])->max($compareNullableInt));
+/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
+max_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->max($compareNullableString));
+
+// VALID failures
+// usage of callback with different types for `carry` and `value`
+/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+max_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->max($compareNullableInt));
+/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+max_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max($compareNullableString));

--- a/tests/static-analysis/max.php
+++ b/tests/static-analysis/max.php
@@ -40,12 +40,6 @@ function max_checkMapNullableString(CollectionInterface $collection): void
 {
 }
 
-$compareInt = static fn (int $left, int $right): int => $right > $left ? $right : $left;
-$compareNullableInt = static fn (?int $left, ?int $right): ?int => $right > $left ? $right : $left;
-
-$compareString = static fn (string $left, string $right): string => $right > $left ? $right : $left;
-$compareNullableString = static fn (?string $left, ?string $right): ?string => $right > $left ? $right : $left;
-
 max_checkListInt(Collection::empty()->max());
 max_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->max());
 
@@ -57,21 +51,3 @@ max_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max()
 
 max_checkMapNullableString(Collection::empty()->max());
 max_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->max());
-
-// These are valid and should work, however Psalm restricts the values that the callable
-// is allowed to accept to the list of values contained in the collection
-/** @psalm-suppress ArgumentTypeCoercion */
-max_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->max($compareInt));
-/** @psalm-suppress ArgumentTypeCoercion */
-max_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max($compareString));
-/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
-max_checkNullableListInt(Collection::fromIterable([1, 2, null, -2, 4])->max($compareNullableInt));
-/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
-max_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->max($compareNullableString));
-
-// VALID failures
-// usage of callback with different types for `carry` and `value`
-/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
-max_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->max($compareNullableInt));
-/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
-max_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max($compareNullableString));

--- a/tests/static-analysis/min.php
+++ b/tests/static-analysis/min.php
@@ -40,12 +40,6 @@ function min_checkMapNullableString(CollectionInterface $collection): void
 {
 }
 
-$compareInt = static fn (int $left, int $right): int => $right < $left ? $right : $left;
-$compareNullableInt = static fn (?int $left, ?int $right): ?int => $right < $left ? $right : $left;
-
-$compareString = static fn (string $left, string $right): string => $right < $left ? $right : $left;
-$compareNullableString = static fn (?string $left, ?string $right): ?string => $right < $left ? $right : $left;
-
 min_checkListInt(Collection::empty()->min());
 min_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->min());
 
@@ -57,21 +51,3 @@ min_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min()
 
 min_checkMapNullableString(Collection::empty()->min());
 min_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->min());
-
-// These are valid and should work, however Psalm restricts the values that the callable
-// is allowed to accept to the list of values contained in the collection
-/** @psalm-suppress ArgumentTypeCoercion */
-min_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->min($compareInt));
-/** @psalm-suppress ArgumentTypeCoercion */
-min_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min($compareString));
-/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
-min_checkNullableListInt(Collection::fromIterable([1, 2, null, -2, 4])->min($compareNullableInt));
-/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
-min_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->min($compareNullableString));
-
-// VALID failures
-// usage of callback with different types for `carry` and `value`
-/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
-min_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->min($compareNullableInt));
-/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
-min_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min($compareNullableString));

--- a/tests/static-analysis/min.php
+++ b/tests/static-analysis/min.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int> $collection
+ */
+function min_checkListInt(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<int, int|null> $collection
+ */
+function min_checkNullableListInt(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function min_checkMapString(CollectionInterface $collection): void
+{
+}
+
+/**
+ * @param CollectionInterface<string, string|null> $collection
+ */
+function min_checkMapNullableString(CollectionInterface $collection): void
+{
+}
+
+$compareInt = static fn (int $left, int $right): int => $right < $left ? $right : $left;
+$compareNullableInt = static fn (?int $left, ?int $right): ?int => $right < $left ? $right : $left;
+
+$compareString = static fn (string $left, string $right): string => $right < $left ? $right : $left;
+$compareNullableString = static fn (?string $left, ?string $right): ?string => $right < $left ? $right : $left;
+
+min_checkListInt(Collection::empty()->min());
+min_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->min());
+
+min_checkNullableListInt(Collection::empty()->min());
+min_checkNullableListInt(Collection::fromIterable([1, 2, null, -2, 4])->min());
+
+min_checkMapString(Collection::empty()->min());
+min_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min());
+
+min_checkMapNullableString(Collection::empty()->min());
+min_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->min());
+
+// These are valid and should work, however Psalm restricts the values that the callable
+// is allowed to accept to the list of values contained in the collection
+/** @psalm-suppress ArgumentTypeCoercion */
+min_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->min($compareInt));
+/** @psalm-suppress ArgumentTypeCoercion */
+min_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min($compareString));
+/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
+min_checkNullableListInt(Collection::fromIterable([1, 2, null, -2, 4])->min($compareNullableInt));
+/** @psalm-suppress ArgumentTypeCoercion,InvalidArgument */
+min_checkMapNullableString(Collection::fromIterable(['f' => 'foo', 'b' => null])->min($compareNullableString));
+
+// VALID failures
+// usage of callback with different types for `carry` and `value`
+/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+min_checkListInt(Collection::fromIterable([1, 2, 3, -2, 4])->min($compareNullableInt));
+/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+min_checkMapString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min($compareNullableString));

--- a/tests/unit/CollectionGenericOperationTest.php
+++ b/tests/unit/CollectionGenericOperationTest.php
@@ -79,6 +79,8 @@ final class CollectionGenericOperationTest extends TestCase
      * @dataProvider mapOperationProvider
      * @dataProvider mapNOperationProvider
      * @dataProvider matchingOperationProvider
+     * @dataProvider maxOperationProvider
+     * @dataProvider minOperationProvider
      * @dataProvider mergeOperationProvider
      * @dataProvider normalizeOperationProvider
      * @dataProvider nthOperationProvider

--- a/tests/unit/CollectionGenericOperationTest.php
+++ b/tests/unit/CollectionGenericOperationTest.php
@@ -40,6 +40,7 @@ final class CollectionGenericOperationTest extends TestCase
      * @dataProvider combinateOperationProvider
      * @dataProvider combineOperationProvider
      * @dataProvider compactOperationProvider
+     * @dataProvider compareOperationProvider
      * @dataProvider cycleOperationProvider
      * @dataProvider diffOperationProvider
      * @dataProvider diffKeysOperationProvider

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -519,6 +519,54 @@ trait GenericCollectionProviders
         ];
     }
 
+    /**
+     * @return iterable<array{0: string, 1: array, 2: iterable, 3: iterable}>
+     */
+    public function compareOperationProvider(): iterable
+    {
+        $operation = 'compare';
+
+        $callback = static fn (int $left, int $right): int => $left < $right ? $left : $right;
+
+        yield [
+            $operation,
+            [$callback],
+            [1, 2, 3, 4, 5],
+            [4 => 1],
+        ];
+
+        $callback = static fn (int $left, int $right): int => $left > $right ? $left : $right;
+
+        yield [
+            $operation,
+            [$callback],
+            [1, 2, 3, 4, 5],
+            [4 => 5],
+        ];
+
+        $callback = static fn (string $left, string $right): string => min($left, $right);
+
+        yield [
+            $operation,
+            [$callback],
+            ['foo' => 'f', 'bar' => 'b', 'tar' => 't'],
+            ['tar' => 'b'],
+        ];
+
+        $callback = static fn (stdClass $carry, stdClass $current): stdClass => $current->age < $carry->age
+            ? $current
+            : $carry;
+
+        $expected = (object) ['id' => 2, 'age' => 3];
+
+        yield [
+            $operation,
+            [$callback],
+            [(object) ['id' => 1, 'age' => 5], $expected, (object) ['id' => 3, 'age' => 12]],
+            [2 => $expected],
+        ];
+    }
+
     public function containsOperationProvider()
     {
         $operation = 'contains';
@@ -2725,20 +2773,6 @@ trait GenericCollectionProviders
             ['foo' => 'f', 'bar' => 'b', 'tar' => 't'],
             ['tar' => 't'],
         ];
-
-        $callback = static fn (stdClass $carry, stdClass $current): stdClass => $current->age > $carry->age
-            ? $current
-            : $carry;
-
-        $expected = (object) ['id' => 2, 'age' => 15];
-        $elem = [(object) ['id' => 1, 'age' => 5], $expected, (object) ['id' => 3, 'age' => 12]];
-
-        yield [
-            $operation,
-            [$callback],
-            $elem,
-            [2 => $expected],
-        ];
     }
 
     public function mergeOperationProvider()
@@ -2797,20 +2831,6 @@ trait GenericCollectionProviders
             [],
             ['foo' => 'f', 'bar' => 'b', 'tar' => 't'],
             ['tar' => 'b'],
-        ];
-
-        $callback = static fn (stdClass $carry, stdClass $current): stdClass => $current->age < $carry->age
-            ? $current
-            : $carry;
-
-        $expected = (object) ['id' => 2, 'age' => 3];
-        $elem = [(object) ['id' => 1, 'age' => 5], $expected, (object) ['id' => 3, 'age' => 12]];
-
-        yield [
-            $operation,
-            [$callback],
-            $elem,
-            [2 => $expected],
         ];
     }
 

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -2698,6 +2698,49 @@ trait GenericCollectionProviders
         ];
     }
 
+    /**
+     * @return iterable<array{0: string, 1: array, 2: iterable, 3: iterable}>
+     */
+    public function maxOperationProvider(): iterable
+    {
+        $operation = 'max';
+
+        yield [
+            $operation,
+            [],
+            [1, 2, 3, 4, 5],
+            [4 => 5],
+        ];
+
+        yield [
+            $operation,
+            [],
+            [-1, 200, -100, -3, -500],
+            [4 => 200],
+        ];
+
+        yield [
+            $operation,
+            [],
+            ['foo' => 'f', 'bar' => 'b', 'tar' => 't'],
+            ['tar' => 't'],
+        ];
+
+        $callback = static fn (stdClass $carry, stdClass $current): stdClass => $current->age > $carry->age
+            ? $current
+            : $carry;
+
+        $expected = (object) ['id' => 2, 'age' => 15];
+        $elem = [(object) ['id' => 1, 'age' => 5], $expected, (object) ['id' => 3, 'age' => 12]];
+
+        yield [
+            $operation,
+            [$callback],
+            $elem,
+            [2 => $expected],
+        ];
+    }
+
     public function mergeOperationProvider()
     {
         $parameter = static function () {
@@ -2725,6 +2768,49 @@ trait GenericCollectionProviders
             ],
             range('A', 'C'),
             $generator(),
+        ];
+    }
+
+    /**
+     * @return iterable<array{0: string, 1: array, 2: iterable, 3: iterable}>
+     */
+    public function minOperationProvider(): iterable
+    {
+        $operation = 'min';
+
+        yield [
+            $operation,
+            [],
+            [1, 2, 3, 4, 5],
+            [4 => 1],
+        ];
+
+        yield [
+            $operation,
+            [],
+            [1, 2, -100, 4, 5],
+            [4 => -100],
+        ];
+
+        yield [
+            $operation,
+            [],
+            ['foo' => 'f', 'bar' => 'b', 'tar' => 't'],
+            ['tar' => 'b'],
+        ];
+
+        $callback = static fn (stdClass $carry, stdClass $current): stdClass => $current->age < $carry->age
+            ? $current
+            : $carry;
+
+        $expected = (object) ['id' => 2, 'age' => 3];
+        $elem = [(object) ['id' => 1, 'age' => 5], $expected, (object) ['id' => 3, 'age' => 12]];
+
+        yield [
+            $operation,
+            [$callback],
+            $elem,
+            [2 => $expected],
         ];
     }
 


### PR DESCRIPTION
This PR:

* [x] Introduces two operations to compute the _minimum_ and _maximum_ value of a collection, as well as to compare items with a custom comparator
* [x] Is covered by unit tests
* [x] Has static analysis tests (psalm, phpstan)
* [x] Has documentation
