### PR TITLE
add `AbstractCollection` abstract class

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -14,11 +14,8 @@ branches:
                   - "Code Style (ubuntu-latest, 8.1)"
                   - "Mutation Testing (ubuntu-latest, 8.1)"
                   - "Static Analysis (ubuntu-latest, 8.1)"
-                  - "Unit Tests (ubuntu-latest, 7.4)"
                   - "Unit Tests (ubuntu-latest, 8.1)"
-                  - "Unit Tests (macOS-latest, 7.4)"
                   - "Unit Tests (macOS-latest, 8.1)"
-                  - "Unit Tests (windows-latest, 7.4)"
                   - "Unit Tests (windows-latest, 8.1)"
                   - "prettier"
           restrictions: null

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     ],
     "require": {
-        "php": ">= 7.4",
+        "php": ">= 8",
         "loophp/iterators": "^2"
     },
     "require-dev": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,6 +131,16 @@ parameters:
 			path: src/Collection.php
 
 		-
+			message: "#^PHPDoc tag @return with type loophp\\\\collection\\\\CollectionDecorator\\<UKey, U\\> is incompatible with native type static\\(loophp\\\\collection\\\\CollectionDecorator\\<TKey, T\\>\\)\\.$#"
+			count: 2
+			path: src/CollectionDecorator.php
+
+		-
+			message: "#^PHPDoc tag @return with type loophp\\\\collection\\\\CollectionDecorator\\<int, string\\> is incompatible with native type static\\(loophp\\\\collection\\\\CollectionDecorator\\<TKey, T\\>\\)\\.$#"
+			count: 1
+			path: src/CollectionDecorator.php
+
+		-
 			message: "#^Template type NewT of method loophp\\\\collection\\\\Operation\\\\Associate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/Associate.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -11,6 +11,24 @@
       <code>CollectionInterface</code>
     </InvalidReturnType>
   </file>
+  <file src="src/CollectionDecorator.php">
+    <InvalidArgument occurrences="4">
+      <code>foldLeft1</code>
+      <code>foldRight1</code>
+      <code>scanLeft1</code>
+      <code>scanRight1</code>
+    </InvalidArgument>
+    <InvalidReturnType occurrences="8">
+      <code>array</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+      <code>static</code>
+    </InvalidReturnType>
+  </file>
   <file src="src/Operation/All.php">
     <InvalidReturnStatement occurrences="1"/>
     <InvalidReturnType occurrences="1">

