### PR TITLE
Add `with` operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -2453,6 +2453,20 @@ Signature: ``Collection::window(int $size): Collection;``
 .. literalinclude:: code/operations/window.php
   :language: php
 
+with
+~~~~
+
+Let users injects a custom operation in the Collection.
+To maintain a lazy nature, each operation needs to return a ``Generator``.
+Custom operations and operations provided in the API can be combined together.
+
+Interface: `Withable`_
+
+Signature: ``Collection::with(Operation $operation, array $arguments = []): Collection;``
+
+.. literalinclude:: code/operations/with.php
+  :language: php
+
 words
 ~~~~~
 
@@ -2624,6 +2638,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Unzipable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Unzipable.php
 .. _Whenable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Whenable.php
 .. _Windowable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Windowable.php
+.. _Withable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Withable.php
 .. _Wordsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Wordsable.php
 .. _Wrapable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Wrapable.php
 .. _Zipable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Zipable.php

--- a/docs/pages/code/operations/with.php
+++ b/docs/pages/code/operations/with.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Closure;
+use Generator;
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+use loophp\collection\Operation\AbstractOperation;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$multiplyBy = new class() extends AbstractOperation {
+    public function __invoke(): Closure
+    {
+        return static function (int $multiplier): Closure {
+            return static function (CollectionInterface $collection) use ($multiplier): Generator {
+                foreach ($collection as $key => $item) {
+                    yield $key => ($item * $multiplier);
+                }
+            };
+        };
+    }
+};
+
+$c = Collection::fromIterable(range(1, 5))
+    ->with($multiplyBy, [3])
+    ->all(); // [3, 6, 9, 12, 15]

--- a/docs/pages/usage.rst
+++ b/docs/pages/usage.rst
@@ -100,8 +100,9 @@ specific feature added on top of it.
 
 If you want to **extend** the Collection, you have multiple options.
 
-1. You just create a ``callable`` and use :ref:`pages/api:pipe` method.
-2. You use the Composition design pattern and create your own library class.
+1. Create your own ``Operation`` classes and use the :ref:`pages/api:pipe` method.
+2. You just create a ``callable`` and use :ref:`pages/api:with` method.
+3. You use the Composition design pattern and create your own library class.
 
 Every classes of this library are ``final`` and then it is impossible to use
 inheritance and use the original Collection class as parent of another one.

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -953,6 +953,11 @@ final class Collection implements CollectionInterface
         return new self((new Window())()($size), [$this]);
     }
 
+    public function with(Operation $operation, array $arguments = []): CollectionInterface
+    {
+        return new self(($operation())(...$arguments), [$this]);
+    }
+
     public function words(): CollectionInterface
     {
         return new self((new Words())(), [$this]);

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -124,6 +124,7 @@ use loophp\collection\Contract\Operation\Unwrapable;
 use loophp\collection\Contract\Operation\Unzipable;
 use loophp\collection\Contract\Operation\Whenable;
 use loophp\collection\Contract\Operation\Windowable;
+use loophp\collection\Contract\Operation\Withable;
 use loophp\collection\Contract\Operation\Wordsable;
 use loophp\collection\Contract\Operation\Wrapable;
 use loophp\collection\Contract\Operation\Zipable;
@@ -249,6 +250,7 @@ use Traversable;
  * @template-extends Unzipable<TKey, T>
  * @template-extends Whenable<TKey, T>
  * @template-extends Windowable<TKey, T>
+ * @template-extends Withable<TKey, T>
  * @template-extends Wordsable<TKey, T>
  * @template-extends Wrapable<TKey, T>
  * @template-extends Zipable<TKey, T>
@@ -375,6 +377,7 @@ interface Collection extends
     Unzipable,
     Whenable,
     Windowable,
+    Withable,
     Wordsable,
     Wrapable,
     Zipable

--- a/src/Contract/Operation/Withable.php
+++ b/src/Contract/Operation/Withable.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+use loophp\collection\Contract\Operation;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Withable
+{
+    /**
+     * @param array<int, mixed> $arguments
+     *
+     * @return Collection<TKey, T>
+     */
+    public function with(Operation $operation, array $arguments = []): Collection;
+}


### PR DESCRIPTION
This PR:

Provide an easy way to extend the features of Collection. It a bit like the `pipe` operation, but instead of taking `callable(s)`, it takes an instance of `Operation`. I guess working with classes and objects is better in PHP (which is not fully functional).

By providing the `with` operation, you allow anyone to plug-in any custom operation.

Minimal working example:

```php
class AddAndMultiply extends AbstractOperation
{
    public function __invoke(): Closure
    {
        return static function (int $a, int $m) {
            return static function (ContractCollection $collection) use ($a, $m): Generator {
                foreach ($collection as $key => $value) {
                    yield $key => ($value + $a) * $m;
                }
            };
        };
    }
}

$c = Collection::unfold(static fn (int $a = 0, int $b = 1): array => [$b, $a + $b])
    ->limit(3)
    ->pluck(0)
    ->with((new AddAndMultiply()), [0, 2]);

print_r($c->all());
```

- [ ] Fix ...
- [ ] Provide ...
- [ ] It breaks backward compatibility
- [ ] Is covered by unit tests
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
