### PR TITLE
refactor: `unfold` constructor is not variadic anymore

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -153,7 +153,7 @@ Create a collection by yielding from a callback with an initial value.
             on the next callback call. Therefore, the returned list should contain values of the same type
             as the parameters for the callback function.
 
-Signature: ``Collection::unfold(callable $callback, ...$parameters): Collection;``
+Signature: ``Collection::unfold(callable $callback, $parameters): Collection;``
 
 .. literalinclude:: code/operations/unfold.php
   :language: php

--- a/docs/pages/code/operations/unfold.php
+++ b/docs/pages/code/operations/unfold.php
@@ -11,7 +11,7 @@ use const INF;
 include __DIR__ . '/../../../../vendor/autoload.php';
 
 // Example 1 -> A list of Naturals from 1 to Infinity (use `limit` to keep only a set of them)
-Collection::unfold(static fn (int $n): array => [$n + 1], 1)
+Collection::unfold(static fn (int $n): array => [$n + 1], [1])
     ->unwrap()
     ->all(); // [1, 2, 3, 4, ...]
 
@@ -22,8 +22,8 @@ Collection::unfold(static fn (int $a = 0, int $b = 1): array => [$b, $a + $b])
     ->all(); // [1, 1, 2, 3, 5, 8, 13, 21, 34, 55]
 
 // Example 3 -> infinite range, similar to the `range` operation
-$even = Collection::unfold(static fn ($carry): array => [$carry + 2], -2)->unwrap();
-$odd = Collection::unfold(static fn ($carry): array => [$carry + 2], -1)->unwrap();
+$even = Collection::unfold(static fn ($carry): array => [$carry + 2], [-2])->unwrap();
+$odd = Collection::unfold(static fn ($carry): array => [$carry + 2], [-1])->unwrap();
 
 // Is the same as
 $even = Collection::range(0, INF, 2);

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -890,9 +890,9 @@ final class Collection implements CollectionInterface
         return (new Truthy())()($this)->current();
     }
 
-    public static function unfold(callable $callback, ...$parameters): CollectionInterface
+    public static function unfold(callable $callback, array $parameters = []): CollectionInterface
     {
-        return new self((new Unfold())()(...$parameters)($callback));
+        return new self((new Unfold())()($parameters)($callback));
     }
 
     public function unlines(): string

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -238,6 +238,7 @@ use Traversable;
  * @template-extends TakeWhileable<TKey, T>
  * @template-extends Transposeable<TKey, T>
  * @template-extends Truthyable<TKey, T>
+ * @template-extends Unfoldable<TKey, T>
  * @template-extends Unlinesable<TKey, T>
  * @template-extends Unpackable<mixed, array{0: TKey, 1: T}>
  * @template-extends Unpairable<TKey, T>

--- a/src/Contract/Operation/Unfoldable.php
+++ b/src/Contract/Operation/Unfoldable.php
@@ -6,6 +6,10 @@ namespace loophp\collection\Contract\Operation;
 
 use loophp\collection\Contract\Collection;
 
+/**
+ * @template TKey
+ * @template T
+ */
 interface Unfoldable
 {
     /**
@@ -13,12 +17,12 @@ interface Unfoldable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#unfold
      *
-     * @template T
+     * @template U of T
      *
-     * @param callable(T ...): list<T> $callback
-     * @param T ...$parameters
+     * @param callable(U ...): list<U> $callback
+     * @param array<int, U> $parameters
      *
-     * @return Collection<int, list<T>>
+     * @return Collection<int, list<U>>
      */
-    public static function unfold(callable $callback, ...$parameters): Collection;
+    public static function unfold(callable $callback, array $parameters = []): Collection;
 }

--- a/src/Operation/Unfold.php
+++ b/src/Operation/Unfold.php
@@ -16,17 +16,17 @@ use Generator;
 final class Unfold extends AbstractOperation
 {
     /**
-     * @return Closure(T...): Closure(callable(T...): list<T>): Closure(): Generator<int, list<T>>
+     * @return Closure(array<int, T>): Closure(callable(T...): list<T>): Closure(): Generator<int, list<T>>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param T ...$parameters
+             * @param array<int, T> $parameters
              *
              * @return Closure(callable(T...): list<T>): Closure(): Generator<int, list<T>>
              */
-            static fn (...$parameters): Closure =>
+            static fn ($parameters): Closure =>
                 /**
                  * @param callable(T...): list<T> $callback
                  *

--- a/tests/static-analysis/unfold.php
+++ b/tests/static-analysis/unfold.php
@@ -24,17 +24,18 @@ $plusTwo = static fn (int $n = 0): array => [$n + 2];
 $fib = static fn (int $a = 0, int $b = 1): array => [$b, $a + $b];
 
 unfold_checkList(Collection::unfold($plusTwo)->unwrap());
-unfold_checkList(Collection::unfold($plusTwo, -2)->unwrap());
+unfold_checkList(Collection::unfold($plusTwo, [-2])->unwrap());
 
 // VALID use cases -> PHPStan thinks the collection is of type Collection<int, array<int, mixed>>, but Psalm works
 
-/** @phpstan-ignore-next-line */
-unfold_checkListOfLists(Collection::unfold($plusTwo));
-/** @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
 unfold_checkListOfLists(Collection::unfold($plusTwo, -2));
-/** @phpstan-ignore-next-line */
-unfold_checkListOfLists(Collection::unfold($fib));
-/** @phpstan-ignore-next-line */
+/**
+ * @psalm-suppress InvalidArgument
+ * @psalm-suppress TooManyArguments
+ *
+ * @phpstan-ignore-next-line
+ */
 unfold_checkListOfLists(Collection::unfold($fib, 0, 1));
 
 // VALID use case -> `Pluck` can return various things so analysers cannot know the type is correct

--- a/tests/unit/CollectionConstructorsTest.php
+++ b/tests/unit/CollectionConstructorsTest.php
@@ -307,7 +307,7 @@ final class CollectionConstructorsTest extends TestCase
     {
         $this::assertIdenticalIterable(
             [[0], [2], [4], [6], [8]],
-            Collection::unfold(static fn (int $n): array => [$n + 2], -2)->limit(5)
+            Collection::unfold(static fn (int $n): array => [$n + 2], [-2])->limit(5)
         );
     }
 }


### PR DESCRIPTION
This PR:

- [ ] Fix ...
- [ ] Provide ...
- [ ] It breaks backward compatibility
- [ ] Is covered by unit tests
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
