### PR TITLE
idea: add `AbstractCollection`

### DIFF
--- a/docs/pages/code/extending-collection-with-abstract-class.php
+++ b/docs/pages/code/extending-collection-with-abstract-class.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../../vendor/autoload.php';
+
+use Generator;
+use loophp\collection\AbstractCollection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+use loophp\collection\Operation\Range;
+use loophp\collection\Operation\Times;
+use loophp\collection\Operation\Unfold;
+use loophp\iterators\ClosureIteratorAggregate;
+use loophp\iterators\IterableIteratorAggregate;
+use loophp\iterators\ResourceIteratorAggregate;
+use loophp\iterators\StringIteratorAggregate;
+use NoRewindIterator;
+use Traversable;
+
+use const INF;
+
+final class MyCustomFoobarCollection extends AbstractCollection
+{
+    /**
+     * @var ClosureIteratorAggregate<TKey, T>
+     */
+    private ClosureIteratorAggregate $innerIterator;
+
+    /**
+     * @param callable(mixed ...$parameters): iterable<TKey, T> $callable
+     * @param iterable<int, mixed> $parameters
+     */
+    private function __construct(callable $callable, iterable $parameters = [])
+    {
+        $this->innerIterator = new ClosureIteratorAggregate($callable, $parameters);
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @return self<UKey, U>
+     */
+    public static function empty(): CollectionInterface
+    {
+        return new self(static fn (): Generator => yield from []);
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param callable(mixed ...$parameters): iterable<UKey, U> $callable
+     * @param iterable<int, mixed> $parameters
+     *
+     * @return self<UKey, U>
+     */
+    public static function fromCallable(callable $callable, iterable $parameters = []): self
+    {
+        return new self($callable, $parameters);
+    }
+
+    /**
+     * @return self<int, string>
+     */
+    public static function fromFile(string $filepath): self
+    {
+        return new self(
+            static fn (): Generator => yield from new ResourceIteratorAggregate(fopen($filepath, 'rb'), true),
+        );
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @return self<UKey, U>
+     */
+    public static function fromGenerator(Generator $generator): self
+    {
+        return new self(static fn (): Generator => yield from new NoRewindIterator($generator));
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param iterable<UKey, U> $iterable
+     *
+     * @return self<UKey, U>
+     */
+    public static function fromIterable(iterable $iterable): self
+    {
+        return new self(static fn (): Generator => yield from new IterableIteratorAggregate($iterable));
+    }
+
+    /**
+     * @param resource $resource
+     *
+     * @return self<int, string>
+     */
+    public static function fromResource($resource): self
+    {
+        return new self(static fn (): Generator => yield from new ResourceIteratorAggregate($resource));
+    }
+
+    /**
+     * @return self<int, string>
+     */
+    public static function fromString(string $string, string $delimiter = ''): self
+    {
+        return new self(static fn (): Generator => yield from new StringIteratorAggregate($string, $delimiter));
+    }
+
+    /**
+     * @return Traversable<TKey, T>
+     */
+    public function getIterator(): Traversable
+    {
+        yield from $this->innerIterator->getIterator();
+    }
+
+    public static function range(float $start = 0.0, float $end = INF, float $step = 1.0): CollectionInterface
+    {
+        return new self((new Range())()($start)($end)($step));
+    }
+
+    public static function times(int $number = 0, ?callable $callback = null): CollectionInterface
+    {
+        return new self((new Times())()($number)($callback));
+    }
+
+    public static function unfold(callable $callback, ...$parameters): CollectionInterface
+    {
+        return new self((new Unfold())()(...$parameters)($callback));
+    }
+}

--- a/docs/pages/usage.rst
+++ b/docs/pages/usage.rst
@@ -100,10 +100,12 @@ enough.
 Then, you would like to create your own collection class with some specific
 feature added on top of it.
 
-Every classes of this library are ``final`` and then it is impossible to use
-inheritance and use the original Collection class as parent of another one.
+The main Collection class of this library is ``final`` and then it is impossible
+to use inheritance and use the original Collection class as parent of another
+one.
 
-If you want to **extend** the Collection, you must use the Composition pattern.
+If you want to **extend** the Collection, you have to use the Composition
+pattern or extend the new AbstractCollection class available since version 7.
 
 You can read more about Inheritance and Composition by doing a query on your
 favorite search engine. I also wrote an `article`_ about this.
@@ -112,6 +114,14 @@ Find here an example on how you could extend the collection class and add a
 new Operation ``foobar``.
 
 .. literalinclude:: code/extending-collection.php
+  :language: php
+
+Since version 7, you can extend the provided abstract class which implements
+most of the available methods. The only methods that are left to implements are
+the static constructors, you can simply copy paste them from the main Collection
+class.
+
+.. literalinclude:: code/extending-collection-with-abstract-class.php
   :language: php
 
 Manipulate strings

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,149 +1,229 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:group\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:group\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:inits\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, array\\{TKey, T\\}\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int, array\\{mixed, mixed\\}\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:inits\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, array\\{TKey, T\\}\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, array\\{mixed, mixed\\}\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:pack\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\{TKey, T\\}\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\{mixed, mixed\\}\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:pack\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\{TKey, T\\}\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\{mixed, mixed\\}\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:partition\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<TKey, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, loophp\\\\collection\\\\Collection\\<mixed, mixed\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:partition\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<TKey, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, loophp\\\\collection\\\\Collection\\<mixed, mixed\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:span\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<TKey, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, loophp\\\\collection\\\\Collection\\<mixed, mixed\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:span\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<TKey, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, loophp\\\\collection\\\\Collection\\<mixed, mixed\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:tails\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:tails\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:transpose\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<TKey, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Collection\\<mixed, array\\<int, mixed\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:transpose\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<TKey, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, array\\<int, mixed\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:unzip\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:unzip\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:wrap\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<\\(int&TKey\\)\\|\\(string&TKey\\), T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int\\|string, mixed\\>\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\AbstractCollection\\:\\:wrap\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<\\(int&TKey\\)\\|\\(string&TKey\\), T\\>\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int\\|string, mixed\\>\\>\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed, mixed, mixed, iterable\\)\\: mixed, callable\\(T\\|V, T, TKey, Iterator\\<TKey, T\\>\\)\\: V given\\.$#"
-			count: 4
-			path: src/Collection.php
+			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed, mixed, mixed, iterable\\)\\: mixed, callable\\(T, T, TKey, Iterator\\<TKey, T\\>\\)\\: T given\\.$#"
+			count: 1
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed, mixed, mixed, iterable\\)\\: mixed, callable\\(T, T, TKey, Iterator\\<TKey, T\\>\\)\\: V given\\.$#"
+			count: 1
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed, mixed, mixed, iterable\\)\\: mixed, callable\\(T\\|W, T, TKey, Iterator\\<TKey, T\\>\\)\\: W given\\.$#"
+			count: 2
+			path: src/AbstractCollection.php
 
 		-
 			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed\\=, mixed\\=, iterable\\=\\)\\: mixed, \\(callable\\(TKey\\=, T\\=, Iterator\\<TKey, T\\>\\=\\)\\: UKey\\)\\|\\(Closure\\(mixed\\)\\: mixed\\) given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
 			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed\\=, mixed\\=, iterable\\=\\)\\: mixed, callable\\(T\\=, TKey\\=, Iterator\\<TKey, T\\>\\=\\)\\: U given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\)\\: Generator\\<mixed, mixed, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed\\=, mixed\\=, mixed\\=, iterable\\=\\)\\: mixed, callable\\(U\\|V, T, TKey, iterable\\<TKey, T\\>\\)\\: V given\\.$#"
+			count: 1
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\)\\: Generator\\<mixed, mixed, mixed, mixed\\> given\\.$#"
 			count: 14
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\)\\: iterable given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\)\\: iterable given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\<array\\<int, mixed\\>\\>\\)\\: Generator\\<mixed, mixed, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\<array\\<int, mixed\\>\\>\\)\\: Generator\\<mixed, mixed, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<array\\<int, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<mixed, array\\<int, mixed\\>, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<array\\<int, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<mixed, array\\<int, mixed\\>, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, array\\{mixed, mixed\\}\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int, array\\{mixed, mixed\\}\\>, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, array\\{mixed, mixed\\}\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int, array\\{mixed, mixed\\}\\>, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int, mixed\\>, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int, mixed\\>, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int, mixed\\>, mixed, void\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int, mixed\\>, mixed, void\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, mixed\\>\\>, Closure\\(iterable\\<array\\<int, mixed\\>\\>\\)\\: Generator\\<int, array\\<int, mixed\\>, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int, mixed\\>\\>, Closure\\(iterable\\<array\\<int, mixed\\>\\>\\)\\: Generator\\<int, array\\<int, mixed\\>, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int\\|string, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int\\|string, mixed\\>, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int\\|string, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int\\|string, mixed\\>, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\{mixed, mixed\\}\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\{mixed, mixed\\}, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\{mixed, mixed\\}\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\{mixed, mixed\\}, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, float\\>, Closure\\(iterable\\)\\: Generator\\<int, float, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, float\\>, Closure\\(iterable\\)\\: Generator\\<int, float, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, mixed\\>, Closure\\(iterable\\)\\: Generator\\<int, mixed, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, mixed\\>, Closure\\(iterable\\)\\: Generator\\<int, mixed, mixed, mixed\\> given\\.$#"
 			count: 3
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, mixed\\>, Closure\\(iterable\\)\\: Generator\\<int, mixed, mixed, void\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, mixed\\>, Closure\\(iterable\\)\\: Generator\\<int, mixed, mixed, void\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, string\\>, Closure\\(iterable\\)\\: Generator\\<int, string, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, string\\>, Closure\\(iterable\\)\\: Generator\\<int, string, mixed, mixed\\> given\\.$#"
 			count: 1
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<string\\>, Closure\\(iterable\\)\\: Generator\\<mixed, string, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\) expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<string\\>, Closure\\(iterable\\)\\: Generator\\<mixed, string, mixed, mixed\\> given\\.$#"
 			count: 3
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<mixed,mixed\\>\\:\\:map\\(\\) expects callable\\(mixed\\=, mixed\\=, Iterator\\<mixed, mixed\\>\\=\\)\\: loophp\\\\collection\\\\Collection\\<mixed, mixed\\>, Closure\\(iterable\\)\\: loophp\\\\collection\\\\Collection\\<mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Mapable\\<mixed,mixed\\>\\:\\:map\\(\\) expects callable\\(mixed\\=, mixed\\=, Iterator\\<mixed, mixed\\>\\=\\)\\: loophp\\\\collection\\\\Collection\\<mixed, mixed\\>, Closure\\(iterable\\)\\: loophp\\\\collection\\\\Collection\\<mixed, mixed\\> given\\.$#"
 			count: 2
-			path: src/Collection.php
+			path: src/AbstractCollection.php
 
 		-
 			message: "#^Parameter \\#1 \\.\\.\\.\\$ of closure expects callable\\(mixed\\=, mixed\\=, iterable\\=\\)\\: bool, callable\\(T, TKey\\)\\: bool given\\.$#"
 			count: 2
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Return type \\(loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<TKey, T\\>\\>\\) of method loophp\\\\collection\\\\AbstractCollection\\:\\:partition\\(\\) should be compatible with return type \\(loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, mixed\\>\\>\\) of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Partitionable\\<TKey,T\\>\\:\\:partition\\(\\)$#"
+			count: 2
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Return type \\(loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<TKey, T\\>\\>\\) of method loophp\\\\collection\\\\AbstractCollection\\:\\:span\\(\\) should be compatible with return type \\(loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<mixed, mixed\\>\\>\\) of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Spanable\\<TKey,T\\>\\:\\:span\\(\\)$#"
+			count: 2
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Template type V of method loophp\\\\collection\\\\AbstractCollection\\:\\:foldLeft1\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Unable to resolve the template type U in call to method static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\)$#"
+			count: 70
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Unable to resolve the template type UKey in call to method static method loophp\\\\collection\\\\Contract\\\\Collection\\<TKey,T\\>\\:\\:fromCallable\\(\\)$#"
+			count: 70
+			path: src/AbstractCollection.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Collection\\:\\:empty\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
 			path: src/Collection.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Collection\\:\\:fromGenerator\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
+			message: "#^Template type UKey of method loophp\\\\collection\\\\Collection\\:\\:empty\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
+			message: "#^Template type UKey of method loophp\\\\collection\\\\Collection\\:\\:fromGenerator\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Contract\\\\Collection\\:\\:empty\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Contract/Collection.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Contract\\\\Collection\\:\\:fromGenerator\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Contract/Collection.php
+
+		-
+			message: "#^Template type UKey of method loophp\\\\collection\\\\Contract\\\\Collection\\:\\:empty\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Contract/Collection.php
+
+		-
+			message: "#^Template type UKey of method loophp\\\\collection\\\\Contract\\\\Collection\\:\\:fromGenerator\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Contract/Collection.php
 
 		-
 			message: "#^Template type NewT of method loophp\\\\collection\\\\Operation\\\\Associate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
@@ -506,59 +586,94 @@ parameters:
 			path: src/Operation/Zip.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: false given\\.$#"
+			message: "#^Parameter \\#1 \\$collection of function append_checkListWithMap expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<string, int\\>\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<string, int\\|string\\>\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/append.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function append_checkMap expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, int\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int\\|string, int\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/append.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function append_checkMixed expects loophp\\\\collection\\\\Contract\\\\Collection\\<int\\|string, int\\|string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int\\|string, array\\{string\\}\\|int\\|string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/append.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: false given\\.$#"
 			count: 1
 			path: tests/static-analysis/apply.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: true given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: true given\\.$#"
 			count: 2
 			path: tests/static-analysis/apply.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: false given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: false given\\.$#"
 			count: 1
 			path: tests/static-analysis/apply.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: true given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: true given\\.$#"
 			count: 2
 			path: tests/static-analysis/apply.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: false given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: false given\\.$#"
 			count: 1
 			path: tests/static-analysis/apply.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: false given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:apply\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: false given\\.$#"
 			count: 1
 			path: tests/static-analysis/apply.php
 
 		-
-			message: "#^Parameter \\#1 \\$callbackForKeys of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: int\\)\\|null, Closure\\(int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$callbackForKeys of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: int\\)\\|null, Closure\\(int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/associate.php
 
 		-
-			message: "#^Parameter \\#1 \\$callbackForKeys of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: string\\)\\|null, Closure\\(int\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callbackForKeys of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: string\\)\\|null, Closure\\(int\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 2
 			path: tests/static-analysis/associate.php
 
 		-
-			message: "#^Parameter \\#2 \\$callbackForValues of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: bool\\)\\|null, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\$callbackForValues of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: bool\\)\\|null, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/associate.php
 
 		-
-			message: "#^Parameter \\#2 \\$callbackForValues of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: int\\)\\|null, Closure\\(int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#2 \\$callbackForValues of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: int\\)\\|null, Closure\\(int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/associate.php
 
 		-