--- a/src/CollectionDecorator.php
+++ b/src/CollectionDecorator.php
@@ -1,0 +1,716 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection;
+
+use Closure;
+use Doctrine\Common\Collections\Criteria;
+use Generator;
+use loophp\collection\Contract\Collection as CollectionInterface;
+use loophp\collection\Contract\Operation;
+use Psr\Cache\CacheItemPoolInterface;
+use Traversable;
+
+use const INF;
+use const PHP_INT_MAX;
+
+/**
+ * @template TKey
+ * @template T
+ *
+ * @immutable
+ *
+ * @psalm-consistent-constructor
+ *
+ * @psalm-consistent-templates
+ *
+ * @implements \loophp\collection\Contract\Collection<TKey, T>
+ */
+abstract class CollectionDecorator implements CollectionInterface
+{
+    /**
+     * @var CollectionInterface<TKey, T>
+     */
+    protected CollectionInterface $innerCollection;
+
+    /**
+     * @param CollectionInterface<TKey, T> $collection
+     */
+    public function __construct(CollectionInterface $collection)
+    {
+        $this->innerCollection = $collection;
+    }
+
+    public function all(bool $normalize = true): array
+    {
+        return $this->innerCollection->all($normalize);
+    }
+
+    public function append(...$items): static
+    {
+        return new static($this->innerCollection->append(...$items));
+    }
+
+    public function apply(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->apply(...$callbacks));
+    }
+
+    public function associate(
+        ?callable $callbackForKeys = null,
+        ?callable $callbackForValues = null
+    ): static {
+        return new static($this->innerCollection->associate($callbackForKeys, $callbackForValues));
+    }
+
+    public function asyncMap(callable $callback): static
+    {
+        return new static($this->innerCollection->asyncMap($callback));
+    }
+
+    public function asyncMapN(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->asyncMapN(...$callbacks));
+    }
+
+    public function averages(): static
+    {
+        return new static($this->innerCollection->averages());
+    }
+
+    public function cache(?CacheItemPoolInterface $cache = null): static
+    {
+        return new static($this->innerCollection->cache($cache));
+    }
+
+    public function chunk(int ...$sizes): static
+    {
+        return new static($this->innerCollection->chunk(...$sizes));
+    }
+
+    public function coalesce(): static
+    {
+        return new static($this->innerCollection->coalesce());
+    }
+
+    public function collapse(): static
+    {
+        return new static($this->innerCollection->collapse());
+    }
+
+    public function column($column): static
+    {
+        return new static($this->innerCollection->column($column));
+    }
+
+    public function combinate(?int $length = null): static
+    {
+        return new static($this->innerCollection->combinate($length));
+    }
+
+    public function combine(...$keys): static
+    {
+        return new static($this->innerCollection->combine(...$keys));
+    }
+
+    public function compact(...$values): static
+    {
+        return new static($this->innerCollection->compact(...$values));
+    }
+
+    public function compare(callable $comparator, $default = null): mixed
+    {
+        return $this->innerCollection->compare($comparator, $default);
+    }
+
+    public function contains(...$values): bool
+    {
+        return $this->innerCollection->contains(...$values);
+    }
+
+    public function current(int $index = 0, $default = null): mixed
+    {
+        return $this->innerCollection->current($index, $default);
+    }
+
+    public function cycle(): static
+    {
+        return new static($this->innerCollection->cycle());
+    }
+
+    public function diff(...$values): static
+    {
+        return new static($this->innerCollection->diff(...$values));
+    }
+
+    public function diffKeys(...$keys): static
+    {
+        return new static($this->innerCollection->diffKeys(...$keys));
+    }
+
+    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): static
+    {
+        return new static($this->innerCollection->distinct($comparatorCallback, $accessorCallback));
+    }
+
+    public function drop(int $count): static
+    {
+        return new static($this->innerCollection->drop($count));
+    }
+
+    public function dropWhile(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->dropWhile(...$callbacks));
+    }
+
+    public function dump(string $name = '', int $size = 1, ?Closure $closure = null): static
+    {
+        return new static($this->innerCollection->dump($name, $size, $closure));
+    }
+
+    public function duplicate(?callable $comparatorCallback = null, ?callable $accessorCallback = null): static
+    {
+        return new static($this->innerCollection->duplicate($comparatorCallback, $accessorCallback));
+    }
+
+    public static function empty(): static
+    {
+        return new static(Collection::empty());
+    }
+
+    public function equals(iterable $other): bool
+    {
+        return $this->innerCollection->equals($other);
+    }
+
+    public function every(callable ...$callbacks): bool
+    {
+        return $this->innerCollection->every(...$callbacks);
+    }
+
+    public function explode(...$explodes): static
+    {
+        return new static($this->innerCollection->explode(...$explodes));
+    }
+
+    public function falsy(): bool
+    {
+        return $this->innerCollection->falsy();
+    }
+
+    public function filter(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->filter(...$callbacks));
+    }
+
+    public function find($default = null, callable ...$callbacks): mixed
+    {
+        return $this->innerCollection->find($default, ...$callbacks);
+    }
+
+    public function first($default = null): mixed
+    {
+        return $this->innerCollection->first($default);
+    }
+
+    public function flatMap(callable $callback): static
+    {
+        return new static($this->innerCollection->flatMap($callback));
+    }
+
+    public function flatten(int $depth = PHP_INT_MAX): static
+    {
+        return new static($this->innerCollection->flatten($depth));
+    }
+
+    public function flip(): static
+    {
+        return new static($this->innerCollection->flip());
+    }
+
+    public function foldLeft(callable $callback, $initial): mixed
+    {
+        return $this->innerCollection->foldLeft($callback, $initial);
+    }
+
+    public function foldLeft1(callable $callback): mixed
+    {
+        return $this->innerCollection->foldLeft1($callback);
+    }
+
+    public function foldRight(callable $callback, $initial): mixed
+    {
+        return $this->innerCollection->foldRight($callback, $initial);
+    }
+
+    public function foldRight1(callable $callback): mixed
+    {
+        return $this->innerCollection->foldRight1($callback);
+    }
+
+    public function forget(...$keys): static
+    {
+        return new static($this->innerCollection->forget(...$keys));
+    }
+
+    public function frequency(): static
+    {
+        return new static($this->innerCollection->frequency());
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param callable(mixed ...$parameters): iterable<UKey, U> $callable
+     * @param iterable<int, mixed> $parameters
+     *
+     * @return static<UKey, U>
+     */
+    public static function fromCallable(callable $callable, iterable $parameters = []): static
+    {
+        return new static(Collection::fromCallable($callable, $parameters));
+    }
+
+    public static function fromFile(string $filepath): static
+    {
+        return new static(Collection::fromFile($filepath));
+    }
+
+    public static function fromGenerator(Generator $generator): static
+    {
+        return new static(Collection::fromGenerator($generator));
+    }
+
+    /**
+     * @template UKey
+     * @template U
+     *
+     * @param iterable<UKey, U> $iterable
+     *
+     * @return static<UKey, U>
+     */
+    public static function fromIterable(iterable $iterable): static
+    {
+        return new static(Collection::fromIterable($iterable));
+    }
+
+    /**
+     * @param resource $resource
+     *
+     * @return static<int, string>
+     */
+    public static function fromResource($resource): static
+    {
+        return new static(Collection::fromResource($resource));
+    }
+
+    public static function fromString(string $string, string $delimiter = ''): static
+    {
+        return new static(Collection::fromString($string, $delimiter));
+    }
+
+    public function get($key, $default = null): mixed
+    {
+        return $this->innerCollection->get($key, $default);
+    }
+
+    /**
+     * @return Traversable<TKey, T>
+     */
+    public function getIterator(): Traversable
+    {
+        yield from $this->innerCollection->getIterator();
+    }
+
+    public function group(): static
+    {
+        return new static($this->innerCollection->group());
+    }
+
+    public function groupBy(callable $callable): static
+    {
+        return new static($this->innerCollection->groupBy($callable));
+    }
+
+    public function has(callable ...$callbacks): bool
+    {
+        return $this->innerCollection->has(...$callbacks);
+    }
+
+    public function head($default = null): mixed
+    {
+        return $this->innerCollection->head($default);
+    }
+
+    public function ifThenElse(callable $condition, callable $then, ?callable $else = null): static
+    {
+        return new static($this->innerCollection->ifThenElse($condition, $then, $else));
+    }
+
+    public function implode(string $glue = ''): string
+    {
+        return $this->innerCollection->implode($glue);
+    }
+
+    public function init(): static
+    {
+        return new static($this->innerCollection->init());
+    }
+
+    public function inits(): static
+    {
+        return new static($this->innerCollection->inits());
+    }
+
+    public function intersect(...$values): static
+    {
+        return new static($this->innerCollection->intersect(...$values));
+    }
+
+    public function intersectKeys(...$keys): static
+    {
+        return new static($this->innerCollection->intersectKeys(...$keys));
+    }
+
+    public function intersperse($element, int $every = 1, int $startAt = 0): static
+    {
+        return new static($this->innerCollection->intersperse($element, $every, $startAt));
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->innerCollection->isEmpty();
+    }
+
+    public function key(int $index = 0): mixed
+    {
+        return $this->innerCollection->key($index);
+    }
+
+    public function keys(): static
+    {
+        return new static($this->innerCollection->keys());
+    }
+
+    public function last($default = null): mixed
+    {
+        return $this->innerCollection->last($default);
+    }
+
+    public function limit(int $count = -1, int $offset = 0): static
+    {
+        return new static($this->innerCollection->limit($count, $offset));
+    }
+
+    public function lines(): static
+    {
+        return new static($this->innerCollection->lines());
+    }
+
+    public function map(callable $callback): static
+    {
+        return new static($this->innerCollection->map($callback));
+    }
+
+    public function mapN(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->mapN(...$callbacks));
+    }
+
+    public function match(callable $callback, ?callable $matcher = null): bool
+    {
+        return $this->innerCollection->match($callback, $matcher);
+    }
+
+    public function matching(Criteria $criteria): static
+    {
+        return new static($this->innerCollection->matching($criteria));
+    }
+
+    public function max($default = null): mixed
+    {
+        return $this->innerCollection->max($default);
+    }
+
+    public function merge(iterable ...$sources): static
+    {
+        return new static($this->innerCollection->merge(...$sources));
+    }
+
+    public function min($default = null): mixed
+    {
+        return $this->innerCollection->min($default);
+    }
+
+    public function normalize(): static
+    {
+        return new static($this->innerCollection->normalize());
+    }
+
+    public function nth(int $step, int $offset = 0): static
+    {
+        return new static($this->innerCollection->nth($step, $offset));
+    }
+
+    public function nullsy(): bool
+    {
+        return $this->innerCollection->nullsy();
+    }
+
+    public function pack(): static
+    {
+        return new static($this->innerCollection->pack());
+    }
+
+    public function pad(int $size, $value): static
+    {
+        return new static($this->innerCollection->pad($size, $value));
+    }
+
+    public function pair(): static
+    {
+        return new static($this->innerCollection->pair());
+    }
+
+    public function partition(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->partition(...$callbacks));
+    }
+
+    public function permutate(): static
+    {
+        return new static($this->innerCollection->permutate());
+    }
+
+    public function pipe(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->pipe(...$callbacks));
+    }
+
+    public function pluck($pluck, $default = null): static
+    {
+        return new static($this->innerCollection->pluck($pluck, $default));
+    }
+
+    public function prepend(...$items): static
+    {
+        return new static($this->innerCollection->prepend(...$items));
+    }
+
+    public function product(iterable ...$iterables): static
+    {
+        return new static($this->innerCollection->product(...$iterables));
+    }
+
+    public function random(int $size = 1, ?int $seed = null): static
+    {
+        return new static($this->innerCollection->random($size, $seed));
+    }
+
+    public static function range(float $start = 0.0, float $end = INF, float $step = 1.0): CollectionInterface
+    {
+        return new static(Collection::range($start, $end, $step));
+    }
+
+    public function reduce(callable $callback, $initial = null): mixed
+    {
+        return $this->innerCollection->reduce($callback, $initial);
+    }
+
+    public function reduction(callable $callback, $initial = null): static
+    {
+        return new static($this->innerCollection->reduction($callback, $initial));
+    }
+
+    public function reject(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->reject(...$callbacks));
+    }
+
+    public function reverse(): static
+    {
+        return new static($this->innerCollection->reverse());
+    }
+
+    public function rsample(float $probability): static
+    {
+        return new static($this->innerCollection->rsample($probability));
+    }
+
+    public function same(iterable $other, ?callable $comparatorCallback = null): bool
+    {
+        return $this->innerCollection->same($other, $comparatorCallback);
+    }
+
+    public function scale(
+        float $lowerBound,
+        float $upperBound,
+        float $wantedLowerBound = 0.0,
+        float $wantedUpperBound = 1.0,
+        float $base = 0.0
+    ): static {
+        return new static($this->innerCollection->scale($lowerBound, $upperBound, $wantedLowerBound, $wantedUpperBound));
+    }
+
+    public function scanLeft(callable $callback, $initial): static
+    {
+        return new static($this->innerCollection->scanLeft($callback, $initial));
+    }
+
+    public function scanLeft1(callable $callback): static
+    {
+        return new static($this->innerCollection->scanLeft1($callback));
+    }
+
+    public function scanRight(callable $callback, $initial): static
+    {
+        return new static($this->innerCollection->scanRight($callback, $initial));
+    }
+
+    public function scanRight1(callable $callback): static
+    {
+        return new static($this->innerCollection->scanRight1($callback));
+    }
+
+    public function shuffle(?int $seed = null): static
+    {
+        return new static($this->innerCollection->shuffle($seed));
+    }
+
+    public function since(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->since(...$callbacks));
+    }
+
+    public function slice(int $offset, int $length = -1): static
+    {
+        return new static($this->innerCollection->slice($offset, $length));
+    }
+
+    public function sort(int $type = Operation\Sortable::BY_VALUES, ?callable $callback = null): static
+    {
+        return new static($this->innerCollection->sort($type, $callback));
+    }
+
+    public function span(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->span(...$callbacks));
+    }
+
+    public function split(int $type = Operation\Splitable::BEFORE, callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->split($type, ...$callbacks));
+    }
+
+    public function squash(): static
+    {
+        return new static($this->innerCollection->squash());
+    }
+
+    public function strict(?callable $callback = null): static
+    {
+        return new static($this->innerCollection->strict($callback));
+    }
+
+    public function tail(): static
+    {
+        return new static($this->innerCollection->tail());
+    }
+
+    public function tails(): static
+    {
+        return new static($this->innerCollection->tails());
+    }
+
+    public function takeWhile(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->takeWhile(...$callbacks));
+    }
+
+    public static function times(int $number = 0, ?callable $callback = null): static
+    {
+        return new static(Collection::times($number, $callback));
+    }
+
+    public function transpose(): static
+    {
+        return new static($this->innerCollection->transpose());
+    }
+
+    public function truthy(): bool
+    {
+        return $this->innerCollection->truthy();
+    }
+
+    public static function unfold(callable $callback, array $parameters = []): static
+    {
+        return new static(Collection::unfold($callback, $parameters));
+    }
+
+    public function unlines(): string
+    {
+        return $this->innerCollection->unlines();
+    }
+
+    public function unpack(): static
+    {
+        return new static($this->innerCollection->unpack());
+    }
+
+    public function unpair(): static
+    {
+        return new static($this->innerCollection->unpair());
+    }
+
+    public function until(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->until(...$callbacks));
+    }
+
+    public function unwindow(): static
+    {
+        return new static($this->innerCollection->unwindow());
+    }
+
+    public function unwords(): string
+    {
+        return $this->innerCollection->unwords();
+    }
+
+    public function unwrap(): static
+    {
+        return new static($this->innerCollection->unwrap());
+    }
+
+    public function unzip(): static
+    {
+        return new static($this->innerCollection->unzip());
+    }
+
+    public function when(callable $predicate, callable $whenTrue, ?callable $whenFalse = null): static
+    {
+        return new static($this->innerCollection->when($predicate, $whenTrue, $whenFalse));
+    }
+
+    public function window(int $size): static
+    {
+        return new static($this->innerCollection->window($size));
+    }
+
+    public function words(): static
+    {
+        return new static($this->innerCollection->words());
+    }
+
+    public function wrap(): static
+    {
+        return new static($this->innerCollection->wrap());
+    }
+
+    public function zip(iterable ...$iterables): static
+    {
+        return new static($this->innerCollection->zip(...$iterables));
+    }
+}

