### PR TITLE
fix: `Distinct` operation

### DIFF
--- a/src/Collection.php
+++ b/src/Collection.php
@@ -13,7 +13,6 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 use loophp\collection\Contract\Operation as OperationInterface;
 use loophp\collection\Utils\CallbacksArrayReducer;
 use loophp\iterators\ClosureIteratorAggregate;
-use loophp\iterators\InterruptableIterableIteratorAggregate;
 use loophp\iterators\IterableIteratorAggregate;
 use loophp\iterators\ResourceIteratorAggregate;
 use loophp\iterators\StringIteratorAggregate;
@@ -163,16 +162,15 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\DiffKeys())()($keys), [$this]);
     }
 
-    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null, int $retries = 2^16): CollectionInterface
+    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null, int $retries = 2 ** 16): CollectionInterface
     {
         $accessorCallback ??=
             /**
              * @param T $value
-             * @param TKey $key
              *
              * @return T
              */
-            static fn (mixed $value, mixed $key): mixed => $value;
+            static fn (mixed $value): mixed => $value;
 
         $comparatorCallback ??=
             /**
@@ -186,7 +184,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
                  */
                 static fn (mixed $right): bool => $left === $right;
 
-        return new self((new Operation\Distinct())()($comparatorCallback)($accessorCallback)($retries), [new InterruptableIterableIteratorAggregate($this)]);
+        return new self((new Operation\Distinct())()($comparatorCallback)($accessorCallback)($retries), [$this]);
     }
 
     public function drop(int $count): CollectionInterface

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -13,6 +13,7 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 use loophp\collection\Contract\Operation as OperationInterface;
 use loophp\collection\Utils\CallbacksArrayReducer;
 use loophp\iterators\ClosureIteratorAggregate;
+use loophp\iterators\InterruptableIterableIteratorAggregate;
 use loophp\iterators\IterableIteratorAggregate;
 use loophp\iterators\ResourceIteratorAggregate;
 use loophp\iterators\StringIteratorAggregate;
@@ -162,7 +163,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\DiffKeys())()($keys), [$this]);
     }
 
-    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): CollectionInterface
+    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null, int $retries = 2^16): CollectionInterface
     {
         $accessorCallback ??=
             /**
@@ -185,7 +186,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
                  */
                 static fn (mixed $right): bool => $left === $right;
 
-        return new self((new Operation\Distinct())()($comparatorCallback)($accessorCallback), [$this]);
+        return new self((new Operation\Distinct())()($comparatorCallback)($accessorCallback)($retries), [new InterruptableIterableIteratorAggregate($this)]);
     }
 
     public function drop(int $count): CollectionInterface

--- a/src/Contract/Operation/Distinctable.php
+++ b/src/Contract/Operation/Distinctable.php
@@ -34,5 +34,5 @@ interface Distinctable
      *
      * @return Collection<TKey, T>
      */
-    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null, int $retries = 2^16): Collection;
+    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null, int $retries = 2 ** 16): Collection;
 }

--- a/src/Contract/Operation/Distinctable.php
+++ b/src/Contract/Operation/Distinctable.php
@@ -34,5 +34,5 @@ interface Distinctable
      *
      * @return Collection<TKey, T>
      */
-    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): Collection;
+    public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null, int $retries = 2^16): Collection;
 }

--- a/src/Operation/Distinct.php
+++ b/src/Operation/Distinct.php
@@ -42,8 +42,6 @@ final class Distinct extends AbstractOperation
                             /** @var ArrayIterator<int, array{0: TKey, 1: T}> $stack */
                             $stack = new ArrayIterator();
 
-                            $accessorCallback = static fn (array $kv): mixed => $accessorCallback($kv[1], $kv[0]);
-
                             $filter = static function (array $kvFilter, Generator $generator) use ($comparatorCallback, $accessorCallback, $stack, &$retries): bool {
                                 if (0 >= $retries) {
                                     $generator->send(InterruptableIterableIteratorAggregate::BREAK);
@@ -51,9 +49,9 @@ final class Distinct extends AbstractOperation
 
                                 $every = (new Every())()(
                                     /**
-                                     * @param array{0: TKey, 1: T} $kv
+                                     * @param array{0: TKey, 1: T} $kvEvery
                                      */
-                                    static fn (int $_, array $kvEvery): bool => !$comparatorCallback($accessorCallback($kvFilter))($accessorCallback($kvEvery))
+                                    static fn (int $_, array $kvEvery): bool => !$comparatorCallback($accessorCallback($kvFilter[1], $kvFilter[0]))($accessorCallback($kvEvery[1], $kvEvery[0]))
                                 )($stack);
 
                                 if (false === $every->current()) {

--- a/tests/unit/CollectionSpecificOperationTest.php
+++ b/tests/unit/CollectionSpecificOperationTest.php
@@ -13,6 +13,7 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 use loophp\collection\Operation\Coalesce;
 use loophp\collection\Operation\Current;
 use loophp\collection\Operation\Limit;
+use loophp\iterators\CachingIteratorAggregate;
 use loophp\PhpUnitIterableAssertions\Traits\IterableAssertions;
 use OutOfBoundsException;
 use PHPUnit\Framework\TestCase;
@@ -218,6 +219,21 @@ final class CollectionSpecificOperationTest extends TestCase
         $this::assertIdenticalIterable(
             $generator(),
             Collection::fromIterable(range(1, 3))->cycle()->limit(7),
+        );
+    }
+
+    public function testDistinctOperation(): void
+    {
+        $integers = static fn (): array => [random_int(0, 9)];
+
+        self::assertCount(
+            10,
+            new CachingIteratorAggregate(
+                Collection::unfold($integers)
+                    ->unwrap()
+                    ->distinct()
+                    ->getIterator()
+            )
         );
     }
 


### PR DESCRIPTION
Fix issue when using infinite generators

This PR:

- [ ] Fix ...
- [ ] Provide ...
- [ ] It breaks backward compatibility
- [ ] Is covered by unit tests
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