-			message: "#^Parameter \\#2 \\$callbackForValues of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: string\\)\\|null, Closure\\(int\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#2 \\$callbackForValues of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:associate\\(\\) expects \\(callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: string\\)\\|null, Closure\\(int\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/associate.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:asyncMap\\(\\) expects callable\\(int, int\\)\\: string, Closure\\(string\\)\\: non\\-falsy\\-string given\\.$#"
+			count: 1
+			path: tests/static-analysis/asyncMap.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:asyncMap\\(\\) expects callable\\(string, string\\)\\: int, Closure\\(int\\)\\: int given\\.$#"
+			count: 1
+			path: tests/static-analysis/asyncMap.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function asyncMap_checkListInt expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<string, int\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/asyncMap.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function asyncMap_checkMapString expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/asyncMap.php
 
 		-
 			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Mapable\\<int,mixed\\>\\:\\:map\\(\\) expects callable\\(mixed\\=, int\\=, Iterator\\<int, mixed\\>\\=\\)\\: int, Closure\\(string\\)\\: int given\\.$#"
@@ -566,132 +681,187 @@ parameters:
 			path: tests/static-analysis/column.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:every\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$comparator of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:compare\\(\\) expects callable\\(int, int\\)\\: int, Closure\\(int\\|null, int\\|null\\)\\: int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/compare.php