--- a/tests/unit/CustomCollection.php
+++ b/tests/unit/CustomCollection.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\loophp\collection;
+
+use loophp\collection\CollectionDecorator;
+
+final class CustomCollection extends CollectionDecorator
+{
+}

--- a/tests/unit/CustomCollectionConstructorsTest.php
+++ b/tests/unit/CustomCollectionConstructorsTest.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\loophp\collection;
+
+use Generator;
+use InvalidArgumentException;
+use loophp\PhpUnitIterableAssertions\Traits\IterableAssertions;
+use PHPUnit\Framework\TestCase;
+use tests\loophp\collection\CustomCollection as Collection;
+
+use const INF;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \loophp\collection
+ */
+final class CustomCollectionConstructorsTest extends TestCase
+{
+    use IterableAssertions;
+
+    public function testFromCallableConstructor(): void
+    {
+        $fibonacci = static function ($start, $inc) {
+            yield $start;
+
+            while (true) {
+                $inc = $start + $inc;
+                $start = $inc - $start;
+
+                yield $start;
+            }
+        };
+
+        self::assertIdenticalIterable(
+            [0, 1, 1, 2, 3, 5, 8, 13, 21, 34],
+            Collection::fromCallable($fibonacci, [0, 1])->limit(10)
+        );
+
+        $test1 = Collection::fromCallable(static fn (int $a, int $b): Generator => yield from range($a, $b), [1, 5]);
+        self::assertInstanceOf(Collection::class, $test1);
+        self::assertIdenticalIterable(
+            range(1, 5),
+            $test1
+        );
+
+        $test2 = Collection::fromCallable(static fn (int $a, int $b): array => range($a, $b), [1, 5]);
+        self::assertInstanceOf(Collection::class, $test2);
+        self::assertIdenticalIterable(
+            range(1, 5),
+            $test2
+        );
+
+        $classWithMethod = new class() {
+            public function getValues(): Generator
+            {
+                yield from range(1, 5);
+            }
+        };
+        $test4 = Collection::fromCallable([$classWithMethod, 'getValues']);
+        self::assertInstanceOf(Collection::class, $test4);
+        self::assertIdenticalIterable(
+            range(1, 5),
+            $test4
+        );
+
+        $classWithStaticMethod = new class() {
+            public static function getValues(): Generator
+            {
+                yield from range(1, 5);
+            }
+        };
+        $test5 = Collection::fromCallable([$classWithStaticMethod, 'getValues']);
+        self::assertInstanceOf(Collection::class, $test5);
+        self::assertIdenticalIterable(
+            range(1, 5),
+            $test5
+        );
+
+        $invokableClass = new class() {
+            public function __invoke(): Generator
+            {
+                yield from range(1, 5);
+            }
+        };
+        $test6 = Collection::fromCallable($invokableClass);
+        self::assertInstanceOf(Collection::class, $test6);
+        self::assertIdenticalIterable(
+            range(1, 5),
+            $test6
+        );
+    }
+
+    public function testFromEmptyConstructor(): void
+    {
+        self::assertIdenticalIterable(
+            [],
+            Collection::empty()
+        );
+    }
+
+    public function testFromFileConstructor()
+    {
+        self::assertIdenticalIterable(
+            ['a', 'b', 'c'],
+            Collection::fromFile(__DIR__ . '/../fixtures/sample.txt')
+        );
+    }
+
+    public function testFromGeneratorConstructor()
+    {
+        $generator = static function () {
+            yield 'a';
+
+            yield 'b';
+
+            yield 'c';
+
+            yield 'd';
+
+            yield 'e';
+        };
+
+        self::assertIdenticalIterable(
+            range('a', 'e'),
+            Collection::fromGenerator($generator())
+        );
+
+        $generator = (static function () {
+            yield 'a';
+
+            yield 'b';
+
+            yield 'c';
+
+            yield 'd';
+
+            yield 'e';
+        })();
+
+        $generator->next();
+        $generator->next();
+
+        self::assertIdenticalIterable(
+            [2 => 'c', 3 => 'd', 4 => 'e'],
+            Collection::fromGenerator($generator)
+        );
+    }
+
+    public function testFromIterableConstructor(): void
+    {
+        self::assertIdenticalIterable(
+            ['A', 'B', 'C'],
+            Collection::fromIterable(range('A', 'C'))
+        );
+
+        $generator = (static function () {
+            yield 'a';
+
+            yield 'b';
+
+            yield 'c';
+
+            yield 'd';
+
+            yield 'e';
+        })();
+
+        $generator->next();
+        $generator->next();
+
+        self::assertIdenticalIterable(
+            [2 => 'c', 3 => 'd', 4 => 'e'],
+            Collection::fromIterable($generator)
+        );
+    }
+
+    public function testFromResourceConstructor()
+    {
+        $string = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.';
+
+        $stream = fopen('data://text/plain,' . $string, 'rb');
+
+        self::assertCount(
+            56,
+            Collection::fromResource($stream)
+        );
+
+        $stream = fopen('data://text/plain,' . $string, 'rb');
+
+        self::assertIdenticalIterable(
+            str_split($string),
+            Collection::fromResource($stream)
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+
+        $stream = imagecreate(100, 100);
+
+        Collection::fromResource($stream)->all();
+    }
+
+    public function testFromStringConstructor(): void
+    {
+        self::assertIdenticalIterable(
+            ['i', 'z', 'u', 'm', 'i'],
+            Collection::fromString('izumi')
+        );
+
+        self::assertIdenticalIterable(
+            [0 => 'hello', 1 => ' world'],
+            Collection::fromString('hello, world', ',')
+        );
+    }
+
+    public function testRangeConstructor(): void
+    {
+        $this::assertIdenticalIterable(
+            [(float) 0, (float) 1, (float) 2, (float) 3, (float) 4],
+            Collection::range(0, 5),
+        );
+
+        $this::assertIdenticalIterable(
+            [(float) 1, (float) 3, (float) 5, (float) 7, (float) 9],
+            Collection::range(1, 10, 2),
+        );
+
+        $this::assertIdenticalIterable(
+            [0 => (float) -5, 1 => (float) -3, 2 => (float) -1, 3 => (float) 1, 4 => (float) 3],
+            Collection::range(-5, 5, 2),
+        );
+
+        $this::assertIdenticalIterable(
+            [0 => (float) 0, 1 => (float) 1, 2 => (float) 2, 3 => (float) 3, 4 => (float) 4, 5 => (float) 5, 6 => (float) 6, 7 => (float) 7, 8 => (float) 8, 9 => (float) 9],
+            Collection::range()->limit(10)
+        );
+
+        $this::assertIdenticalIterable(
+            array_pad([], 10, (float) 0),
+            Collection::range(0, INF, 0)->limit(10)
+        );
+
+        $this::assertIdenticalIterable(
+            [(float) 1, (float) 2, (float) 3, (float) 4],
+            Collection::range(1, 5)
+        );
+
+        $this::assertIdenticalIterable(
+            array_pad([], 5, (float) 1),
+            Collection::range(1, 5, 0)->limit(5)
+        );
+
+        $this::assertIdenticalIterable(
+            [(float) 0],
+            Collection::range(0, 1)
+        );
+
+        $this::assertIdenticalIterable(
+            [(float) 0, (float) 1, (float) 2, (float) 3, (float) 4],
+            Collection::range()->limit(5)
+        );
+    }
+
+    public function testTimesConstructor(): void
+    {
+        $a = [[1, 2, 3, 4, 5], [1, 2, 3, 4, 5]];
+
+        $this::assertIdenticalIterable(
+            $a,
+            Collection::times(2, static fn (): array => range(1, 5)),
+        );
+
+        $this::assertIdenticalIterable(
+            [],
+            Collection::times(-1, 'count'),
+        );
+
+        $this::assertIdenticalIterable(
+            range(1, 10),
+            Collection::times(10),
+        );
+
+        $this::assertIdenticalIterable(
+            [],
+            Collection::times(-5),
+        );
+
+        $this::assertIdenticalIterable(
+            [1],
+            Collection::times(1),
+        );
+
+        $this::assertIdenticalIterable(
+            [],
+            Collection::times(0),
+        );
+
+        $this::assertIdenticalIterable(
+            [],
+            Collection::times(),
+        );
+    }
+
+    public function testUnfoldConstructor(): void
+    {
+        $this::assertIdenticalIterable(
+            [[0], [2], [4], [6], [8]],
+            Collection::unfold(static fn (int $n): array => [$n + 2], [-2])->limit(5)
+        );
+    }
+}

--- a/tests/unit/CustomCollectionGenericOperationTest.php
+++ b/tests/unit/CustomCollectionGenericOperationTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\loophp\collection;
+
+use loophp\collection\Collection;
+use loophp\PhpUnitIterableAssertions\Traits\IterableAssertions;
+use PHPUnit\Framework\TestCase;
+use tests\loophp\collection\Traits\GenericCollectionProviders;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \loophp\collection
+ */
+final class CustomCollectionGenericOperationTest extends TestCase
+{
+    use GenericCollectionProviders;
+
+    use IterableAssertions;
+
+    /**
+     * @dataProvider allOperationProvider
+     * @dataProvider appendOperationProvider
+     * @dataProvider applyOperationProvider
+     * @dataProvider associateOperationProvider
+     * @dataProvider asyncMapOperationProvider
+     * @dataProvider asyncMapNOperationProvider
+     * @dataProvider averagesOperationProvider
+     * @dataProvider cacheOperationProvider
+     * @dataProvider chunkOperationProvider
+     * @dataProvider coalesceOperationProvider
+     * @dataProvider collapseOperationProvider
+     * @dataProvider columnOperationProvider
+     * @dataProvider combinateOperationProvider
+     * @dataProvider combineOperationProvider
+     * @dataProvider compactOperationProvider
+     * @dataProvider cycleOperationProvider
+     * @dataProvider diffOperationProvider
+     * @dataProvider diffKeysOperationProvider
+     * @dataProvider distinctOperationProvider
+     * @dataProvider dropOperationProvider
+     * @dataProvider dropWhileOperationProvider
+     * @dataProvider dumpOperationProvider
+     * @dataProvider duplicateOperationProvider
+     * @dataProvider explodeOperationProvider
+     * @dataProvider filterOperationProvider
+     * @dataProvider flatMapOperationProvider
+     * @dataProvider flattenOperationProvider
+     * @dataProvider flipOperationProvider
+     * @dataProvider forgetOperationProvider
+     * @dataProvider frequencyOperationProvider
+     * @dataProvider groupOperationProvider
+     * @dataProvider groupByOperationProvider
+     * @dataProvider ifThenElseOperationProvider
+     * @dataProvider initOperationProvider
+     * @dataProvider initsOperationProvider
+     * @dataProvider intersectOperationProvider
+     * @dataProvider intersectKeysOperationProvider
+     * @dataProvider intersperseOperationProvider
+     * @dataProvider keysOperationProvider
+     * @dataProvider limitOperationProvider
+     * @dataProvider linesOperationProvider
+     * @dataProvider mapOperationProvider
+     * @dataProvider mapNOperationProvider
+     * @dataProvider matchingOperationProvider
+     * @dataProvider mergeOperationProvider
+     * @dataProvider normalizeOperationProvider
+     * @dataProvider nthOperationProvider
+     * @dataProvider packOperationProvider
+     * @dataProvider padOperationProvider
+     * @dataProvider pairOperationProvider
+     * @dataProvider permutateOperationProvider
+     * @dataProvider pipeOperationProvider
+     * @dataProvider pluckOperationProvider
+     * @dataProvider prependOperationProvider
+     * @dataProvider productOperationProvider
+     * @dataProvider reductionOperationProvider
+     * @dataProvider rejectOperationProvider
+     * @dataProvider reverseOperationProvider
+     * @dataProvider scaleOperationProvider
+     * @dataProvider scanLeftOperationProvider
+     * @dataProvider scanLeft1OperationProvider
+     * @dataProvider scanRightOperationProvider
+     * @dataProvider scanRight1OperationProvider
+     * @dataProvider shuffleOperationProvider
+     * @dataProvider sinceOperationProvider
+     * @dataProvider sliceOperationProvider
+     * @dataProvider sortOperationProvider
+     * @dataProvider splitOperationProvider
+     * @dataProvider squashOperationProvider
+     * @dataProvider strictOperationProvider
+     * @dataProvider tailOperationProvider
+     * @dataProvider tailsOperationProvider
+     * @dataProvider takeWhileOperationProvider
+     * @dataProvider transposeOperationProvider
+     * @dataProvider unpackOperationProvider
+     * @dataProvider unpairOperationProvider
+     * @dataProvider untilOperationProvider
+     * @dataProvider unwindowOperationProvider
+     * @dataProvider unwrapOperationProvider
+     * @dataProvider unzipOperationProvider
+     * @dataProvider whenOperationProvider
+     * @dataProvider windowOperationProvider
+     * @dataProvider wordsOperationProvider
+     * @dataProvider wrapOperationProvider
+     * @dataProvider zipOperationProvider
+     */
+    public function testCollectionGeneric(
+        string $operation,
+        array $parameters,
+        iterable $actual,
+        iterable $expected,
+        int $limit = 0
+    ): void {
+        $actual = (new CustomCollection(Collection::fromIterable($actual)))
+            ->{$operation}(...$parameters);
+
+        if (0 !== $limit) {
+            $actual = $actual->limit($limit);
+        }
+
+        $this::assertIdenticalIterable(
+            $expected,
+            $actual
+        );
+    }
+
+    /**
+     * @dataProvider compareOperationProvider
+     * @dataProvider containsOperationProvider
+     * @dataProvider currentOperationProvider
+     * @dataProvider equalsOperationProvider
+     * @dataProvider everyOperationProvider
+     * @dataProvider falsyOperationProvider
+     * @dataProvider findOperationProvider
+     * @dataProvider firstOperationProvider
+     * @dataProvider foldLeftOperationProvider
+     * @dataProvider foldLeft1OperationProvider
+     * @dataProvider foldRightOperationProvider
+     * @dataProvider foldRight1OperationProvider
+     * @dataProvider getOperationProvider
+     * @dataProvider hasOperationProvider
+     * @dataProvider headOperationProvider
+     * @dataProvider implodeOperationProvider
+     * @dataProvider isEmptyOperationProvider
+     * @dataProvider keyOperationProvider
+     * @dataProvider lastOperationProvider
+     * @dataProvider matchOperationProvider
+     * @dataProvider maxOperationProvider
+     * @dataProvider minOperationProvider
+     * @dataProvider nullsyOperationProvider
+     * @dataProvider reduceOperationProvider
+     * @dataProvider sameOperationProvider
+     * @dataProvider truthyOperationProvider
+     * @dataProvider unlinesOperationProvider
+     * @dataProvider unwordsOperationProvider
+     *
+     * @param mixed $expected
+     */
+    public function testGenericScalar(
+        string $operation,
+        array $parameters,
+        iterable $actual,
+        $expected
+    ): void {
+        self::assertSame(
+            $expected,
+            (new CustomCollection(Collection::fromIterable($actual)))->{$operation}(...$parameters)
+        );
+    }
+}

--- a/tests/unit/CustomCollectionSpecificOperationTest.php
+++ b/tests/unit/CustomCollectionSpecificOperationTest.php
@@ -1,0 +1,547 @@
+<?php
+
+declare(strict_types=1);
+
+namespace tests\loophp\collection;
+
+use Closure;
+use Exception;
+use Generator;
+use InvalidArgumentException;
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+use loophp\collection\Operation\Coalesce;
+use loophp\collection\Operation\Current;
+use loophp\collection\Operation\Limit;
+use loophp\PhpUnitIterableAssertions\Traits\IterableAssertions;
+use OutOfBoundsException;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use tests\loophp\collection\Traits\GenericCollectionProviders;
+
+use function gettype;
+
+use const PHP_VERSION_ID;
+
+/**
+ * @internal
+ *
+ * @coversDefaultClass \loophp\collection
+ */
+final class CustomCollectionSpecificOperationTest extends TestCase
+{
+    use GenericCollectionProviders;
+
+    use IterableAssertions;
+
+    public function testApplyOperation(): void
+    {
+        $input = range('a', 'e');
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->apply(
+                    static function ($item) use (&$stack): bool {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+
+                        return true;
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1'],
+            'b' => ['fn1'],
+            'c' => ['fn1'],
+            'd' => ['fn1'],
+            'e' => ['fn1'],
+        ];
+
+        self::assertSame($expected, $stack);
+
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->apply(
+                    static function ($item) use (&$stack): bool {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+
+                        return false;
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1'],
+        ];
+
+        self::assertSame($expected, $stack);
+
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->apply(
+                    static function ($item) use (&$stack): bool {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+
+                        return true;
+                    },
+                    static function ($item) use (&$stack): bool {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn2';
+
+                        return true;
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1', 'fn2'],
+            'b' => ['fn1', 'fn2'],
+            'c' => ['fn1', 'fn2'],
+            'd' => ['fn1', 'fn2'],
+            'e' => ['fn1', 'fn2'],
+        ];
+
+        self::assertSame($expected, $stack);
+
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->apply(
+                    static function ($item) use (&$stack): bool {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+
+                        if ('c' === $item) {
+                            return false;
+                        }
+
+                        return true;
+                    },
+                    static function ($item) use (&$stack): bool {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn2';
+
+                        if ('b' === $item) {
+                            return false;
+                        }
+
+                        return true;
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1', 'fn2'],
+            'b' => ['fn1', 'fn2'],
+            'c' => ['fn1'],
+        ];
+
+        self::assertSame($expected, $stack);
+    }
+
+    public function testCoalesceOperation(): void
+    {
+        $input = range('a', 'e');
+
+        $coalesce = new Coalesce();
+
+        self::assertCount(1, $coalesce->__invoke()($input));
+
+        self::assertIdenticalIterable(
+            [
+                0 => 'a',
+            ],
+            $coalesce->__invoke()($input)
+        );
+
+        $input = ['', null, 'foo', false, ...range('a', 'e')];
+
+        self::assertCount(1, $coalesce->__invoke()($input));
+
+        self::assertIdenticalIterable(
+            [
+                2 => 'foo',
+            ],
+            $coalesce->__invoke()($input)
+        );
+    }
+
+    public function testCurrentOperation(): void
+    {
+        $input = range('a', 'e');
+
+        $current = new Current();
+
+        self::assertIdenticalIterable(
+            ['a'],
+            $current->__invoke()(0)(null)($input)
+        );
+
+        self::assertCount(1, $current->__invoke()(0)(null)($input));
+
+        self::assertIdenticalIterable(
+            ['unavailable'],
+            $current->__invoke()(10)('unavailable')($input)
+        );
+    }
+
+    public function testCycleOperation(): void
+    {
+        $generator = static function (): Generator {
+            yield 0 => 1;
+
+            yield 1 => 2;
+
+            yield 2 => 3;
+
+            yield 0 => 1;
+
+            yield 1 => 2;
+
+            yield 2 => 3;
+
+            yield 0 => 1;
+        };
+
+        $this::assertIdenticalIterable(
+            $generator(),
+            Collection::fromIterable(range(1, 3))->cycle()->limit(7),
+        );
+    }
+
+    public function testDumpOperation(): void
+    {
+        $count = 0;
+        $input = range('a', 'e');
+
+        $callback = static function (string $name, $key, $value) use (&$count) {
+            ++$count;
+        };
+
+        $test1 = (new CustomCollection(Collection::fromIterable($input)))
+            ->dump('here', 0, $callback);
+
+        self::assertIdenticalIterable(
+            $input,
+            $test1
+        );
+
+        self::assertSame(5, $count);
+
+        $count = 0;
+
+        $callback = static function (string $name, $key, $value) use (&$count) {
+            ++$count;
+        };
+
+        $test2 = (new CustomCollection(Collection::fromIterable($input)))->dump('here', -1, $callback);
+
+        self::assertIdenticalIterable(
+            $input,
+            $test2
+        );
+
+        self::assertSame(0, $count);
+
+        $callback = static function (string $name, $key, $value) use (&$count) {
+            ++$count;
+        };
+
+        $test3 = (new CustomCollection(Collection::fromIterable($input)))
+            ->dump('here', 2, $callback);
+
+        self::assertIdenticalIterable(
+            $input,
+            $test3
+        );
+
+        self::assertSame(2, $count);
+
+        $expectedOutput = <<<'EOF'
+            array(3) {
+              ["name"]=>
+              string(5) "debug"
+              ["key"]=>
+              int(0)
+              ["value"]=>
+              string(1) "a"
+            }
+            array(3) {
+              ["name"]=>
+              string(5) "debug"
+              ["key"]=>
+              int(1)
+              ["value"]=>
+              string(1) "b"
+            }
+
+            EOF;
+
+        $test4 = (new CustomCollection(Collection::fromIterable($input)))->dump('debug', 2);
+        $this->expectOutputString($expectedOutput);
+        self::assertIdenticalIterable($input, $test4);
+    }
+
+    public function testLimitOperation(): void
+    {
+        $limit = new Limit();
+        $input = range('a', 'e');
+
+        self::assertCount(1, $limit()(1)(0)($input));
+
+        self::assertCount(2, $limit()(2)(0)($input));
+
+        self::assertIdenticalIterable(
+            [2 => 'c'],
+            $limit()(1)(2)($input)
+        );
+
+        self::assertCount(2, $limit()(2)(2)($input));
+
+        self::assertIdenticalIterable(
+            ['a', 'b', 'c', 'd', 'e'],
+            $limit()()()($input)
+        );
+    }
+
+    public function testPartitionOperation(): void
+    {
+        $isGreaterThan = static fn (int $left): Closure => static fn (int $right): bool => $left < $right;
+        $input = array_combine(range('a', 'l'), [1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3]);
+
+        // Using `first` and `last`, single callback
+        $subject = (new CustomCollection(Collection::fromIterable($input)))->partition($isGreaterThan(5));
+        self::assertCount(2, $subject);
+
+        $first = $subject->first();
+        $last = $subject->last();
+
+        self::assertInstanceOf(CollectionInterface::class, $first);
+        self::assertInstanceOf(CollectionInterface::class, $last);
+
+        self::assertCount(4, $first);
+        self::assertCount(8, $last);
+
+        self::assertIdenticalIterable(
+            ['f' => 6, 'g' => 7, 'h' => 8, 'i' => 9],
+            $first
+        );
+        self::assertIdenticalIterable(
+            ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'j' => 1, 'k' => 2, 'l' => 3],
+            $last
+        );
+
+        // Using `all` and array destructuring, single callback
+
+        [$passed, $rejected] = (new CustomCollection(Collection::fromIterable($input)))->partition($isGreaterThan(5))->all();
+        self::assertInstanceOf(CollectionInterface::class, $passed);
+        self::assertInstanceOf(CollectionInterface::class, $rejected);
+
+        self::assertCount(4, $passed);
+        self::assertCount(8, $rejected);
+
+        self::assertIdenticalIterable(
+            ['f' => 6, 'g' => 7, 'h' => 8, 'i' => 9],
+            $passed
+        );
+        self::assertIdenticalIterable(
+            ['a' => 1, 'b' => 2, 'c' => 3, 'd' => 4, 'e' => 5, 'j' => 1, 'k' => 2, 'l' => 3],
+            $rejected
+        );
+
+        // Using multiple callbacks
+        self::assertIdenticalIterable(
+            ['d' => 4, 'e' => 5, 'f' => 6, 'g' => 7, 'h' => 8, 'i' => 9],
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->partition($isGreaterThan(5), $isGreaterThan(3))
+                ->first()
+        );
+
+        self::assertIdenticalIterable(
+            ['a' => 1, 'b' => 2, 'c' => 3, 'j' => 1, 'k' => 2, 'l' => 3],
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->partition($isGreaterThan(5), $isGreaterThan(3))
+                ->last()
+        );
+    }
+
+    public function testRandomOperation(): void
+    {
+        $input = range('a', 'z');
+
+        self::assertCount(
+            1,
+            (new CustomCollection(Collection::fromIterable($input)))->random()
+        );
+
+        self::assertCount(
+            26,
+            (new CustomCollection(Collection::fromIterable($input)))->random(100)
+        );
+
+        // TODO: Implements assertNotIdenticalIterable in PHPunit
+        /*
+        $this::fromIterable($input)
+            ->random(26)
+            ->shouldNotIterateAs($generator($input));
+         */
+
+        self::assertIdenticalIterable(
+            ['a'],
+            Collection::fromIterable(['a'])->random()
+        );
+
+        $this->expectException(OutOfBoundsException::class);
+
+        (new CustomCollection(Collection::fromIterable($input)))->random(0)->all();
+    }
+
+    public function testRsampleOperation(): void
+    {
+        self::assertCount(
+            10,
+            Collection::fromIterable(range(1, 10))->rsample(1)
+        );
+
+        self::assertNotCount(
+            10,
+            Collection::fromIterable(range(1, 10))->rsample(.5)
+        );
+    }
+
+    public function testSortInvalidSortType()
+    {
+        $this->expectException(Exception::class);
+
+        Collection::empty()->sort(10)->all();
+    }
+
+    public function testSpanOperation(): void
+    {
+        $input = range(1, 10);
+
+        $callbacks = [
+            static fn (int $x): bool => 4 > $x,
+        ];
+
+        $subject = (new CustomCollection(Collection::fromIterable($input)))->span(...$callbacks);
+        self::assertCount(2, $subject);
+        self::assertInstanceOf(
+            CollectionInterface::class,
+            $subject->first()
+        );
+        self::assertInstanceOf(
+            CollectionInterface::class,
+            $subject->last()
+        );
+
+        $first = $subject->first();
+        $last = $subject->last();
+
+        self::assertCount(3, $first);
+        self::assertCount(7, $last);
+
+        self::assertIdenticalIterable(
+            [1, 2, 3],
+            $first
+        );
+        self::assertIdenticalIterable(
+            [3 => 4, 4 => 5, 5 => 6, 6 => 7, 7 => 8, 8 => 9, 9 => 10],
+            $last
+        );
+
+        $callbacks = [
+            static fn (int $x): bool => 4 > $x,
+            static fn (int $x): bool => $x % 2 === 0,
+        ];
+        $subject = (new CustomCollection(Collection::fromIterable($input)))->span(...$callbacks);
+        self::assertCount(2, $subject);
+        self::assertInstanceOf(
+            CollectionInterface::class,
+            $subject->first()
+        );
+        self::assertInstanceOf(
+            CollectionInterface::class,
+            $subject->last()
+        );
+        self::assertIdenticalIterable(
+            [1, 2, 3, 4],
+            $subject->first()
+        );
+        self::assertIdenticalIterable(
+            [4 => 5, 5 => 6, 6 => 7, 7 => 8, 8 => 9, 9 => 10],
+            $subject->last()
+        );
+    }
+
+    public function testSquashOperation(): void
+    {
+        if (PHP_VERSION_ID >= 80000) {
+            $this->expectException(Exception::class);
+
+            Collection::fromIterable([16, 4, -9, 9])
+                ->map(
+                    static function (int $value): int {
+                        if (0 > $value) {
+                            throw new Exception('This should error');
+                        }
+
+                        return (int) sqrt($value);
+                    }
+                )
+                ->squash();
+        }
+
+        self::assertIdenticalIterable(
+            [4, 2, 3, 3],
+            Collection::fromIterable([16, 4, 9, 9])
+                ->map(
+                    static function (int $value): int {
+                        if (-100 > $value) {
+                            throw new Exception('This should not error');
+                        }
+
+                        return (int) sqrt($value);
+                    }
+                )
+                ->squash()
+        );
+    }
+
+    public function testStrictOperation(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Collection::fromIterable([1, 'foo', 2])->strict()->all();
+
+        $obj1 = new stdClass();
+        $obj2 = new class() {
+            public function count(): int
+            {
+                return 0;
+            }
+        };
+
+        $collection = Collection::fromIterable([$obj1, $obj2]);
+
+        $callback = static fn ($value): string => gettype($value);
+
+        self::assertIdenticalIterable(
+            [$obj1, $obj2],
+            $collection->strict($callback)->all()
+        );
+    }
+}


### PR DESCRIPTION
This PR has been created while discussing with @AlexandruGG

This is an alternate way to provide an abstract collection class:
- without depending on it
- without altering what's already existing
- without repeating code all over the place.

Minimal Working Example:
```php
class AAA extends AbstractCollection
{
}

$c = AAA::unfold(static fn (int $a = 0, int $b = 1): array => [$b, $a + $b]);
print_r($c->limit(10)->all());
```

This PR:

- [x] Provide an alternate way to have an abstract class in the library
- [ ] Provide ...
- [ ] It breaks backward compatibility
- [ ] Is covered by unit tests
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Related to #268 