+
+		-
+			message: "#^Parameter \\#1 \\$comparator of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:compare\\(\\) expects callable\\(string, string\\)\\: string, Closure\\(string\\|null, string\\|null\\)\\: string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/compare.php
+
+		-
+			message: "#^Parameter \\#1 \\$int of function compare_takeInt expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/compare.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function compare_takeString expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/compare.php
+
+		-
+			message: "#^Parameter \\#1 \\$nonNullable of function current_checkNonNullable expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/current.php
+
+		-
+			message: "#^Parameter \\#1 \\$nonNullable of function current_checkNonNullable expects int, int\\|string given\\.$#"
+			count: 1
+			path: tests/static-analysis/current.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function distinct_checkIntList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/distinct.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function distinct_checkMap expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<string, int\\|string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/distinct.php
+
+		-
+			message: "#^Parameter \\#2 \\$accessorCallback of method loophp\\\\collection\\\\AbstractCollection\\<int,tests\\\\loophp\\\\collection\\\\NamedItem\\>\\:\\:distinct\\(\\) expects \\(callable\\(tests\\\\loophp\\\\collection\\\\NamedItem, int\\)\\: string\\)\\|null, Closure\\(string\\)\\: string given\\.$#"
+			count: 1
+			path: tests/static-analysis/distinct.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function drop_checkList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/drop.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function drop_checkMap expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<string, int\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/drop.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:every\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 3
 			path: tests/static-analysis/every.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:every\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:every\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/every.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:every\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:every\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/every.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:every\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:every\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/every.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:filter\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:filter\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/filter.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 3
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 3
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:find\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#3 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:find\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/find.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:flatMap\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: iterable\\<int, \\(float\\|int\\)\\>, Closure\\(int\\)\\: array\\{\\(float\\|int\\)\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:flatMap\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: iterable\\<int, \\(float\\|int\\)\\>, Closure\\(int\\)\\: array\\{\\(float\\|int\\)\\} given\\.$#"
 			count: 3
 			path: tests/static-analysis/flatMap.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:flatMap\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: iterable\\<int, \\(float\\|int\\)\\>, Closure\\(int\\)\\: loophp\\\\collection\\\\Collection\\<int, \\(float\\|int\\)\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:flatMap\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: iterable\\<int, \\(float\\|int\\)\\>, Closure\\(int\\)\\: loophp\\\\collection\\\\Collection\\<int, \\(float\\|int\\)\\> given\\.$#"
 			count: 1
 			path: tests/static-analysis/flatMap.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:flatMap\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: iterable\\<int, string\\>, Closure\\(int\\)\\: array\\{numeric\\-string\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:flatMap\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: iterable\\<int, string\\>, Closure\\(int\\)\\: array\\{numeric\\-string\\} given\\.$#"
 			count: 1
 			path: tests/static-analysis/flatMap.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:flatMap\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: iterable\\<int, string\\>, Closure\\(string\\)\\: array\\{non\\-falsy\\-string\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:flatMap\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: iterable\\<int, string\\>, Closure\\(string\\)\\: array\\{non\\-falsy\\-string\\} given\\.$#"
 			count: 1
 			path: tests/static-analysis/flatMap.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:flatMap\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: iterable\\<string, string\\>, Closure\\(string\\)\\: non\\-empty\\-array\\<string, string\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:flatMap\\(\\) expects callable\\(string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: iterable\\<string, string\\>, Closure\\(string\\)\\: non\\-empty\\-array\\<string, string\\> given\\.$#"
 			count: 1
 			path: tests/static-analysis/flatMap.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:flatMap\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: iterable\\<int, stdClass\\>, Closure\\(string\\)\\: ArrayIterator\\<int, stdClass\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:flatMap\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: iterable\\<int, stdClass\\>, Closure\\(string\\)\\: ArrayIterator\\<int, stdClass\\> given\\.$#"
 			count: 1
 			path: tests/static-analysis/flatMap.php
 
@@ -711,57 +881,127 @@ parameters:
 			path: tests/static-analysis/flatMap.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:groupBy\\(\\) expects callable\\(string\\=, int\\=\\)\\: int, Closure\\(string, int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$collection of function get_checkList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/get.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function get_checkMap expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>, string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/get.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function get_checkIntElement expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/get.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function get_checkStringElement expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/get.php
+
+		-
+			message: "#^Parameter \\#1 \\$callable of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:groupBy\\(\\) expects callable\\(string\\=, int\\=\\)\\: int, Closure\\(string, int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/groupbyable.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:groupBy\\(\\) expects callable\\(string\\=, int\\=\\)\\: string, Closure\\(string\\)\\: string given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:groupBy\\(\\) expects callable\\(string\\=, int\\=\\)\\: string, Closure\\(string\\)\\: string given\\.$#"
 			count: 1
 			path: tests/static-analysis/groupbyable.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:has\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:has\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/has.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:has\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: 1\\|3 given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:has\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: 1\\|3 given\\.$#"
 			count: 1
 			path: tests/static-analysis/has.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:has\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string\\)\\: string given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:has\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string\\)\\: string given\\.$#"
 			count: 1
 			path: tests/static-analysis/has.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:has\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: 'b'\\|'f' given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:has\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: 'b'\\|'f' given\\.$#"
 			count: 1
 			path: tests/static-analysis/has.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:map\\(\\) expects callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: int, Closure\\(int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$value of function head_checkIntElement expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/head.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function head_checkStringElement expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/head.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function key_checkInt expects int, int\\|null given\\.$#"
+			count: 2
+			path: tests/static-analysis/key.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function key_checkInt expects int, int\\|string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/key.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function key_checkString expects string, int\\|string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/key.php
+
+		-
+			message: "#^Parameter \\#1 \\$key of function key_checkString expects string, string\\|null given\\.$#"
+			count: 2
+			path: tests/static-analysis/key.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function keys_checkIntList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\|string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/keys.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function keys_checkStringList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\|string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/keys.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function last_checkIntElement expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/last.php
+
+		-
+			message: "#^Parameter \\#1 \\$value of function last_checkStringElement expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/last.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:map\\(\\) expects callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: int, Closure\\(int\\)\\: int given\\.$#"
 			count: 3
 			path: tests/static-analysis/map.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:map\\(\\) expects callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: string, Closure\\(int\\)\\: numeric\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:map\\(\\) expects callable\\(int\\=, int\\=, Iterator\\<int, int\\>\\=\\)\\: string, Closure\\(int\\)\\: numeric\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/map.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:map\\(\\) expects callable\\(string\\=, int\\=, Iterator\\<int, string\\>\\=\\)\\: string, Closure\\(string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:map\\(\\) expects callable\\(string\\=, int\\=, Iterator\\<int, string\\>\\=\\)\\: string, Closure\\(string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/map.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:map\\(\\) expects callable\\(string\\=, string\\=, Iterator\\<string, string\\>\\=\\)\\: stdClass, Closure\\(string\\)\\: stdClass given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:map\\(\\) expects callable\\(string\\=, string\\=, Iterator\\<string, string\\>\\=\\)\\: stdClass, Closure\\(string\\)\\: stdClass given\\.$#"
 			count: 1
 			path: tests/static-analysis/map.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:map\\(\\) expects callable\\(string\\=, string\\=, Iterator\\<string, string\\>\\=\\)\\: string, Closure\\(string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:map\\(\\) expects callable\\(string\\=, string\\=, Iterator\\<string, string\\>\\=\\)\\: string, Closure\\(string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/map.php
 
@@ -781,181 +1021,291 @@ parameters:
 			path: tests/static-analysis/map.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:match\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:match\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 4
 			path: tests/static-analysis/match.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:match\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:match\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 3
 			path: tests/static-analysis/match.php
 
 		-
-			message: "#^Parameter \\#2 \\$matcher of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:match\\(\\) expects \\(callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool\\)\\|null, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\$matcher of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:match\\(\\) expects \\(callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool\\)\\|null, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/match.php
 
 		-
-			message: "#^Parameter \\#2 \\$matcher of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:match\\(\\) expects \\(callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool\\)\\|null, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\$matcher of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:match\\(\\) expects \\(callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool\\)\\|null, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/match.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:partition\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$int of function max_takeInt expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/max.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function max_takeString expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/max.php
+
+		-
+			message: "#^Parameter \\#1 \\$int of function min_takeInt expects int, int\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/min.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function min_takeString expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/static-analysis/min.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function pair_checkListInt expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\|null\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/pair.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function pair_checkListNullableInt expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\|null\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\|null\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/pair.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function pair_checkMapNullableString expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\|null\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\|null\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/pair.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function pair_checkMapString expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\|null\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/pair.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function partition_checkListCollectionInt expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<int, int\\>\\> given\\.$#"
+			count: 2
+			path: tests/static-analysis/partition.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function partition_checkMapCollectionString expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<string, string\\>\\> given\\.$#"
+			count: 2
+			path: tests/static-analysis/partition.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:partition\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 5
 			path: tests/static-analysis/partition.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:partition\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:partition\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 5
 			path: tests/static-analysis/partition.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:partition\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:partition\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/partition.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:partition\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:partition\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/partition.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<\\*NEVER\\*,\\*NEVER\\*\\>\\:\\:reduce\\(\\) expects callable\\(int\\|null\\=, \\*NEVER\\*\\=, \\*NEVER\\*\\=, iterable\\<\\*NEVER\\*, \\*NEVER\\*\\>\\=\\)\\: int, Closure\\(int\\|null, int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<\\*NEVER\\*,\\*NEVER\\*\\>\\:\\:reduce\\(\\) expects callable\\(int\\|null\\=, \\*NEVER\\*\\=, \\*NEVER\\*\\=, iterable\\<\\*NEVER\\*, \\*NEVER\\*\\>\\=\\)\\: int, Closure\\(int\\|null, int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduce.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:reduce\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:reduce\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduce.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:reduce\\(\\) expects callable\\(int\\|null\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int\\|null, int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:reduce\\(\\) expects callable\\(int\\|null\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int\\|null, int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduce.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:reduce\\(\\) expects callable\\(string\\=, string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:reduce\\(\\) expects callable\\(string\\=, string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduce.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:reduce\\(\\) expects callable\\(string\\|null\\=, string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:reduce\\(\\) expects callable\\(string\\|null\\=, string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: string given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduce.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:reduction\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:reduction\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduction.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:reduction\\(\\) expects callable\\(string\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:reduction\\(\\) expects callable\\(string\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduction.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:reduction\\(\\) expects callable\\(string\\|null\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:reduction\\(\\) expects callable\\(string\\|null\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/reduction.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
 			count: 2
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:reject\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int, int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:reject\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string, string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/reject.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:scanLeft\\(\\) expects callable\\(bool\\|string\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: string, Closure\\(mixed, int\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:scanLeft\\(\\) expects callable\\(bool\\|string\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: string, Closure\\(mixed, int\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanLeft.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:scanLeft\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:scanLeft\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanLeft.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:scanLeft\\(\\) expects callable\\(string\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:scanLeft\\(\\) expects callable\\(string\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanLeft.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:scanLeft\\(\\) expects callable\\(string\\|null\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:scanLeft\\(\\) expects callable\\(string\\|null\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanLeft.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:scanRight\\(\\) expects callable\\(bool\\|string\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: string, Closure\\(mixed, int\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$collection of function scanLeft_checkListOfSize1String expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, bool\\|string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/scanLeft.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function scanLeft_checkListStringWithNull expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\|null\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/scanLeft.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function scanLeft1_checkListOfSize1String expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\|string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/scanLeft1.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:scanRight\\(\\) expects callable\\(bool\\|string\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: string, Closure\\(mixed, int\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanRight.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:scanRight\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:scanRight\\(\\) expects callable\\(int\\=, int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: int, Closure\\(int, int\\)\\: int given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanRight.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:scanRight\\(\\) expects callable\\(string\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:scanRight\\(\\) expects callable\\(string\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string, string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanRight.php
 
 		-
-			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Collection\\<int,string\\>\\:\\:scanRight\\(\\) expects callable\\(string\\|null\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\AbstractCollection\\<int,string\\>\\:\\:scanRight\\(\\) expects callable\\(string\\=, string\\=, int\\=, iterable\\<int, string\\>\\=\\)\\: string, Closure\\(string\\|null, string\\)\\: non\\-falsy\\-string given\\.$#"
 			count: 1
 			path: tests/static-analysis/scanRight.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:span\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\$collection of function scanRight_checkListOfSize1String expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, bool\\|string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/scanRight.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function scanRight_checkListStringWithNull expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\|null\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/scanRight.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function scanRight1_checkListOfSize1String expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\|string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/scanRight1.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function span_checkListCollectionInt expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<int, int\\>\\> given\\.$#"
+			count: 2
+			path: tests/static-analysis/span.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function span_checkMapCollectionString expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, loophp\\\\collection\\\\Collection\\<string, string\\>\\> given\\.$#"
+			count: 2
+			path: tests/static-analysis/span.php
+
+		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:span\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 5
 			path: tests/static-analysis/span.php
 
 		-
-			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:span\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#1 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:span\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 5
 			path: tests/static-analysis/span.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<int,int\\>\\:\\:span\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<int,int\\>\\:\\:span\\(\\) expects callable\\(int\\=, int\\=, iterable\\<int, int\\>\\=\\)\\: bool, Closure\\(int\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/span.php
 
 		-
-			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\Collection\\<string,string\\>\\:\\:span\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
+			message: "#^Parameter \\#2 \\.\\.\\.\\$callbacks of method loophp\\\\collection\\\\AbstractCollection\\<string,string\\>\\:\\:span\\(\\) expects callable\\(string\\=, string\\=, iterable\\<string, string\\>\\=\\)\\: bool, Closure\\(string\\)\\: bool given\\.$#"
 			count: 1
 			path: tests/static-analysis/span.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function squash_checkList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, int\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/squash.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function squash_checkMap expects loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<string, int\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/squash.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function squash_checkStringList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, string\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<string, string\\> given\\.$#"
+			count: 1
+			path: tests/static-analysis/squash.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function unfold_checkListOfLists expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, int\\>\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, mixed\\>\\> given\\.$#"
+			count: 4
+			path: tests/static-analysis/unfold.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,29 +1,191 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.29.0@7ec5ffbd5f68ae03782d7fd33fff0c45a69f95b3">
-  <file src="src/Collection.php">
-    <InvalidArgument occurrences="5">
+  <file src="src/AbstractCollection.php">
+    <ImplementedParamTypeMismatch occurrences="2">
+      <code>$callback</code>
+      <code>$callbacks</code>
+    </ImplementedParamTypeMismatch>
+    <ImplementedReturnTypeMismatch occurrences="3">
+      <code>CollectionInterface&lt;UKey, U&gt;</code>
+      <code>CollectionInterface&lt;int, Collection&lt;TKey, T&gt;&gt;</code>
+      <code>CollectionInterface&lt;int, Collection&lt;TKey, T&gt;&gt;</code>
+    </ImplementedReturnTypeMismatch>
+    <InvalidArgument occurrences="34">
       <code>$callback</code>
       <code>$callback</code>
       <code>$callback</code>
       <code>$callback</code>
       <code>$callback</code>
+      <code>$this-&gt;pack()-&gt;all(false)</code>
+      <code>(new Averages())()</code>
+      <code>(new Chunk())()(...$sizes)</code>
+      <code>(new Column())()($column)</code>
+      <code>(new Explode())()(...$explodes)</code>
+      <code>(new Frequency())()</code>
+      <code>(new Group())()</code>
+      <code>(new GroupBy())()($callable)</code>
+      <code>(new Implode())()($glue)</code>
+      <code>(new Inits())()</code>
+      <code>(new Keys())()</code>
+      <code>(new Lines())()</code>
+      <code>(new Normalize())()</code>
+      <code>(new Pack())()</code>
+      <code>(new Partition())()(...$callbacks)</code>
+      <code>(new Pluck())()($pluck)($default)</code>
+      <code>(new Scale())()($lowerBound)($upperBound)($wantedLowerBound)($wantedUpperBound)($base)</code>
+      <code>(new Span())()(...$callbacks)</code>
+      <code>(new Split())()($type)(...$callbacks)</code>
+      <code>(new Tails())()</code>
+      <code>(new Transpose())()</code>
+      <code>(new Unlines())()</code>
+      <code>(new Unpair())()</code>
+      <code>(new Unwords())()</code>
+      <code>(new Unzip())()</code>
+      <code>(new Window())()($size)</code>
+      <code>(new Words())()</code>
+      <code>(new Wrap())()</code>
+      <code>(new Zip())()(...$iterables)</code>
     </InvalidArgument>
-    <InvalidReturnStatement occurrences="1">
-      <code>new self((new Wrap())(), [$this])</code>
+    <InvalidReturnStatement occurrences="60">
+      <code>static::fromCallable((new Apply())()(...$callbacks), [$this])</code>
+      <code>static::fromCallable((new AsyncMap())()($callback), [$this])</code>
+      <code>static::fromCallable((new Cache())()($cache ?? new ArrayAdapter()), [$this])</code>
+      <code>static::fromCallable((new Coalesce())(), [$this])</code>
+      <code>static::fromCallable((new Collapse())(), [$this])</code>
+      <code>static::fromCallable((new Combinate())()($length), [$this])</code>
+      <code>static::fromCallable((new Compact())()(...$values), [$this])</code>
+      <code>static::fromCallable((new Cycle())(), [$this])</code>
+      <code>static::fromCallable((new Diff())()(...$values), [$this])</code>
+      <code>static::fromCallable((new DiffKeys())()(...$keys), [$this])</code>
+      <code>static::fromCallable((new Distinct())()($comparatorCallback)($accessorCallback), [$this])</code>
+      <code>static::fromCallable((new Drop())()($count), [$this])</code>
+      <code>static::fromCallable((new DropWhile())()(...$callbacks), [$this])</code>
+      <code>static::fromCallable((new Dump())()($name)($size)($closure), [$this])</code>
+      <code>static::fromCallable((new Duplicate())()($comparatorCallback)($accessorCallback), [$this])</code>
+      <code>static::fromCallable((new Filter())()(...$callbacks), [$this])</code>
+      <code>static::fromCallable((new Flip())(), [$this])</code>
+      <code>static::fromCallable((new FoldLeft1())()($callback), [$this])-&gt;current()</code>
+      <code>static::fromCallable((new Forget())()(...$keys), [$this])</code>
+      <code>static::fromCallable((new Frequency())(), [$this])</code>
+      <code>static::fromCallable((new IfThenElse())()($condition)($then)($else ?? $identity), [$this])</code>
+      <code>static::fromCallable((new Init())(), [$this])</code>
+      <code>static::fromCallable((new Intersect())()(...$values), [$this])</code>
+      <code>static::fromCallable((new IntersectKeys())()(...$keys), [$this])</code>
+      <code>static::fromCallable((new Intersperse())()($element)($every)($startAt), [$this])</code>
+      <code>static::fromCallable((new Keys())(), [$this])</code>
+      <code>static::fromCallable((new Limit())()($count)($offset), [$this])</code>
+      <code>static::fromCallable((new Map())()($callback), [$this])</code>
+      <code>static::fromCallable((new Matching())()($criteria), [$this])</code>
+      <code>static::fromCallable((new Merge())()(...$sources), [$this])</code>
+      <code>static::fromCallable((new Normalize())(), [$this])</code>
+      <code>static::fromCallable((new Nth())()($step)($offset), [$this])</code>
+      <code>static::fromCallable((new Pair())(), [$this])</code>
+      <code>static::fromCallable((new Permutate())(), [$this])</code>
+      <code>static::fromCallable((new Prepend())()(...$items), [$this])</code>
+      <code>static::fromCallable((new Product())()(...$iterables), [$this])</code>
+      <code>static::fromCallable((new RSample())()($probability), [$this])</code>
+      <code>static::fromCallable((new Random())()($seed ?? random_int(0, 1000))($size), [$this])</code>
+      <code>static::fromCallable((new Reduction())()($callback)($initial), [$this])</code>
+      <code>static::fromCallable((new Reject())()(...$callbacks), [$this])</code>
+      <code>static::fromCallable((new Reverse())(), [$this])</code>
+      <code>static::fromCallable((new Scale())()($lowerBound)($upperBound)($wantedLowerBound)($wantedUpperBound)($base), [$this])</code>
+      <code>static::fromCallable((new ScanLeft())()($callback)($initial), [$this])</code>
+      <code>static::fromCallable((new ScanLeft1())()($callback), [$this])</code>
+      <code>static::fromCallable((new ScanRight())()($callback)($initial), [$this])</code>
+      <code>static::fromCallable((new ScanRight1())()($callback), [$this])</code>
+      <code>static::fromCallable((new Shuffle())()($seed ?? random_int(0, 1000)), [$this])</code>
+      <code>static::fromCallable((new Since())()(...$callbacks), [$this])</code>
+      <code>static::fromCallable((new Slice())()($offset)($length), [$this])</code>
+      <code>static::fromCallable((new Sort())()($type)($callback), [$this])</code>
+      <code>static::fromCallable((new Strict())()($callback), [$this])</code>
+      <code>static::fromCallable((new Tail())(), [$this])</code>
+      <code>static::fromCallable((new TakeWhile())()(...$callbacks), [$this])</code>
+      <code>static::fromCallable((new Transpose())(), [$this])</code>
+      <code>static::fromCallable((new Unpair())(), [$this])</code>
+      <code>static::fromCallable((new Until())()(...$callbacks), [$this])</code>
+      <code>static::fromCallable((new Unwindow())(), [$this])</code>
+      <code>static::fromCallable((new When())()($predicate)($whenTrue)($whenFalse), [$this])</code>
+      <code>static::fromCallable((new Window())()($size), [$this])</code>
+      <code>static::fromCallable((new Words())(), [$this])</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
-      <code>CollectionInterface</code>
+    <InvalidReturnType occurrences="60">
+      <code>CollectionInterface&lt;T, TKey&gt;</code>
+      <code>CollectionInterface&lt;T, T|null&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T&gt;</code>
+      <code>CollectionInterface&lt;TKey, T|U&gt;</code>
+      <code>CollectionInterface&lt;TKey, T|U&gt;</code>
+      <code>CollectionInterface&lt;TKey, U&gt;</code>
+      <code>CollectionInterface&lt;TKey, V&gt;</code>
+      <code>CollectionInterface&lt;TKey, W&gt;</code>
+      <code>CollectionInterface&lt;TKey, W&gt;</code>
+      <code>CollectionInterface&lt;TKey, W&gt;</code>
+      <code>CollectionInterface&lt;TKey, W&gt;</code>
+      <code>CollectionInterface&lt;TKey, W&gt;</code>
+      <code>CollectionInterface&lt;TKey, float|int&gt;</code>
+      <code>CollectionInterface&lt;TKey, list&lt;T&gt;&gt;</code>
+      <code>CollectionInterface&lt;TKey, list&lt;T&gt;&gt;</code>
+      <code>CollectionInterface&lt;TKey, list&lt;T|U&gt;&gt;</code>
+      <code>CollectionInterface&lt;TKey, string&gt;</code>
+      <code>CollectionInterface&lt;int, T&gt;</code>
+      <code>CollectionInterface&lt;int, T&gt;</code>
+      <code>CollectionInterface&lt;int, TKey&gt;</code>
+      <code>CollectionInterface&lt;int, TKey|T&gt;</code>
+      <code>CollectionInterface&lt;int|TKey, T&gt;</code>
+      <code>T|null</code>
     </InvalidReturnType>
-    <LessSpecificReturnStatement occurrences="1">
-      <code>new self((new Zip())()(...$iterables), [$this])</code>
-    </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
-      <code>CollectionInterface</code>
+    <LessSpecificReturnStatement occurrences="2"/>
+    <MissingParamType occurrences="2">
+      <code>$keys</code>
+      <code>$values</code>
+    </MissingParamType>
+    <MoreSpecificReturnType occurrences="2">
+      <code>CollectionInterface&lt;int, Collection&lt;TKey, T&gt;&gt;</code>
+      <code>CollectionInterface&lt;int, Collection&lt;TKey, T&gt;&gt;</code>
     </MoreSpecificReturnType>
     <PossiblyInvalidArgument occurrences="2">
       <code>$callbackForKeys ?? $defaultCallback</code>
       <code>$callbackForValues ?? $defaultCallback</code>
     </PossiblyInvalidArgument>
+    <PossiblyNullArgument occurrences="1">
+      <code>$initial</code>
+    </PossiblyNullArgument>
   </file>
   <file src="src/Operation/All.php">
     <InvalidReturnStatement occurrences="1"/>
@@ -50,6 +212,22 @@
     <InvalidArgument occurrences="2">
       <code>[[]]</code>
       <code>static fn (iterable $a, iterable $x): Generator =&gt; $f($x)($a)</code>
+    </InvalidArgument>
+  </file>
+  <file src="tests/static-analysis/all.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>Collection::fromIterable(['foo' =&gt; 1, 'bar' =&gt; 2])-&gt;all()</code>
+    </InvalidScalarArgument>
+  </file>
+  <file src="tests/static-analysis/normalize.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>Collection::fromIterable(['foo' =&gt; 'f', 'bar' =&gt; 'f'])-&gt;normalize()</code>
+    </InvalidScalarArgument>
+  </file>
+  <file src="tests/static-analysis/partition.php">
+    <InvalidArgument occurrences="2">
+      <code>Collection::fromIterable($integers())-&gt;partition($intValueCallback)</code>
+      <code>Collection::fromIterable($integers())-&gt;partition($intValueCallback, $intValueCallback)</code>
     </InvalidArgument>
   </file>
 </files>

--- a/src/AbstractCollection.php
+++ b/src/AbstractCollection.php
@@ -1,0 +1,1385 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection;
+
+use Closure;
+use Doctrine\Common\Collections\Criteria;
+use Iterator;
+use loophp\collection\Contract\Collection as CollectionInterface;
+use loophp\collection\Contract\Operation;
+use loophp\collection\Operation\All;
+use loophp\collection\Operation\Append;
+use loophp\collection\Operation\Apply;
+use loophp\collection\Operation\Associate;
+use loophp\collection\Operation\AsyncMap;
+use loophp\collection\Operation\AsyncMapN;
+use loophp\collection\Operation\Averages;
+use loophp\collection\Operation\Cache;
+use loophp\collection\Operation\Chunk;
+use loophp\collection\Operation\Coalesce;
+use loophp\collection\Operation\Collapse;
+use loophp\collection\Operation\Column;
+use loophp\collection\Operation\Combinate;
+use loophp\collection\Operation\Combine;
+use loophp\collection\Operation\Compact;
+use loophp\collection\Operation\Compare;
+use loophp\collection\Operation\Contains;
+use loophp\collection\Operation\Current;
+use loophp\collection\Operation\Cycle;
+use loophp\collection\Operation\Diff;
+use loophp\collection\Operation\DiffKeys;
+use loophp\collection\Operation\Distinct;
+use loophp\collection\Operation\Drop;
+use loophp\collection\Operation\DropWhile;
+use loophp\collection\Operation\Dump;
+use loophp\collection\Operation\Duplicate;
+use loophp\collection\Operation\Equals;
+use loophp\collection\Operation\Every;
+use loophp\collection\Operation\Explode;
+use loophp\collection\Operation\Falsy;
+use loophp\collection\Operation\Filter;
+use loophp\collection\Operation\Find;
+use loophp\collection\Operation\First;
+use loophp\collection\Operation\FlatMap;
+use loophp\collection\Operation\Flatten;
+use loophp\collection\Operation\Flip;
+use loophp\collection\Operation\FoldLeft;
+use loophp\collection\Operation\FoldLeft1;
+use loophp\collection\Operation\FoldRight;
+use loophp\collection\Operation\FoldRight1;
+use loophp\collection\Operation\Forget;
+use loophp\collection\Operation\Frequency;
+use loophp\collection\Operation\Get;
+use loophp\collection\Operation\Group;
+use loophp\collection\Operation\GroupBy;
+use loophp\collection\Operation\Has;
+use loophp\collection\Operation\Head;
+use loophp\collection\Operation\IfThenElse;
+use loophp\collection\Operation\Implode;
+use loophp\collection\Operation\Init;
+use loophp\collection\Operation\Inits;
+use loophp\collection\Operation\Intersect;
+use loophp\collection\Operation\IntersectKeys;
+use loophp\collection\Operation\Intersperse;
+use loophp\collection\Operation\IsEmpty;
+use loophp\collection\Operation\Key;
+use loophp\collection\Operation\Keys;
+use loophp\collection\Operation\Last;
+use loophp\collection\Operation\Limit;
+use loophp\collection\Operation\Lines;
+use loophp\collection\Operation\Map;
+use loophp\collection\Operation\MapN;
+use loophp\collection\Operation\Matching;
+use loophp\collection\Operation\MatchOne;
+use loophp\collection\Operation\Max;
+use loophp\collection\Operation\Merge;
+use loophp\collection\Operation\Min;
+use loophp\collection\Operation\Normalize;
+use loophp\collection\Operation\Nth;
+use loophp\collection\Operation\Nullsy;
+use loophp\collection\Operation\Pack;
+use loophp\collection\Operation\Pad;
+use loophp\collection\Operation\Pair;
+use loophp\collection\Operation\Partition;
+use loophp\collection\Operation\Permutate;
+use loophp\collection\Operation\Pipe;
+use loophp\collection\Operation\Pluck;
+use loophp\collection\Operation\Prepend;
+use loophp\collection\Operation\Product;
+use loophp\collection\Operation\Random;
+use loophp\collection\Operation\Reduce;
+use loophp\collection\Operation\Reduction;
+use loophp\collection\Operation\Reject;
+use loophp\collection\Operation\Reverse;
+use loophp\collection\Operation\RSample;
+use loophp\collection\Operation\Same;
+use loophp\collection\Operation\Scale;
+use loophp\collection\Operation\ScanLeft;
+use loophp\collection\Operation\ScanLeft1;
+use loophp\collection\Operation\ScanRight;
+use loophp\collection\Operation\ScanRight1;
+use loophp\collection\Operation\Shuffle;
+use loophp\collection\Operation\Since;
+use loophp\collection\Operation\Slice;
+use loophp\collection\Operation\Sort;
+use loophp\collection\Operation\Span;
+use loophp\collection\Operation\Split;
+use loophp\collection\Operation\Strict;
+use loophp\collection\Operation\Tail;
+use loophp\collection\Operation\Tails;
+use loophp\collection\Operation\TakeWhile;
+use loophp\collection\Operation\Transpose;
+use loophp\collection\Operation\Truthy;
+use loophp\collection\Operation\Unlines;
+use loophp\collection\Operation\Unpack;
+use loophp\collection\Operation\Unpair;
+use loophp\collection\Operation\Until;
+use loophp\collection\Operation\Unwindow;
+use loophp\collection\Operation\Unwords;
+use loophp\collection\Operation\Unwrap;
+use loophp\collection\Operation\Unzip;
+use loophp\collection\Operation\When;
+use loophp\collection\Operation\Window;
+use loophp\collection\Operation\Words;
+use loophp\collection\Operation\Wrap;
+use loophp\collection\Operation\Zip;
+use loophp\collection\Utils\CallbacksArrayReducer;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+use const PHP_INT_MAX;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ *
+ * phpcs:disable Generic.Files.LineLength.TooLong
+ *
+ * @implements \loophp\collection\Contract\Collection<TKey, T>
+ */
+abstract class AbstractCollection implements CollectionInterface
+{
+    /**
+     * @psalm-return ($normalize is true ? list<T> : array<TKey, T>)
+     */
+    public function all(bool $normalize = true): array
+    {
+        return iterator_to_array((new All())()($normalize)($this));
+    }
+
+    /**
+     * @template U
+     *
+     * @param U ...$items
+     *
+     * @return CollectionInterface<int|TKey, T|U>
+     */
+    public function append(...$items): CollectionInterface
+    {
+        return static::fromCallable((new Append())()(...$items), [$this]);
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function apply(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Apply())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param callable(TKey=, T=, Iterator<TKey, T>=): UKey $callbackForKeys
+     * @param callable(T=, TKey=, Iterator<TKey, T>=): U $callbackForValues
+     *
+     * @return CollectionInterface<UKey, U>
+     */
+    public function associate(
+        ?callable $callbackForKeys = null,
+        ?callable $callbackForValues = null
+    ): CollectionInterface {
+        $defaultCallback =
+            /**
+             * @param mixed $carry
+             *
+             * @return mixed
+             */
+            static fn ($carry) => $carry;
+
+        return static::fromCallable((new Associate())()($callbackForKeys ?? $defaultCallback)($callbackForValues ?? $defaultCallback), [$this]);
+    }
+
+    /**
+     * @template V
+     *
+     * @param callable(T, TKey): V $callback
+     *
+     * @return CollectionInterface<TKey, V>
+     */
+    public function asyncMap(callable $callback): CollectionInterface
+    {
+        return static::fromCallable((new AsyncMap())()($callback), [$this]);
+    }
+
+    /**
+     * @param callable(mixed, mixed): mixed ...$callbacks
+     *
+     * @return CollectionInterface<mixed, mixed>
+     */
+    public function asyncMapN(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new AsyncMapN())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, float>
+     */
+    public function averages(): CollectionInterface
+    {
+        return static::fromCallable((new Averages())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function cache(?CacheItemPoolInterface $cache = null): CollectionInterface
+    {
+        return static::fromCallable((new Cache())()($cache ?? new ArrayAdapter()), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, list<T>>
+     */
+    public function chunk(int ...$sizes): CollectionInterface
+    {
+        return static::fromCallable((new Chunk())()(...$sizes), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function coalesce(): CollectionInterface
+    {
+        return static::fromCallable((new Coalesce())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function collapse(): CollectionInterface
+    {
+        return static::fromCallable((new Collapse())(), [$this]);
+    }
+
+    /**
+     * @param mixed $column
+     *
+     * @return CollectionInterface<int, mixed>
+     */
+    public function column($column): CollectionInterface
+    {
+        return static::fromCallable((new Column())()($column), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function combinate(?int $length = null): CollectionInterface
+    {
+        return static::fromCallable((new Combinate())()($length), [$this]);
+    }
+
+    /**
+     * @template U
+     *
+     * @param U ...$keys
+     *
+     * @return CollectionInterface<U|null, T|null>
+     */
+    public function combine(...$keys): CollectionInterface
+    {
+        return static::fromCallable((new Combine())()(...$keys), [$this]);
+    }
+
+    /**
+     * @param T ...$values
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function compact(...$values): CollectionInterface
+    {
+        return static::fromCallable((new Compact())()(...$values), [$this]);
+    }
+
+    /**
+     * @template V
+     *
+     * @param callable(T, T): T $comparator
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function compare(callable $comparator, $default = null)
+    {
+        return static::fromCallable((new Compare())()($comparator), [$this])->current(0, $default);
+    }
+
+    /**
+     * @param T ...$values
+     */
+    public function contains(...$values): bool
+    {
+        return (new Contains())()(...$values)($this)->current();
+    }
+
+    public function count(): int
+    {
+        return iterator_count($this);
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function current(int $index = 0, $default = null)
+    {
+        return (new Current())()($index)($default)($this)->current();
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function cycle(): CollectionInterface
+    {
+        return static::fromCallable((new Cycle())(), [$this]);
+    }
+
+    /**
+     * @template U
+     *
+     * @param U ...$values
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function diff(...$values): CollectionInterface
+    {
+        return static::fromCallable((new Diff())()(...$values), [$this]);
+    }
+
+    /**
+     * @param TKey ...$keys
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function diffKeys(...$keys): CollectionInterface
+    {
+        return static::fromCallable((new DiffKeys())()(...$keys), [$this]);
+    }
+
+    /**
+     * @template U
+     *
+     * @param null|callable(U): (Closure(U): bool) $comparatorCallback
+     * @param null|callable(T, TKey): U $accessorCallback
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): CollectionInterface
+    {
+        $accessorCallback ??=
+            /**
+             * @param T $value
+             * @param TKey $key
+             *
+             * @return T
+             */
+            static fn ($value, $key) => $value;
+
+        $comparatorCallback ??=
+            /**
+             * @param T $left
+             *
+             * @return Closure(T): bool
+             */
+            static fn ($left): Closure =>
+                /**
+                 * @param T $right
+                 */
+                static fn ($right): bool => $left === $right;
+
+        return static::fromCallable((new Distinct())()($comparatorCallback)($accessorCallback), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function drop(int $count): CollectionInterface
+    {
+        return static::fromCallable((new Drop())()($count), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function dropWhile(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new DropWhile())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function dump(string $name = '', int $size = 1, ?Closure $closure = null): CollectionInterface
+    {
+        return static::fromCallable((new Dump())()($name)($size)($closure), [$this]);
+    }
+
+    /**
+     * @template U
+     *
+     * @param null|callable(U): (Closure(U): bool) $comparatorCallback
+     * @param null|callable(T, TKey): U $accessorCallback
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function duplicate(?callable $comparatorCallback = null, ?callable $accessorCallback = null): CollectionInterface
+    {
+        $accessorCallback ??=
+            /**
+             * @param T $value
+             * @param TKey $key
+             *
+             * @return T
+             */
+            static fn ($value, $key) => $value;
+
+        $comparatorCallback ??=
+            /**
+             * @param T $left
+             *
+             * @return Closure(T): bool
+             */
+            static fn ($left): Closure =>
+                /**
+                 * @param T $right
+                 */
+                static fn ($right): bool => $left === $right;
+
+        return static::fromCallable((new Duplicate())()($comparatorCallback)($accessorCallback), [$this]);
+    }
+
+    /**
+     * @param iterable<mixed, mixed> $other
+     */
+    public function equals(iterable $other): bool
+    {
+        return (new Equals())()($other)($this)->current();
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
+     */
+    public function every(callable ...$callbacks): bool
+    {
+        return (new Every())()(static fn (int $index, $value, $key, iterable $iterable) => CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable))($this)
+            ->current();
+    }
+
+    /**
+     * @param mixed ...$explodes
+     *
+     * @return CollectionInterface<int, list<T>>
+     */
+    public function explode(...$explodes): CollectionInterface
+    {
+        return static::fromCallable((new Explode())()(...$explodes), [$this]);
+    }
+
+    public function falsy(): bool
+    {
+        return (new Falsy())()($this)->current();
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function filter(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Filter())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $default
+     * @param (callable(T=, TKey=, iterable<TKey, T>=): bool) ...$callbacks
+     *
+     * @return T|V
+     */
+    public function find($default = null, callable ...$callbacks)
+    {
+        return (new Find())()($default)(...$callbacks)($this)->current();
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function first($default = null)
+    {
+        return static::fromCallable((new First())(), [$this])->current(0, $default);
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param callable(T=, TKey=, iterable<TKey, T>=): iterable<UKey, U> $callback
+     *
+     * @return CollectionInterface<UKey, U>
+     */
+    public function flatMap(callable $callback): CollectionInterface
+    {
+        return static::fromCallable((new FlatMap())()($callback), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<mixed, mixed>
+     */
+    public function flatten(int $depth = PHP_INT_MAX): CollectionInterface
+    {
+        return static::fromCallable((new Flatten())()($depth), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<T, TKey>
+     */
+    public function flip(): CollectionInterface
+    {
+        return static::fromCallable((new Flip())(), [$this]);
+    }
+
+    /**
+     * @template V
+     * @template W
+     *
+     * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
+     * @param V $initial
+     *
+     * @return V|W
+     */
+    public function foldLeft(callable $callback, $initial)
+    {
+        return static::fromCallable((new FoldLeft())()($callback)($initial), [$this])->current();
+    }
+
+    /**
+     * @template V
+     *
+     * @param callable(T, T, TKey, Iterator<TKey, T>): T $callback
+     *
+     * @return T|null
+     */
+    public function foldLeft1(callable $callback)
+    {
+        return static::fromCallable((new FoldLeft1())()($callback), [$this])->current();
+    }
+
+    /**
+     * @template U
+     * @template V
+     *
+     * @param callable(U|V, T, TKey, iterable<TKey, T>): V $callback
+     * @param U|null $initial
+     *
+     * @return V|null
+     */
+    public function foldRight(callable $callback, $initial = null)
+    {
+        return static::fromCallable((new Foldright())()($callback)($initial), [$this])->current();
+    }
+
+    /**
+     * @template V
+     *
+     * @param callable(T, T, TKey, Iterator<TKey, T>): V $callback
+     *
+     * @return V|null
+     */
+    public function foldRight1(callable $callback)
+    {
+        return static::fromCallable((new FoldRight1())()($callback), [$this])->current();
+    }
+
+    /**
+     * @param mixed ...$keys
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function forget(...$keys): CollectionInterface
+    {
+        return static::fromCallable((new Forget())()(...$keys), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, T>
+     */
+    public function frequency(): CollectionInterface
+    {
+        return static::fromCallable((new Frequency())(), [$this]);
+    }
+
+    /**
+     * @template V
+     *
+     * @param TKey $key
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function get($key, $default = null)
+    {
+        return static::fromCallable((new Get())()($key)($default), [$this])->current(0, $default);
+    }
+
+    /**
+     * @return CollectionInterface<int, list<T>>
+     */
+    public function group(): CollectionInterface
+    {
+        return static::fromCallable((new Group())(), [$this]);
+    }
+
+    /**
+     * @template UKey
+     *
+     * @param callable(T=, TKey=): UKey $callable
+     *
+     * @return CollectionInterface<UKey, non-empty-list<T>>
+     */
+    public function groupBy(callable $callable): CollectionInterface
+    {
+        return static::fromCallable((new GroupBy())()($callable), [$this]);
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): T ...$callbacks
+     */
+    public function has(callable ...$callbacks): bool
+    {
+        return (new Has())()(...$callbacks)($this)->current();
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function head($default = null)
+    {
+        return static::fromCallable((new Head())(), [$this])->current(0, $default);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function ifThenElse(callable $condition, callable $then, ?callable $else = null): CollectionInterface
+    {
+        $identity =
+            /**
+             * @param T $value
+             *
+             * @return T
+             */
+            static fn ($value) => $value;
+
+        return static::fromCallable((new IfThenElse())()($condition)($then)($else ?? $identity), [$this]);
+    }
+
+    public function implode(string $glue = ''): string
+    {
+        return static::fromCallable((new Implode())()($glue), [$this])->current(0, '');
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function init(): CollectionInterface
+    {
+        return static::fromCallable((new Init())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, list<array{0: TKey, 1: T}>>
+     */
+    public function inits(): CollectionInterface
+    {
+        return static::fromCallable((new Inits())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function intersect(...$values): CollectionInterface
+    {
+        return static::fromCallable((new Intersect())()(...$values), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function intersectKeys(...$keys): CollectionInterface
+    {
+        return static::fromCallable((new IntersectKeys())()(...$keys), [$this]);
+    }
+
+    /**
+     * @template U
+     *
+     * @param U $element
+     *
+     * @return CollectionInterface<TKey, T|U>
+     */
+    public function intersperse($element, int $every = 1, int $startAt = 0): CollectionInterface
+    {
+        return static::fromCallable((new Intersperse())()($element)($every)($startAt), [$this]);
+    }
+
+    public function isEmpty(): bool
+    {
+        return (new IsEmpty())()($this)->current();
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->all(false);
+    }
+
+    /**
+     * @return TKey|null
+     */
+    public function key(int $index = 0)
+    {
+        return (new Key())()($index)($this)->current();
+    }
+
+    /**
+     * @return CollectionInterface<int, TKey>
+     */
+    public function keys(): CollectionInterface
+    {
+        return static::fromCallable((new Keys())(), [$this]);
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function last($default = null)
+    {
+        return static::fromCallable((new Last())(), [$this])->current(0, $default);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function limit(int $count = -1, int $offset = 0): CollectionInterface
+    {
+        return static::fromCallable((new Limit())()($count)($offset), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, string>
+     */
+    public function lines(): CollectionInterface
+    {
+        return static::fromCallable((new Lines())(), [$this]);
+    }
+
+    /**
+     * @template U
+     *
+     * @param callable(T=, TKey=, Iterator<TKey, T>=): U $callback
+     *
+     * @return CollectionInterface<TKey, U>
+     */
+    public function map(callable $callback): CollectionInterface
+    {
+        return static::fromCallable((new Map())()($callback), [$this]);
+    }
+
+    /**
+     * @param callable(mixed, mixed, iterable<TKey, T>): mixed ...$callbacks
+     *
+     * @return CollectionInterface<mixed, mixed>
+     */
+    public function mapN(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new MapN())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool $callback
+     * @param null|callable(T=, TKey=, iterable<TKey, T>=): bool $matcher
+     */
+    public function match(callable $callback, ?callable $matcher = null): bool
+    {
+        return (new MatchOne())()($matcher ?? static fn (): bool => true)($callback)($this)->current();
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function matching(Criteria $criteria): CollectionInterface
+    {
+        return static::fromCallable((new Matching())()($criteria), [$this]);
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function max($default = null)
+    {
+        return static::fromCallable((new Max())(), [$this])->current(0, $default);
+    }
+
+    /**
+     * @template U
+     *
+     * @param iterable<U> ...$sources
+     *
+     * @return CollectionInterface<TKey, T|U>
+     */
+    public function merge(iterable ...$sources): CollectionInterface
+    {
+        return static::fromCallable((new Merge())()(...$sources), [$this]);
+    }
+
+    /**
+     * @template V
+     *
+     * @param V $default
+     *
+     * @return T|V
+     */
+    public function min($default = null)
+    {
+        return static::fromCallable((new Min())(), [$this])->current(0, $default);
+    }
+
+    /**
+     * @return CollectionInterface<int, T>
+     */
+    public function normalize(): CollectionInterface
+    {
+        return static::fromCallable((new Normalize())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function nth(int $step, int $offset = 0): CollectionInterface
+    {
+        return static::fromCallable((new Nth())()($step)($offset), [$this]);
+    }
+
+    public function nullsy(): bool
+    {
+        return (new Nullsy())()($this)->current();
+    }
+
+    /**
+     * @return CollectionInterface<int, array{0: TKey, 1: T}>
+     */
+    public function pack(): CollectionInterface
+    {
+        return static::fromCallable((new Pack())(), [$this]);
+    }
+
+    /**
+     * Pad a collection to the given length with a given value.
+     *
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#pad
+     *
+     * @template U
+     *
+     * @param U $value
+     *
+     * @return CollectionInterface<int|TKey, T|U>
+     */
+    public function pad(int $size, $value): CollectionInterface
+    {
+        return static::fromCallable((new Pad())()($size)($value), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<T, T|null>
+     */
+    public function pair(): CollectionInterface
+    {
+        return static::fromCallable((new Pair())(), [$this]);
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
+     *
+     * @return CollectionInterface<int, Collection<TKey, T>>
+     */
+    public function partition(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Partition())()(...$callbacks), [$this])
+            ->map(
+                /**
+                 * @param iterable<TKey, T> $iterable
+                 *
+                 * @return CollectionInterface<TKey, T>
+                 */
+                static fn (iterable $iterable): CollectionInterface => Collection::fromIterable($iterable)
+            );
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function permutate(): CollectionInterface
+    {
+        return static::fromCallable((new Permutate())(), [$this]);
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param callable(iterable<TKey, T>): iterable<UKey, U> ...$callbacks
+     *
+     * @return CollectionInterface<UKey, U>
+     */
+    public function pipe(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Pipe())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @param array<int, string>|array-key $pluck
+     * @param mixed|null $default
+     *
+     * @return CollectionInterface<int, iterable<int, T>|T>
+     */
+    public function pluck($pluck, $default = null): CollectionInterface
+    {
+        return static::fromCallable((new Pluck())()($pluck)($default), [$this]);
+    }
+
+    /**
+     * @param mixed ...$items
+     *
+     * @return CollectionInterface<int|TKey, T>
+     */
+    public function prepend(...$items): CollectionInterface
+    {
+        return static::fromCallable((new Prepend())()(...$items), [$this]);
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param iterable<UKey, U> ...$iterables
+     *
+     * @return CollectionInterface<TKey, list<T|U>>
+     */
+    public function product(iterable ...$iterables): CollectionInterface
+    {
+        return static::fromCallable((new Product())()(...$iterables), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function random(int $size = 1, ?int $seed = null): CollectionInterface
+    {
+        return static::fromCallable((new Random())()($seed ?? random_int(0, 1000))($size), [$this]);
+    }
+
+    /**
+     * @template V
+     * @template W
+     *
+     * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
+     * @param V $initial
+     *
+     * @return W
+     */
+    public function reduce(callable $callback, $initial = null)
+    {
+        return static::fromCallable((new Reduce())()($callback)($initial), [$this])->current();
+    }
+
+    /**
+     * @template V
+     * @template W
+     *
+     * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
+     * @param V $initial
+     *
+     * @return CollectionInterface<TKey, W>
+     */
+    public function reduction(callable $callback, $initial = null): CollectionInterface
+    {
+        return static::fromCallable((new Reduction())()($callback)($initial), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function reject(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Reject())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function reverse(): CollectionInterface
+    {
+        return static::fromCallable((new Reverse())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function rsample(float $probability): CollectionInterface
+    {
+        return static::fromCallable((new RSample())()($probability), [$this]);
+    }
+
+    /**
+     * @param iterable<mixed, mixed> $other
+     * @param null|callable(mixed, mixed): (Closure(mixed, mixed): bool) $comparatorCallback
+     */
+    public function same(iterable $other, ?callable $comparatorCallback = null): bool
+    {
+        $comparatorCallback ??=
+            /**
+             * @param T $leftValue
+             * @param TKey $leftKey
+             *
+             * @return Closure(T, TKey): bool
+             */
+            static fn ($leftValue, $leftKey): Closure =>
+                /**
+                 * @param T $rightValue
+                 * @param TKey $rightKey
+                 */
+                static fn ($rightValue, $rightKey): bool => $leftValue === $rightValue && $leftKey === $rightKey;
+
+        return (new Same())()($other)($comparatorCallback)($this)->current();
+    }
+
+    /**
+     * @return CollectionInterface<TKey, float|int>
+     */
+    public function scale(
+        float $lowerBound,
+        float $upperBound,
+        float $wantedLowerBound = 0.0,
+        float $wantedUpperBound = 1.0,
+        float $base = 0.0
+    ): CollectionInterface {
+        return static::fromCallable((new Scale())()($lowerBound)($upperBound)($wantedLowerBound)($wantedUpperBound)($base), [$this]);
+    }
+
+    /**
+     * @template V
+     * @template W
+     *
+     * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
+     * @param V $initial
+     *
+     * @return CollectionInterface<TKey, W>
+     */
+    public function scanLeft(callable $callback, $initial): CollectionInterface
+    {
+        return static::fromCallable((new ScanLeft())()($callback)($initial), [$this]);
+    }
+
+    /**
+     * @template W
+     *
+     * @param callable(T|W, T, TKey, Iterator<TKey, T>): W $callback
+     *
+     * @return CollectionInterface<TKey, W>
+     */
+    public function scanLeft1(callable $callback): CollectionInterface
+    {
+        return static::fromCallable((new ScanLeft1())()($callback), [$this]);
+    }
+
+    /**
+     * @template V
+     * @template W
+     *
+     * @param callable((V|W)=, T=, TKey=, iterable<TKey, T>=): W $callback
+     * @param V $initial
+     *
+     * @return CollectionInterface<TKey, W>
+     */
+    public function scanRight(callable $callback, $initial): CollectionInterface
+    {
+        return static::fromCallable((new ScanRight())()($callback)($initial), [$this]);
+    }
+
+    /**
+     * @template W
+     *
+     * @param callable(T|W, T, TKey, Iterator<TKey, T>): W $callback
+     *
+     * @return CollectionInterface<TKey, W>
+     */
+    public function scanRight1(callable $callback): CollectionInterface
+    {
+        return static::fromCallable((new ScanRight1())()($callback), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function shuffle(?int $seed = null): CollectionInterface
+    {
+        return static::fromCallable((new Shuffle())()($seed ?? random_int(0, 1000)), [$this]);
+    }
+
+    /**
+     * @param callable(T, TKey): bool ...$callbacks
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function since(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Since())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function slice(int $offset, int $length = -1): CollectionInterface
+    {
+        return static::fromCallable((new Slice())()($offset)($length), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function sort(int $type = Operation\Sortable::BY_VALUES, ?callable $callback = null): CollectionInterface
+    {
+        return static::fromCallable((new Sort())()($type)($callback), [$this]);
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
+     *
+     * @return CollectionInterface<int, Collection<TKey, T>>
+     */
+    public function span(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Span())()(...$callbacks), [$this])
+            ->map(
+                /**
+                 * @param iterable<TKey, T> $iterable
+                 *
+                 * @return CollectionInterface<TKey, T>
+                 */
+                static fn (iterable $iterable): CollectionInterface => Collection::fromIterable($iterable)
+            );
+    }
+
+    /**
+     * @return CollectionInterface<int, list<T>>
+     */
+    public function split(int $type = Operation\Splitable::BEFORE, callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Split())()($type)(...$callbacks), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function squash(): CollectionInterface
+    {
+        return static::fromIterable($this->pack()->all(false))->unpack();
+    }
+
+    /**
+     * @param null|callable(mixed): string $callback
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function strict(?callable $callback = null): CollectionInterface
+    {
+        return static::fromCallable((new Strict())()($callback), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function tail(): CollectionInterface
+    {
+        return static::fromCallable((new Tail())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, list<T>>
+     */
+    public function tails(): CollectionInterface
+    {
+        return static::fromCallable((new Tails())(), [$this]);
+    }
+
+    /**
+     * @param callable(T=, TKey=, iterable<TKey, T>=): bool ...$callbacks
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function takeWhile(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new TakeWhile())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, list<T>>
+     */
+    public function transpose(): CollectionInterface
+    {
+        return static::fromCallable((new Transpose())(), [$this]);
+    }
+
+    public function truthy(): bool
+    {
+        return (new Truthy())()($this)->current();
+    }
+
+    public function unlines(): string
+    {
+        return static::fromCallable((new Unlines())(), [$this])->current(0, '');
+    }
+
+    /**
+     * @return CollectionInterface<mixed, mixed>
+     */
+    public function unpack(): CollectionInterface
+    {
+        return static::fromCallable((new Unpack())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, TKey|T>
+     */
+    public function unpair(): CollectionInterface
+    {
+        return static::fromCallable((new Unpair())(), [$this]);
+    }
+
+    /**
+     * @param callable(T, TKey):bool ...$callbacks
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function until(callable ...$callbacks): CollectionInterface
+    {
+        return static::fromCallable((new Until())()(...$callbacks), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, T>
+     */
+    public function unwindow(): CollectionInterface
+    {
+        return static::fromCallable((new Unwindow())(), [$this]);
+    }
+
+    public function unwords(): string
+    {
+        return static::fromCallable((new Unwords())(), [$this])->current(0, '');
+    }
+
+    /**
+     * @return CollectionInterface<mixed, mixed>
+     */
+    public function unwrap(): CollectionInterface
+    {
+        return static::fromCallable((new Unwrap())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, list<T>>
+     */
+    public function unzip(): CollectionInterface
+    {
+        return static::fromCallable((new Unzip())(), [$this]);
+    }
+
+    /**
+     * @param callable(iterable<TKey, T>): bool $predicate
+     * @param callable(iterable<TKey, T>): iterable<TKey, T> $whenTrue
+     * @param callable(iterable<TKey, T>): iterable<TKey, T> $whenFalse
+     *
+     * @return CollectionInterface<TKey, T>
+     */
+    public function when(callable $predicate, callable $whenTrue, ?callable $whenFalse = null): CollectionInterface
+    {
+        $whenFalse ??=
+            /**
+             * @param iterable<TKey, T> $iterable
+             *
+             * @return iterable<TKey, T>
+             */
+            static fn (iterable $iterable): iterable => $iterable;
+
+        return static::fromCallable((new When())()($predicate)($whenTrue)($whenFalse), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, list<T>>
+     */
+    public function window(int $size): CollectionInterface
+    {
+        return static::fromCallable((new Window())()($size), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<TKey, string>
+     */
+    public function words(): CollectionInterface
+    {
+        return static::fromCallable((new Words())(), [$this]);
+    }
+
+    /**
+     * @return CollectionInterface<int, array<TKey, T>>
+     */
+    public function wrap(): CollectionInterface
+    {
+        return static::fromCallable((new Wrap())(), [$this]);
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param iterable<UKey, U> ...$iterables
+     *
+     * @return CollectionInterface<list<TKey|UKey>, list<T|U>>
+     */
+    public function zip(iterable ...$iterables): CollectionInterface
+    {
+        return static::fromCallable((new Zip())()(...$iterables), [$this]);
+    }
+}

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -4,142 +4,19 @@ declare(strict_types=1);
 
 namespace loophp\collection;
 
-use Closure;
-use Doctrine\Common\Collections\Criteria;
 use Generator;
 use loophp\collection\Contract\Collection as CollectionInterface;
-use loophp\collection\Contract\Operation;
-use loophp\collection\Operation\All;
-use loophp\collection\Operation\Append;
-use loophp\collection\Operation\Apply;
-use loophp\collection\Operation\Associate;
-use loophp\collection\Operation\AsyncMap;
-use loophp\collection\Operation\AsyncMapN;
-use loophp\collection\Operation\Averages;
-use loophp\collection\Operation\Cache;
-use loophp\collection\Operation\Chunk;
-use loophp\collection\Operation\Coalesce;
-use loophp\collection\Operation\Collapse;
-use loophp\collection\Operation\Column;
-use loophp\collection\Operation\Combinate;
-use loophp\collection\Operation\Combine;
-use loophp\collection\Operation\Compact;
-use loophp\collection\Operation\Compare;
-use loophp\collection\Operation\Contains;
-use loophp\collection\Operation\Current;
-use loophp\collection\Operation\Cycle;
-use loophp\collection\Operation\Diff;
-use loophp\collection\Operation\DiffKeys;
-use loophp\collection\Operation\Distinct;
-use loophp\collection\Operation\Drop;
-use loophp\collection\Operation\DropWhile;
-use loophp\collection\Operation\Dump;
-use loophp\collection\Operation\Duplicate;
-use loophp\collection\Operation\Equals;
-use loophp\collection\Operation\Every;
-use loophp\collection\Operation\Explode;
-use loophp\collection\Operation\Falsy;
-use loophp\collection\Operation\Filter;
-use loophp\collection\Operation\Find;
-use loophp\collection\Operation\First;
-use loophp\collection\Operation\FlatMap;
-use loophp\collection\Operation\Flatten;
-use loophp\collection\Operation\Flip;
-use loophp\collection\Operation\FoldLeft;
-use loophp\collection\Operation\FoldLeft1;
-use loophp\collection\Operation\FoldRight;
-use loophp\collection\Operation\FoldRight1;
-use loophp\collection\Operation\Forget;
-use loophp\collection\Operation\Frequency;
-use loophp\collection\Operation\Get;
-use loophp\collection\Operation\Group;
-use loophp\collection\Operation\GroupBy;
-use loophp\collection\Operation\Has;
-use loophp\collection\Operation\Head;
-use loophp\collection\Operation\IfThenElse;
-use loophp\collection\Operation\Implode;
-use loophp\collection\Operation\Init;
-use loophp\collection\Operation\Inits;
-use loophp\collection\Operation\Intersect;
-use loophp\collection\Operation\IntersectKeys;
-use loophp\collection\Operation\Intersperse;
-use loophp\collection\Operation\IsEmpty;
-use loophp\collection\Operation\Key;
-use loophp\collection\Operation\Keys;
-use loophp\collection\Operation\Last;
-use loophp\collection\Operation\Limit;
-use loophp\collection\Operation\Lines;
-use loophp\collection\Operation\Map;
-use loophp\collection\Operation\MapN;
-use loophp\collection\Operation\Matching;
-use loophp\collection\Operation\MatchOne;
-use loophp\collection\Operation\Max;
-use loophp\collection\Operation\Merge;
-use loophp\collection\Operation\Min;
-use loophp\collection\Operation\Normalize;
-use loophp\collection\Operation\Nth;
-use loophp\collection\Operation\Nullsy;
-use loophp\collection\Operation\Pack;
-use loophp\collection\Operation\Pad;
-use loophp\collection\Operation\Pair;
-use loophp\collection\Operation\Partition;
-use loophp\collection\Operation\Permutate;
-use loophp\collection\Operation\Pipe;
-use loophp\collection\Operation\Pluck;
-use loophp\collection\Operation\Prepend;
-use loophp\collection\Operation\Product;
-use loophp\collection\Operation\Random;
 use loophp\collection\Operation\Range;
-use loophp\collection\Operation\Reduce;
-use loophp\collection\Operation\Reduction;
-use loophp\collection\Operation\Reject;
-use loophp\collection\Operation\Reverse;
-use loophp\collection\Operation\RSample;
-use loophp\collection\Operation\Same;
-use loophp\collection\Operation\Scale;
-use loophp\collection\Operation\ScanLeft;
-use loophp\collection\Operation\ScanLeft1;
-use loophp\collection\Operation\ScanRight;
-use loophp\collection\Operation\ScanRight1;
-use loophp\collection\Operation\Shuffle;
-use loophp\collection\Operation\Since;
-use loophp\collection\Operation\Slice;
-use loophp\collection\Operation\Sort;
-use loophp\collection\Operation\Span;
-use loophp\collection\Operation\Split;
-use loophp\collection\Operation\Strict;
-use loophp\collection\Operation\Tail;
-use loophp\collection\Operation\Tails;
-use loophp\collection\Operation\TakeWhile;
 use loophp\collection\Operation\Times;
-use loophp\collection\Operation\Transpose;
-use loophp\collection\Operation\Truthy;
 use loophp\collection\Operation\Unfold;
-use loophp\collection\Operation\Unlines;
-use loophp\collection\Operation\Unpack;
-use loophp\collection\Operation\Unpair;
-use loophp\collection\Operation\Until;
-use loophp\collection\Operation\Unwindow;
-use loophp\collection\Operation\Unwords;
-use loophp\collection\Operation\Unwrap;
-use loophp\collection\Operation\Unzip;
-use loophp\collection\Operation\When;
-use loophp\collection\Operation\Window;
-use loophp\collection\Operation\Words;
-use loophp\collection\Operation\Wrap;
-use loophp\collection\Operation\Zip;
-use loophp\collection\Utils\CallbacksArrayReducer;
 use loophp\iterators\ClosureIteratorAggregate;
 use loophp\iterators\IterableIteratorAggregate;
 use loophp\iterators\ResourceIteratorAggregate;
 use loophp\iterators\StringIteratorAggregate;
 use NoRewindIterator;
-use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use Traversable;
 
 use const INF;
-use const PHP_INT_MAX;
 
 /**
  * @immutable
@@ -149,9 +26,9 @@ use const PHP_INT_MAX;
  *
  * phpcs:disable Generic.Files.LineLength.TooLong
  *
- * @implements \loophp\collection\Contract\Collection<TKey, T>
+ * @extends \loophp\collection\AbstractCollection<TKey, T>
  */
-final class Collection implements CollectionInterface
+final class Collection extends AbstractCollection
 {
     /**
      * @var ClosureIteratorAggregate<TKey, T>
@@ -167,290 +44,25 @@ final class Collection implements CollectionInterface
         $this->innerIterator = new ClosureIteratorAggregate($callable, $parameters);
     }
 
-    public function all(bool $normalize = true): array
-    {
-        return iterator_to_array((new All())()($normalize)($this));
-    }
-
-    public function append(...$items): CollectionInterface
-    {
-        return new self((new Append())()(...$items), [$this]);
-    }
-
-    public function apply(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new Apply())()(...$callbacks), [$this]);
-    }
-
-    public function associate(
-        ?callable $callbackForKeys = null,
-        ?callable $callbackForValues = null
-    ): CollectionInterface {
-        $defaultCallback =
-            /**
-             * @param mixed $carry
-             *
-             * @return mixed
-             */
-            static fn ($carry) => $carry;
-
-        return new self((new Associate())()($callbackForKeys ?? $defaultCallback)($callbackForValues ?? $defaultCallback), [$this]);
-    }
-
-    public function asyncMap(callable $callback): CollectionInterface
-    {
-        return new self((new AsyncMap())()($callback), [$this]);
-    }
-
-    public function asyncMapN(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new AsyncMapN())()(...$callbacks), [$this]);
-    }
-
-    public function averages(): CollectionInterface
-    {
-        return new self((new Averages())(), [$this]);
-    }
-
-    public function cache(?CacheItemPoolInterface $cache = null): CollectionInterface
-    {
-        return new self((new Cache())()($cache ?? new ArrayAdapter()), [$this]);
-    }
-
-    public function chunk(int ...$sizes): CollectionInterface
-    {
-        return new self((new Chunk())()(...$sizes), [$this]);
-    }
-
-    public function coalesce(): CollectionInterface
-    {
-        return new self((new Coalesce())(), [$this]);
-    }
-
-    public function collapse(): CollectionInterface
-    {
-        return new self((new Collapse())(), [$this]);
-    }
-
-    public function column($column): CollectionInterface
-    {
-        return new self((new Column())()($column), [$this]);
-    }
-
-    public function combinate(?int $length = null): CollectionInterface
-    {
-        return new self((new Combinate())()($length), [$this]);
-    }
-
-    public function combine(...$keys): CollectionInterface
-    {
-        return new self((new Combine())()(...$keys), [$this]);
-    }
-
-    public function compact(...$values): CollectionInterface
-    {
-        return new self((new Compact())()(...$values), [$this]);
-    }
-
-    public function compare(callable $comparator, $default = null)
-    {
-        return (new self((new Compare())()($comparator), [$this]))->current(0, $default);
-    }
-
-    public function contains(...$values): bool
-    {
-        return (new Contains())()(...$values)($this)->current();
-    }
-
-    public function count(): int
-    {
-        return iterator_count($this);
-    }
-
-    public function current(int $index = 0, $default = null)
-    {
-        return (new Current())()($index)($default)($this)->current();
-    }
-
-    public function cycle(): CollectionInterface
-    {
-        return new self((new Cycle())(), [$this]);
-    }
-
-    public function diff(...$values): CollectionInterface
-    {
-        return new self((new Diff())()(...$values), [$this]);
-    }
-
-    public function diffKeys(...$keys): CollectionInterface
-    {
-        return new self((new DiffKeys())()(...$keys), [$this]);
-    }
-
-    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): CollectionInterface
-    {
-        $accessorCallback ??=
-            /**
-             * @param T $value
-             * @param TKey $key
-             *
-             * @return T
-             */
-            static fn ($value, $key) => $value;
-
-        $comparatorCallback ??=
-            /**
-             * @param T $left
-             *
-             * @return Closure(T): bool
-             */
-            static fn ($left): Closure =>
-                /**
-                 * @param T $right
-                 */
-                static fn ($right): bool => $left === $right;
-
-        return new self((new Distinct())()($comparatorCallback)($accessorCallback), [$this]);
-    }
-
-    public function drop(int $count): CollectionInterface
-    {
-        return new self((new Drop())()($count), [$this]);
-    }
-
-    public function dropWhile(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new DropWhile())()(...$callbacks), [$this]);
-    }
-
-    public function dump(string $name = '', int $size = 1, ?Closure $closure = null): CollectionInterface
-    {
-        return new self((new Dump())()($name)($size)($closure), [$this]);
-    }
-
-    public function duplicate(?callable $comparatorCallback = null, ?callable $accessorCallback = null): CollectionInterface
-    {
-        $accessorCallback ??=
-            /**
-             * @param T $value
-             * @param TKey $key
-             *
-             * @return T
-             */
-            static fn ($value, $key) => $value;
-
-        $comparatorCallback ??=
-            /**
-             * @param T $left
-             *
-             * @return Closure(T): bool
-             */
-            static fn ($left): Closure =>
-                /**
-                 * @param T $right
-                 */
-                static fn ($right): bool => $left === $right;
-
-        return new self((new Duplicate())()($comparatorCallback)($accessorCallback), [$this]);
-    }
-
     /**
-     * @return self<TKey, T>
+     * @template UKey
+     * @template U
+     *
+     * @return self<UKey, U>
      */
     public static function empty(): CollectionInterface
     {
         return new self(static fn (): Generator => yield from []);
     }
 
-    public function equals(iterable $other): bool
-    {
-        return (new Equals())()($other)($this)->current();
-    }
-
-    public function every(callable ...$callbacks): bool
-    {
-        return (new Every())()(static fn (int $index, $value, $key, iterable $iterable) => CallbacksArrayReducer::or()($callbacks)($value, $key, $iterable))($this)
-            ->current();
-    }
-
-    public function explode(...$explodes): CollectionInterface
-    {
-        return new self((new Explode())()(...$explodes), [$this]);
-    }
-
-    public function falsy(): bool
-    {
-        return (new Falsy())()($this)->current();
-    }
-
-    public function filter(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new Filter())()(...$callbacks), [$this]);
-    }
-
-    public function find($default = null, callable ...$callbacks)
-    {
-        return (new Find())()($default)(...$callbacks)($this)->current();
-    }
-
-    public function first($default = null)
-    {
-        return (new self((new First())(), [$this]))->current(0, $default);
-    }
-
-    public function flatMap(callable $callback): CollectionInterface
-    {
-        return new self((new FlatMap())()($callback), [$this]);
-    }
-
-    public function flatten(int $depth = PHP_INT_MAX): CollectionInterface
-    {
-        return new self((new Flatten())()($depth), [$this]);
-    }
-
-    public function flip(): CollectionInterface
-    {
-        return new self((new Flip())(), [$this]);
-    }
-
-    public function foldLeft(callable $callback, $initial)
-    {
-        return (new self((new FoldLeft())()($callback)($initial), [$this]))->current();
-    }
-
-    public function foldLeft1(callable $callback)
-    {
-        return (new self((new FoldLeft1())()($callback), [$this]))->current();
-    }
-
-    public function foldRight(callable $callback, $initial)
-    {
-        return (new self((new Foldright())()($callback)($initial), [$this]))->current();
-    }
-
-    public function foldRight1(callable $callback)
-    {
-        return (new self((new FoldRight1())()($callback), [$this]))->current();
-    }
-
-    public function forget(...$keys): CollectionInterface
-    {
-        return new self((new Forget())()(...$keys), [$this]);
-    }
-
-    public function frequency(): CollectionInterface
-    {
-        return new self((new Frequency())(), [$this]);
-    }
-
     /**
-     * @template NewTKey
-     * @template NewT
+     * @template UKey
+     * @template U
      *
-     * @param callable(mixed ...$parameters): iterable<NewTKey, NewT> $callable
+     * @param callable(mixed ...$parameters): iterable<UKey, U> $callable
      * @param iterable<int, mixed> $parameters
      *
-     * @return self<NewTKey, NewT>
+     * @return self<UKey, U>
      */
     public static function fromCallable(callable $callable, iterable $parameters = []): self
     {
@@ -468,12 +80,10 @@ final class Collection implements CollectionInterface
     }
 
     /**
-     * @template NewTKey
-     * @template NewT
+     * @template UKey
+     * @template U
      *
-     * @param Generator<NewTKey, NewT> $generator
-     *
-     * @return self<NewTKey, NewT>
+     * @return self<UKey, U>
      */
     public static function fromGenerator(Generator $generator): self
     {
@@ -481,12 +91,12 @@ final class Collection implements CollectionInterface
     }
 
     /**
-     * @template NewTKey
-     * @template NewT
+     * @template UKey
+     * @template U
      *
-     * @param iterable<NewTKey, NewT> $iterable
+     * @param iterable<UKey, U> $iterable
      *
-     * @return self<NewTKey, NewT>
+     * @return self<UKey, U>
      */
     public static function fromIterable(iterable $iterable): self
     {
@@ -511,11 +121,6 @@ final class Collection implements CollectionInterface
         return new self(static fn (): Generator => yield from new StringIteratorAggregate($string, $delimiter));
     }
 
-    public function get($key, $default = null)
-    {
-        return (new self((new Get())()($key)($default), [$this]))->current(0, $default);
-    }
-
     /**
      * @return Traversable<TKey, T>
      */
@@ -524,355 +129,9 @@ final class Collection implements CollectionInterface
         yield from $this->innerIterator->getIterator();
     }
 
-    public function group(): CollectionInterface
-    {
-        return new self((new Group())(), [$this]);
-    }
-
-    public function groupBy(callable $callable): CollectionInterface
-    {
-        return new self((new GroupBy())()($callable), [$this]);
-    }
-
-    public function has(callable ...$callbacks): bool
-    {
-        return (new Has())()(...$callbacks)($this)->current();
-    }
-
-    public function head($default = null)
-    {
-        return (new self((new Head())(), [$this]))->current(0, $default);
-    }
-
-    public function ifThenElse(callable $condition, callable $then, ?callable $else = null): CollectionInterface
-    {
-        $identity =
-            /**
-             * @param T $value
-             *
-             * @return T
-             */
-            static fn ($value) => $value;
-
-        return new self((new IfThenElse())()($condition)($then)($else ?? $identity), [$this]);
-    }
-
-    public function implode(string $glue = ''): string
-    {
-        return (new self((new Implode())()($glue), [$this]))->current(0, '');
-    }
-
-    public function init(): CollectionInterface
-    {
-        return new self((new Init())(), [$this]);
-    }
-
-    public function inits(): CollectionInterface
-    {
-        return new self((new Inits())(), [$this]);
-    }
-
-    public function intersect(...$values): CollectionInterface
-    {
-        return new self((new Intersect())()(...$values), [$this]);
-    }
-
-    public function intersectKeys(...$keys): CollectionInterface
-    {
-        return new self((new IntersectKeys())()(...$keys), [$this]);
-    }
-
-    public function intersperse($element, int $every = 1, int $startAt = 0): CollectionInterface
-    {
-        return new self((new Intersperse())()($element)($every)($startAt), [$this]);
-    }
-
-    public function isEmpty(): bool
-    {
-        return (new IsEmpty())()($this)->current();
-    }
-
-    /**
-     * @return array<mixed>
-     */
-    public function jsonSerialize(): array
-    {
-        return $this->all(false);
-    }
-
-    public function key(int $index = 0)
-    {
-        return (new Key())()($index)($this)->current();
-    }
-
-    public function keys(): CollectionInterface
-    {
-        return new self((new Keys())(), [$this]);
-    }
-
-    public function last($default = null)
-    {
-        return (new self((new Last())(), [$this]))->current(0, $default);
-    }
-
-    public function limit(int $count = -1, int $offset = 0): CollectionInterface
-    {
-        return new self((new Limit())()($count)($offset), [$this]);
-    }
-
-    public function lines(): CollectionInterface
-    {
-        return new self((new Lines())(), [$this]);
-    }
-
-    public function map(callable $callback): CollectionInterface
-    {
-        return new self((new Map())()($callback), [$this]);
-    }
-
-    public function mapN(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new MapN())()(...$callbacks), [$this]);
-    }
-
-    public function match(callable $callback, ?callable $matcher = null): bool
-    {
-        return (new MatchOne())()($matcher ?? static fn (): bool => true)($callback)($this)->current();
-    }
-
-    public function matching(Criteria $criteria): CollectionInterface
-    {
-        return new self((new Matching())()($criteria), [$this]);
-    }
-
-    public function max($default = null)
-    {
-        return (new self((new Max())(), [$this]))->current(0, $default);
-    }
-
-    public function merge(iterable ...$sources): CollectionInterface
-    {
-        return new self((new Merge())()(...$sources), [$this]);
-    }
-
-    public function min($default = null)
-    {
-        return (new self((new Min())(), [$this]))->current(0, $default);
-    }
-
-    public function normalize(): CollectionInterface
-    {
-        return new self((new Normalize())(), [$this]);
-    }
-
-    public function nth(int $step, int $offset = 0): CollectionInterface
-    {
-        return new self((new Nth())()($step)($offset), [$this]);
-    }
-
-    public function nullsy(): bool
-    {
-        return (new Nullsy())()($this)->current();
-    }
-
-    public function pack(): CollectionInterface
-    {
-        return new self((new Pack())(), [$this]);
-    }
-
-    public function pad(int $size, $value): CollectionInterface
-    {
-        return new self((new Pad())()($size)($value), [$this]);
-    }
-
-    public function pair(): CollectionInterface
-    {
-        return new self((new Pair())(), [$this]);
-    }
-
-    public function partition(callable ...$callbacks): CollectionInterface
-    {
-        return (new self((new Partition())()(...$callbacks), [$this]))
-            ->map(
-                /**
-                 * @param iterable<TKey, T> $iterable
-                 *
-                 * @return CollectionInterface<TKey, T>
-                 */
-                static fn (iterable $iterable): CollectionInterface => Collection::fromIterable($iterable)
-            );
-    }
-
-    public function permutate(): CollectionInterface
-    {
-        return new self((new Permutate())(), [$this]);
-    }
-
-    public function pipe(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new Pipe())()(...$callbacks), [$this]);
-    }
-
-    public function pluck($pluck, $default = null): CollectionInterface
-    {
-        return new self((new Pluck())()($pluck)($default), [$this]);
-    }
-
-    public function prepend(...$items): CollectionInterface
-    {
-        return new self((new Prepend())()(...$items), [$this]);
-    }
-
-    public function product(iterable ...$iterables): CollectionInterface
-    {
-        return new self((new Product())()(...$iterables), [$this]);
-    }
-
-    public function random(int $size = 1, ?int $seed = null): CollectionInterface
-    {
-        return new self((new Random())()($seed ?? random_int(0, 1000))($size), [$this]);
-    }
-
     public static function range(float $start = 0.0, float $end = INF, float $step = 1.0): CollectionInterface
     {
         return new self((new Range())()($start)($end)($step));
-    }
-
-    public function reduce(callable $callback, $initial = null)
-    {
-        return (new self((new Reduce())()($callback)($initial), [$this]))->current();
-    }
-
-    public function reduction(callable $callback, $initial = null): CollectionInterface
-    {
-        return new self((new Reduction())()($callback)($initial), [$this]);
-    }
-
-    public function reject(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new Reject())()(...$callbacks), [$this]);
-    }
-
-    public function reverse(): CollectionInterface
-    {
-        return new self((new Reverse())(), [$this]);
-    }
-
-    public function rsample(float $probability): CollectionInterface
-    {
-        return new self((new RSample())()($probability), [$this]);
-    }
-
-    public function same(iterable $other, ?callable $comparatorCallback = null): bool
-    {
-        $comparatorCallback ??=
-            /**
-             * @param T $leftValue
-             * @param TKey $leftKey
-             *
-             * @return Closure(T, TKey): bool
-             */
-            static fn ($leftValue, $leftKey): Closure =>
-                /**
-                 * @param T $rightValue
-                 * @param TKey $rightKey
-                 */
-                static fn ($rightValue, $rightKey): bool => $leftValue === $rightValue && $leftKey === $rightKey;
-
-        return (new Same())()($other)($comparatorCallback)($this)->current();
-    }
-
-    public function scale(
-        float $lowerBound,
-        float $upperBound,
-        float $wantedLowerBound = 0.0,
-        float $wantedUpperBound = 1.0,
-        float $base = 0.0
-    ): CollectionInterface {
-        return new self((new Scale())()($lowerBound)($upperBound)($wantedLowerBound)($wantedUpperBound)($base), [$this]);
-    }
-
-    public function scanLeft(callable $callback, $initial): CollectionInterface
-    {
-        return new self((new ScanLeft())()($callback)($initial), [$this]);
-    }
-
-    public function scanLeft1(callable $callback): CollectionInterface
-    {
-        return new self((new ScanLeft1())()($callback), [$this]);
-    }
-
-    public function scanRight(callable $callback, $initial): CollectionInterface
-    {
-        return new self((new ScanRight())()($callback)($initial), [$this]);
-    }
-
-    public function scanRight1(callable $callback): CollectionInterface
-    {
-        return new self((new ScanRight1())()($callback), [$this]);
-    }
-
-    public function shuffle(?int $seed = null): CollectionInterface
-    {
-        return new self((new Shuffle())()($seed ?? random_int(0, 1000)), [$this]);
-    }
-
-    public function since(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new Since())()(...$callbacks), [$this]);
-    }
-
-    public function slice(int $offset, int $length = -1): CollectionInterface
-    {
-        return new self((new Slice())()($offset)($length), [$this]);
-    }
-
-    public function sort(int $type = Operation\Sortable::BY_VALUES, ?callable $callback = null): CollectionInterface
-    {
-        return new self((new Sort())()($type)($callback), [$this]);
-    }
-
-    public function span(callable ...$callbacks): CollectionInterface
-    {
-        return (new self((new Span())()(...$callbacks), [$this]))
-            ->map(
-                /**
-                 * @param iterable<TKey, T> $iterable
-                 *
-                 * @return CollectionInterface<TKey, T>
-                 */
-                static fn (iterable $iterable): CollectionInterface => Collection::fromIterable($iterable)
-            );
-    }
-
-    public function split(int $type = Operation\Splitable::BEFORE, callable ...$callbacks): CollectionInterface
-    {
-        return new self((new Split())()($type)(...$callbacks), [$this]);
-    }
-
-    public function squash(): CollectionInterface
-    {
-        return self::fromIterable($this->pack()->all(false))->unpack();
-    }
-
-    public function strict(?callable $callback = null): CollectionInterface
-    {
-        return new self((new Strict())()($callback), [$this]);
-    }
-
-    public function tail(): CollectionInterface
-    {
-        return new self((new Tail())(), [$this]);
-    }
-
-    public function tails(): CollectionInterface
-    {
-        return new self((new Tails())(), [$this]);
-    }
-
-    public function takeWhile(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new TakeWhile())()(...$callbacks), [$this]);
     }
 
     public static function times(int $number = 0, ?callable $callback = null): CollectionInterface
@@ -880,91 +139,8 @@ final class Collection implements CollectionInterface
         return new self((new Times())()($number)($callback));
     }
 
-    public function transpose(): CollectionInterface
-    {
-        return new self((new Transpose())(), [$this]);
-    }
-
-    public function truthy(): bool
-    {
-        return (new Truthy())()($this)->current();
-    }
-
     public static function unfold(callable $callback, ...$parameters): CollectionInterface
     {
         return new self((new Unfold())()(...$parameters)($callback));
-    }
-
-    public function unlines(): string
-    {
-        return (new self((new Unlines())(), [$this]))->current(0, '');
-    }
-
-    public function unpack(): CollectionInterface
-    {
-        return new self((new Unpack())(), [$this]);
-    }
-
-    public function unpair(): CollectionInterface
-    {
-        return new self((new Unpair())(), [$this]);
-    }
-
-    public function until(callable ...$callbacks): CollectionInterface
-    {
-        return new self((new Until())()(...$callbacks), [$this]);
-    }
-
-    public function unwindow(): CollectionInterface
-    {
-        return new self((new Unwindow())(), [$this]);
-    }
-
-    public function unwords(): string
-    {
-        return (new self((new Unwords())(), [$this]))->current(0, '');
-    }
-
-    public function unwrap(): CollectionInterface
-    {
-        return new self((new Unwrap())(), [$this]);
-    }
-
-    public function unzip(): CollectionInterface
-    {
-        return new self((new Unzip())(), [$this]);
-    }
-
-    public function when(callable $predicate, callable $whenTrue, ?callable $whenFalse = null): CollectionInterface
-    {
-        $whenFalse ??=
-            /**
-             * @param iterable<TKey, T> $iterable
-             *
-             * @return iterable<TKey, T>
-             */
-            static fn (iterable $iterable): iterable => $iterable;
-
-        return new self((new When())()($predicate)($whenTrue)($whenFalse), [$this]);
-    }
-
-    public function window(int $size): CollectionInterface
-    {
-        return new self((new Window())()($size), [$this]);
-    }
-
-    public function words(): CollectionInterface
-    {
-        return new self((new Words())(), [$this]);
-    }
-
-    public function wrap(): CollectionInterface
-    {
-        return new self((new Wrap())(), [$this]);
-    }
-
-    public function zip(iterable ...$iterables): CollectionInterface
-    {
-        return new self((new Zip())()(...$iterables), [$this]);
     }
 }

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace loophp\collection\Contract;
 
 use Countable;
+use Generator;
 use IteratorAggregate;
 use JsonSerializable;
 use loophp\collection\Contract\Operation\Allable;
@@ -378,6 +379,60 @@ interface Collection extends
     Wrapable,
     Zipable
 {
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @return self<UKey, U>
+     */
+    public static function empty(): Collection;
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param callable(mixed ...$parameters): iterable<UKey, U> $callable
+     * @param iterable<int, mixed> $parameters
+     *
+     * @return self<UKey, U>
+     */
+    public static function fromCallable(callable $callable, iterable $parameters = []): Collection;
+
+    /**
+     * @return Collection<int, string>
+     */
+    public static function fromFile(string $filepath): Collection;
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @return self<UKey, U>
+     */
+    public static function fromGenerator(Generator $generator): Collection;
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param iterable<UKey, U> $iterable
+     *
+     * @return self<UKey, U>
+     */
+    public static function fromIterable(iterable $iterable): Collection;
+
+    /**
+     * @param resource $resource
+     *
+     * @return Collection<int, string>
+     */
+    public static function fromResource($resource): Collection;
+
+    /**
+     * @return Collection<int, string>
+     */
+    public static function fromString(string $string, string $delimiter = ''): Collection;
+
     /**
      * @return Traversable<TKey, T>
      */

--- a/tests/static-analysis/all.php
+++ b/tests/static-analysis/all.php
@@ -31,7 +31,7 @@ all_checkMixed(Collection::fromIterable([1, 2, 'b', '5', 4])->all());
 all_checkMixed(Collection::fromIterable([1, 2, 'b', '5', 4])->all(false));
 
 // VALID failures -> improper usage
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
 all_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all());
 /** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
 all_checkList(Collection::fromIterable(['foo' => 1, 'bar' => 2])->all(false));

--- a/tests/static-analysis/append.php
+++ b/tests/static-analysis/append.php
@@ -65,6 +65,9 @@ append_checkMixed(Collection::empty()->append(1, '2'));
 append_checkMixed(Collection::empty()->append(...[1, '2']));
 append_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1, '3'));
 
+append_checkList(Collection::fromIterable([5])->append('foo'));
+append_checkList(Collection::fromIterable([5])->append('foo', 1));
+
 // ## VALID FAILURE ###
 /** @psalm-suppress InvalidArgument */
 append_checkList(Collection::empty()->append(1, 'foo'));
@@ -75,15 +78,13 @@ append_checkList(Collection::fromIterable([5])->append('foo', 1)); // @phpstan-i
 
 /** @psalm-suppress InvalidArgument */
 append_checkListWithMap(Collection::empty()->append($foo, ['bar' => 'baz']));
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 append_checkListWithMap(Collection::fromIterable([1 => $foo])->append(['bar' => 'baz']));
 
 /**
  * Append will transform any Collection<string, int> into Collection<int|TKey, int>.
  *
  * @psalm-suppress InvalidScalarArgument
- *
- * @phpstan-ignore-next-line
  */
 append_checkMap(Collection::fromIterable($foo)->append(3));
 
@@ -91,5 +92,5 @@ append_checkMap(Collection::fromIterable($foo)->append(3));
 append_checkMixed(Collection::empty()->append(1, [3]));
 /** @psalm-suppress InvalidArgument */
 append_checkMixed(Collection::empty()->append(...[1, [3]]));
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument */
 append_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1, ['3']));

--- a/tests/static-analysis/append.php
+++ b/tests/static-analysis/append.php
@@ -65,18 +65,15 @@ append_checkMixed(Collection::empty()->append(1, '2'));
 append_checkMixed(Collection::empty()->append(...[1, '2']));
 append_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1, '3'));
 
-append_checkList(Collection::fromIterable([5])->append('foo'));
-append_checkList(Collection::fromIterable([5])->append('foo', 1));
-
 // ## VALID FAILURE ###
-/** @psalm-suppress InvalidArgument */
+/** @psalm-suppress InvalidScalarArgument */
 append_checkList(Collection::empty()->append(1, 'foo'));
 /** @psalm-suppress InvalidScalarArgument */
 append_checkList(Collection::fromIterable([5])->append('foo')); // @phpstan-ignore-line
 /** @psalm-suppress InvalidScalarArgument */
 append_checkList(Collection::fromIterable([5])->append('foo', 1)); // @phpstan-ignore-line
 
-/** @psalm-suppress InvalidArgument */
+/** @psalm-suppress InvalidScalarArgument */
 append_checkListWithMap(Collection::empty()->append($foo, ['bar' => 'baz']));
 /** @psalm-suppress InvalidScalarArgument */
 append_checkListWithMap(Collection::fromIterable([1 => $foo])->append(['bar' => 'baz']));

--- a/tests/static-analysis/asyncMap.php
+++ b/tests/static-analysis/asyncMap.php
@@ -60,7 +60,7 @@ asyncMap_checkListString(Collection::fromIterable([1, 2, 3])->asyncMap($square)-
 
 // VALID failures due to usage with wrong types
 
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 asyncMap_checkListInt(Collection::fromIterable(['foo' => 'bar'])->asyncMap($square));
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 asyncMap_checkMapString(Collection::fromIterable([1, 2, 3])->asyncMap($appendBar));

--- a/tests/static-analysis/compare.php
+++ b/tests/static-analysis/compare.php
@@ -39,13 +39,13 @@ compare_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => null])->
 // VALID failures
 
 // `compare` can return NULL
-/** @psalm-suppress ArgumentTypeCoercion,PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress ArgumentTypeCoercion,PossiblyNullArgument */
 compare_takeInt(Collection::fromIterable([1, 2, 3, -2, 4])->compare($compareInt));
-/** @psalm-suppress ArgumentTypeCoercion,PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress ArgumentTypeCoercion,PossiblyNullArgument */
 compare_takeString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->compare($compareString));
 
 // usage of callback with different types for `carry` and `value`
-/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+/** @psalm-suppress ArgumentTypeCoercion */
 compare_takeIntOrNull(Collection::fromIterable([1, 2, 3, -2, 4])->compare($compareNullableInt));
-/** @psalm-suppress ArgumentTypeCoercion @phpstan-ignore-next-line */
+/** @psalm-suppress ArgumentTypeCoercion */
 compare_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->compare($compareNullableString));

--- a/tests/static-analysis/current.php
+++ b/tests/static-analysis/current.php
@@ -40,7 +40,7 @@ current_checkNonNullable(Collection::fromIterable(range(0, 6))->current(0, -1));
 // VALID failures because `current` can return `NULL` when the collection is empty
 /** @psalm-suppress PossiblyNullArgument */
 current_checkNonNullable(Collection::fromIterable(range(0, 6))->current());
-/** @psalm-suppress PossiblyNullArgument PHPStan is lost here, type inference for `empty` is not as good as Psalm */
+/** @psalm-suppress NullArgument PHPStan is lost here, type inference for `empty` is not as good as Psalm */
 current_checkNonNullable(Collection::empty()->current());
 
 // VALID failures because `current` can use a default value of any type

--- a/tests/static-analysis/current.php
+++ b/tests/static-analysis/current.php
@@ -38,13 +38,13 @@ current_checkEmptyWithDefaultValue(Collection::empty()->current(10, randomString
 current_checkNonNullable(Collection::fromIterable(range(0, 6))->current(0, -1));
 
 // VALID failures because `current` can return `NULL` when the collection is empty
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line  */
+/** @psalm-suppress PossiblyNullArgument */
 current_checkNonNullable(Collection::fromIterable(range(0, 6))->current());
 /** @psalm-suppress PossiblyNullArgument PHPStan is lost here, type inference for `empty` is not as good as Psalm */
 current_checkNonNullable(Collection::empty()->current());
 
 // VALID failures because `current` can use a default value of any type
-/** @psalm-suppress PossiblyInvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyInvalidArgument */
 current_checkNonNullable(Collection::fromIterable(range(0, 6))->current(0, 'not found'));
 /** @psalm-suppress InvalidArgument */
 current_checkEmptyWithDefaultValue(Collection::empty()->current(10, 404));

--- a/tests/static-analysis/distinct.php
+++ b/tests/static-analysis/distinct.php
@@ -56,9 +56,9 @@ distinct_checkObjectList(Collection::fromIterable($catGenerator())->distinct(nul
 // VALID failures
 
 // `distinct` does not change the collection types TKey, T
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 distinct_checkIntList(Collection::fromIterable(['a', 'b', 'c'])->distinct());
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 distinct_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2, 'baz' => 'f'])->distinct());
 
 // mixing object comparator parameter types
@@ -68,7 +68,7 @@ distinct_checkObjectList(Collection::fromIterable($catGenerator())->distinct($ob
 
 // using wrong type parameter for accessor callback
 $accessor = static fn (string $object): string => $object;
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument */
 distinct_checkObjectList(Collection::fromIterable($catGenerator())->distinct(null, $accessor));
 
 // comparator parameter types need to match accessor return type

--- a/tests/static-analysis/drop.php
+++ b/tests/static-analysis/drop.php
@@ -24,7 +24,7 @@ drop_checkList(Collection::fromIterable([1, 2, 3])->drop(1));
 drop_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->drop(2));
 
 // VALID failures -> `drop` does not change the key and value types
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 drop_checkList(Collection::fromIterable(['a', 'b', 'c'])->drop(1));
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 drop_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->drop(3));

--- a/tests/static-analysis/get.php
+++ b/tests/static-analysis/get.php
@@ -52,15 +52,15 @@ get_checkListNullable(Collection::fromIterable([1, 2, 3])->get(1, -1));
 get_checkMapNullable(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo', 'x'));
 
 // VALID failures - `get` returns `Collection<TKey, T|V>, where V can be anything
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument */
 get_checkList(Collection::fromIterable([1, 2, 3])->get(1));
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument */
 get_checkMap(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo'));
 
 // VALID failures - `current` can return `NULL`
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 get_checkIntElement(Collection::fromIterable([1, 2, 3])->get(1));
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 get_checkStringElement(Collection::fromIterable(['foo' => 'a', 'bar' => 'b'])->get('foo'));
 
 // VALID but inconvenient failures - although a non-null default is provided to `get`, `current` can return `NULL`

--- a/tests/static-analysis/head.php
+++ b/tests/static-analysis/head.php
@@ -41,9 +41,9 @@ head_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'
 head_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->head('not-found'));
 
 // VALID failures - `current` returns T|null
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 head_checkIntElement(Collection::fromIterable([1, 2, 3])->head());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 head_checkStringElement(Collection::fromIterable(['foo' => 'bar'])->head());
 
 // VALID failures - these keys don't exist

--- a/tests/static-analysis/key.php
+++ b/tests/static-analysis/key.php
@@ -26,18 +26,18 @@ key_checkNullableString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->
 key_checkNullableString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key(1));
 
 // VALID failure -> `key` can return `NULL` because `current` can return `NULL`
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 key_checkInt(Collection::fromIterable([1, 2, 3])->key());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 key_checkInt(Collection::fromIterable([1, 2, 3])->key(2));
 
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key(1));
 
 // VALID failure -> mixed key
-/** @psalm-suppress PossiblyInvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 key_checkInt(Collection::fromIterable([1, 2, 'foo' => 4])->key());
-/** @psalm-suppress PossiblyInvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 key_checkString(Collection::fromIterable([1, 2, 'foo' => 4])->key());

--- a/tests/static-analysis/key.php
+++ b/tests/static-analysis/key.php
@@ -37,7 +37,7 @@ key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key());
 key_checkString(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->key(1));
 
 // VALID failure -> mixed key
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress PossiblyInvalidArgument */
 key_checkInt(Collection::fromIterable([1, 2, 'foo' => 4])->key());
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress PossiblyInvalidArgument */
 key_checkString(Collection::fromIterable([1, 2, 'foo' => 4])->key());

--- a/tests/static-analysis/keys.php
+++ b/tests/static-analysis/keys.php
@@ -24,7 +24,7 @@ keys_checkIntList(Collection::fromIterable([1, 2, 3])->keys());
 keys_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->keys());
 
 // VALID failure -> mixed keys
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 keys_checkIntList(Collection::fromIterable([1, 2, 'foo' => 4])->keys());
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 keys_checkStringList(Collection::fromIterable([1, 2, 'foo' => 4])->keys());

--- a/tests/static-analysis/last.php
+++ b/tests/static-analysis/last.php
@@ -40,7 +40,7 @@ last_checkIntElement(Collection::fromIterable([1, 2, 3])->last(0));
 last_checkStringElement(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->last(''));
 
 // VALID failures - `current` returns T|null
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 last_checkIntElement(Collection::fromIterable([1, 2, 3])->last());
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 last_checkStringElement(Collection::fromIterable(['foo' => 'bar'])->last());

--- a/tests/static-analysis/max.php
+++ b/tests/static-analysis/max.php
@@ -33,13 +33,13 @@ max_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => null])->max(
 
 // VALID failures - `max` can return NULL
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 max_takeInt(Collection::empty()->max());
 
 /** @psalm-suppress PossiblyNullArgument */
 max_takeInt(Collection::fromIterable([1, 2, 3, -2, 4])->max());
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 max_takeString(Collection::empty()->max());
 
 /** @psalm-suppress PossiblyNullArgument */

--- a/tests/static-analysis/max.php
+++ b/tests/static-analysis/max.php
@@ -36,11 +36,11 @@ max_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => null])->max(
 /** @psalm-suppress PossiblyNullArgument */
 max_takeInt(Collection::empty()->max());
 
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 max_takeInt(Collection::fromIterable([1, 2, 3, -2, 4])->max());
 
 /** @psalm-suppress PossiblyNullArgument */
 max_takeString(Collection::empty()->max());
 
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 max_takeString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max());

--- a/tests/static-analysis/min.php
+++ b/tests/static-analysis/min.php
@@ -36,11 +36,11 @@ min_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => null])->min(
 /** @psalm-suppress PossiblyNullArgument */
 min_takeInt(Collection::empty()->min());
 
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 min_takeInt(Collection::fromIterable([1, 2, 3, -2, 4])->min());
 
 /** @psalm-suppress PossiblyNullArgument */
 min_takeString(Collection::empty()->min());
 
-/** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
+/** @psalm-suppress PossiblyNullArgument */
 min_takeString(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min());

--- a/tests/static-analysis/min.php
+++ b/tests/static-analysis/min.php
@@ -33,13 +33,13 @@ min_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => null])->min(
 
 // VALID failures - `min` can return NULL
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 min_takeInt(Collection::empty()->min());
 
 /** @psalm-suppress PossiblyNullArgument */
 min_takeInt(Collection::fromIterable([1, 2, 3, -2, 4])->min());
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 min_takeString(Collection::empty()->min());
 
 /** @psalm-suppress PossiblyNullArgument */

--- a/tests/static-analysis/normalize.php
+++ b/tests/static-analysis/normalize.php
@@ -30,5 +30,5 @@ normalize_checkIntList(Collection::fromIterable([1, 2, 3])->normalize());
 normalize_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->normalize());
 
 // VALID failure -> `normalize` always returns a collection with `int` keys
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
 normalize_checkStringMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'f'])->normalize());

--- a/tests/static-analysis/pair.php
+++ b/tests/static-analysis/pair.php
@@ -36,13 +36,13 @@ pair_checkListNullableInt(Collection::fromIterable([1, 2, 3])->pair());
 pair_checkMapNullableString(Collection::fromIterable(range('a', 'b'))->pair());
 
 // VALID failures -> `pair` can return `NULL` in the collection
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument */
 pair_checkListInt(Collection::fromIterable([1, 2, 3])->pair());
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument */
 pair_checkMapString(Collection::fromIterable(range('a', 'b'))->pair());
 
 // VALID failures -> `pair` will use values as keys
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 pair_checkListNullableInt(Collection::fromIterable(['1', '2', '3'])->pair());
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 pair_checkMapNullableString(Collection::fromIterable(['foo' => 1, 'bar' => 2])->pair());

--- a/tests/static-analysis/scanLeft.php
+++ b/tests/static-analysis/scanLeft.php
@@ -46,5 +46,7 @@ function scanLeft_checkListOfSize1String(CollectionInterface $collection): void
 
 scanLeft_checkListInt(Collection::fromIterable([1, 2, 3])->scanLeft($sum, 5));
 scanLeft_checkListString(Collection::fromIterable(range('a', 'c'))->scanLeft($concat, ''));
+/** @psalm-suppress InvalidArgument */
 scanLeft_checkListStringWithNull(Collection::fromIterable(range('a', 'c'))->scanLeft($concatWithNull, null));
+/** @psalm-suppress InvalidArgument */
 scanLeft_checkListOfSize1String(Collection::fromIterable([10])->scanLeft($toString, true));

--- a/tests/static-analysis/scanLeft1.php
+++ b/tests/static-analysis/scanLeft1.php
@@ -30,4 +30,5 @@ function scanLeft1_checkListOfSize1String(CollectionInterface $collection): void
 
 // see Psalm bug: https://github.com/vimeo/psalm/issues/6108
 scanLeft1_checkListString(Collection::fromIterable(range('a', 'c'))->scanLeft1($concat));
+/** @psalm-suppress InvalidArgument */
 scanLeft1_checkListOfSize1String(Collection::fromIterable([10])->scanLeft1($toString));

--- a/tests/static-analysis/scanRight.php
+++ b/tests/static-analysis/scanRight.php
@@ -46,5 +46,7 @@ function scanRight_checkListOfSize1String(CollectionInterface $collection): void
 
 scanRight_checkListInt(Collection::fromIterable([1, 2, 3])->scanRight($sum, 5));
 scanRight_checkListString(Collection::fromIterable(range('a', 'c'))->scanRight($concat, ''));
-scanRight_checkListStringWithNull(Collection::fromIterable(range('a', 'c'))->scanRight($concatWithNull, null));
+/** @psalm-suppress InvalidArgument */
+scanRight_checkListStringWithNull(Collection::fromIterable(range('a', 'c'))->scanRight($concatWithNull, ''));
+/** @psalm-suppress InvalidArgument */
 scanRight_checkListOfSize1String(Collection::fromIterable([10])->scanRight($toString, true));

--- a/tests/static-analysis/scanRight1.php
+++ b/tests/static-analysis/scanRight1.php
@@ -30,4 +30,5 @@ function scanRight1_checkListOfSize1String(CollectionInterface $collection): voi
 
 // see Psalm bug: https://github.com/vimeo/psalm/issues/6108
 scanRight1_checkListString(Collection::fromIterable(range('a', 'c'))->scanRight1($concat));
+/** @psalm-suppress InvalidArgument */
 scanRight1_checkListOfSize1String(Collection::fromIterable([10])->scanRight1($toString));

--- a/tests/static-analysis/squash.php
+++ b/tests/static-analysis/squash.php
@@ -35,9 +35,9 @@ squash_checkList(Collection::fromIterable(['foo' => 1, 'bar' => 2])->normalize()
 squash_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->normalize()->squash());
 
 // VALID failures -> `squash` does not change the key and value types
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 squash_checkList(Collection::fromIterable(['a', 'b', 'c'])->squash());
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 squash_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->squash());
-/** @psalm-suppress InvalidScalarArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidScalarArgument */
 squash_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->squash());

--- a/tests/static-analysis/unfold.php
+++ b/tests/static-analysis/unfold.php
@@ -28,13 +28,9 @@ unfold_checkList(Collection::unfold($plusTwo, -2)->unwrap());
 
 // VALID use cases -> PHPStan thinks the collection is of type Collection<int, array<int, mixed>>, but Psalm works
 
-/** @phpstan-ignore-next-line */
 unfold_checkListOfLists(Collection::unfold($plusTwo));
-/** @phpstan-ignore-next-line */
 unfold_checkListOfLists(Collection::unfold($plusTwo, -2));
-/** @phpstan-ignore-next-line */
 unfold_checkListOfLists(Collection::unfold($fib));
-/** @phpstan-ignore-next-line */
 unfold_checkListOfLists(Collection::unfold($fib, 0, 1));
 
 // VALID use case -> `Pluck` can return various things so analysers cannot know the type is correct


### PR DESCRIPTION
Context from @busterneece on Twitter: https://twitter.com/BusterNeece/status/1587570951918870529

This PR:

- [x] Add an abstract class `AbstractCollection` to ease the process of extending
- [x] Update PHPStan baseline (needs review)
- [x] Update PSalm baseline (needs review)
- [x] Has documentation
- [ ] It breaks backward compatibility
- [ ] Is covered by unit tests
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Is an experimental thing

