### PR TITLE
Psalm 5.4 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     ],
     "require": {
         "php": ">= 8",
-        "loophp/iterators": "^2.3.1"
+        "loophp/iterators": "^2.3.1",
+        "vimeo/psalm": "dev-master#f723e08221c5028612d928241c84d9cac7fe6d86"
     },
     "require-dev": {
         "amphp/parallel-functions": "^1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,6 +26,11 @@ parameters:
 			path: src/Collection.php
 
 		-
+			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:squash\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<TKey, T\\> but returns loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\{TKey, T\\}\\>\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
 			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:tails\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
 			count: 1
 			path: src/Collection.php
@@ -41,7 +46,7 @@ parameters:
 			path: src/Collection.php
 
 		-
-			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:wrap\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<\\(int&TKey\\)\\|\\(string&TKey\\), T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\>\\.$#"
+			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:wrap\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<\\(int&TKey\\)\\|\\(string&TKey\\), T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int\\|string, mixed\\>\\>\\.$#"
 			count: 1
 			path: src/Collection.php
 
@@ -57,7 +62,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\)\\: Generator\\<mixed, mixed, mixed, mixed\\> given\\.$#"
-			count: 14
+			count: 13
 			path: src/Collection.php
 
 		-
@@ -67,6 +72,11 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\<array\\<int, mixed\\>\\>\\)\\: Generator\\<mixed, mixed, mixed, mixed\\> given\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
+			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable, Closure\\(iterable\\<array\\{mixed, mixed\\}\\>\\)\\: Generator\\<mixed, mixed, mixed, mixed\\> given\\.$#"
 			count: 1
 			path: src/Collection.php
 
@@ -96,7 +106,7 @@ parameters:
 			path: src/Collection.php
 
 		-
-			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\>, Closure\\(iterable\\)\\: Generator\\<int, array, mixed, mixed\\> given\\.$#"
+			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(\\.\\.\\.mixed\\)\\: iterable\\<int, array\\<int\\|string, mixed\\>\\>, Closure\\(iterable\\)\\: Generator\\<int, array\\<int\\|string, mixed\\>, mixed, mixed\\> given\\.$#"
 			count: 1
 			path: src/Collection.php
 
@@ -149,6 +159,11 @@ parameters:
 			message: "#^PHPDoc tag @return with type loophp\\\\collection\\\\CollectionDecorator\\<int, string\\> is incompatible with native type static\\(loophp\\\\collection\\\\CollectionDecorator\\<TKey, T\\>\\)\\.$#"
 			count: 1
 			path: src/CollectionDecorator.php
+
+		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Append\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Append.php
 
 		-
 			message: "#^Template type NewT of method loophp\\\\collection\\\\Operation\\\\Associate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
@@ -241,6 +256,11 @@ parameters:
 			path: src/Operation/Map.php
 
 		-
+			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Prepend\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
+			count: 1
+			path: src/Operation/Prepend.php
+
+		-
 			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Product\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/Product.php
@@ -314,3 +334,8 @@ parameters:
 			message: "#^While loop condition is always true\\.$#"
 			count: 1
 			path: tests/static-analysis/scanRight1.php
+
+		-
+			message: "#^Parameter \\#1 \\$collection of function unfold_checkList expects loophp\\\\collection\\\\Contract\\\\Collection\\<int, iterable\\>, loophp\\\\collection\\\\Contract\\\\Collection\\<int, iterable\\<\\(int\\|string\\), mixed\\>\\> given\\.$#"
+			count: 3
+			path: tests/static-analysis/unfold.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,58 +1,72 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+<files psalm-version="dev-master@c6cfa86f35350842d00e8f1f3b92839fbda5f8f9">
   <file src="src/Collection.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$callback</code>
+      <code>$parameters</code>
     </InvalidArgument>
-    <InvalidReturnStatement occurrences="1">
+    <InvalidReturnStatement>
+      <code>new self((new Operation\Unfold())()($parameters)($callback))</code>
       <code>new self((new Operation\Wrap())(), [$this])</code>
     </InvalidReturnStatement>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnType>
+      <code>CollectionInterface</code>
       <code>CollectionInterface</code>
     </InvalidReturnType>
-    <PossiblyNullArgument occurrences="2">
+    <PossiblyNullArgument>
       <code>$default</code>
       <code>$default</code>
     </PossiblyNullArgument>
   </file>
   <file src="src/CollectionDecorator.php">
-    <InvalidArgument occurrences="4">
+    <InvalidArgument>
       <code>foldLeft1</code>
       <code>foldRight1</code>
-      <code>scanLeft1</code>
-      <code>scanRight1</code>
     </InvalidArgument>
-    <InvalidReturnType occurrences="8">
-      <code>array</code>
-      <code>static</code>
-      <code>static</code>
-      <code>static</code>
-      <code>static</code>
-      <code>static</code>
-      <code>static</code>
+    <InvalidReturnType>
       <code>static</code>
     </InvalidReturnType>
   </file>
   <file src="src/Operation/All.php">
-    <InvalidReturnStatement occurrences="1"/>
-    <InvalidReturnType occurrences="1">
+    <InvalidReturnStatement>
+      <code>static fn (bool $normalize): Closure =&gt;
+                /**
+                 * @param iterable&lt;TKey, T&gt; $iterable
+                 *
+                 * @return Generator&lt;int, T&gt;|Generator&lt;TKey, T&gt;
+                 */
+                static fn (iterable $iterable): Generator =&gt; yield from ($normalize ? (new Normalize())()($iterable) : $iterable)</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
       <code>Closure(bool): Closure(iterable&lt;TKey, T&gt;): (Generator&lt;int, T&gt;|Generator&lt;TKey, T&gt;)</code>
     </InvalidReturnType>
   </file>
-  <file src="src/Operation/Inits.php">
-    <InvalidArgument occurrences="2">
-      <code>[]</code>
-    </InvalidArgument>
-  </file>
-  <file src="src/Operation/Pack.php">
-    <InvalidReturnType occurrences="1">
-      <code>Generator&lt;int, array{0: TKey, 1: T}&gt;</code>
-    </InvalidReturnType>
+  <file src="src/Operation/Pluck.php">
+    <ArgumentTypeCoercion>
+      <code>$segment</code>
+    </ArgumentTypeCoercion>
   </file>
   <file src="src/Operation/Product.php">
-    <InvalidArgument occurrences="2">
+    <InvalidArgument>
       <code>[[]]</code>
       <code>static fn (iterable $a, iterable $x): Generator =&gt; $f($x)($a)</code>
     </InvalidArgument>
+  </file>
+  <file src="src/Operation/Zip.php">
+    <MoreSpecificReturnType>
+      <code>Generator&lt;list&lt;TKey|UKey|null&gt;, list&lt;T|U|null&gt;&gt;</code>
+    </MoreSpecificReturnType>
+  </file>
+  <file src="tests/static-analysis/partition.php">
+    <PossiblyUndefinedArrayOffset>
+      <code>$left</code>
+      <code>$left</code>
+    </PossiblyUndefinedArrayOffset>
+  </file>
+  <file src="tests/static-analysis/span.php">
+    <PossiblyUndefinedArrayOffset>
+      <code>$left</code>
+      <code>$left</code>
+    </PossiblyUndefinedArrayOffset>
   </file>
 </files>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -528,7 +528,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\Matching())()($criteria), [$this]);
     }
 
-    public function max(mixed $default = null): mixed
+    public function max(mixed $default = null)
     {
         return (new self((new Operation\Max())(), [$this]))->current(0, $default);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -493,7 +493,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\Keys())(), [$this]);
     }
 
-    public function last(mixed $default = null): mixed
+    public function last(mixed $default = null)
     {
         return (new self((new Operation\Last())(), [$this]))->current(0, $default);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -127,7 +127,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\Compact())()($values), [$this]);
     }
 
-    public function compare(callable $comparator, $default = null): mixed
+    public function compare(callable $comparator, $default = null)
     {
         return (new self((new Operation\Compare())()($comparator), [$this]))->current(0, $default);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -389,7 +389,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self(static fn (): Generator => yield from new StringIteratorAggregate($string, $delimiter));
     }
 
-    public function get(mixed $key, mixed $default = null): mixed
+    public function get(mixed $key, mixed $default = null)
     {
         return (new self((new Operation\Get())()($key)($default), [$this]))->current(0, $default);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -417,7 +417,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return (new Operation\Has())()(...$callbacks)($this)->current();
     }
 
-    public function head(mixed $default = null): mixed
+    public function head(mixed $default = null)
     {
         return (new self((new Operation\Head())(), [$this]))->current(0, $default);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -142,7 +142,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return iterator_count($this);
     }
 
-    public function current(int $index = 0, $default = null): mixed
+    public function current(int $index = 0, $default = null)
     {
         return (new Operation\Current())()($index)($default)($this)->current();
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -266,7 +266,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\Filter())()(...$callbacks), [$this]);
     }
 
-    public function find(mixed $default = null, callable ...$callbacks): mixed
+    public function find(mixed $default = null, callable ...$callbacks)
     {
         return (new Operation\Find())()($default)(...$callbacks)($this)->current();
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -538,7 +538,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\Merge())()(...$sources), [$this]);
     }
 
-    public function min(mixed $default = null): mixed
+    public function min(mixed $default = null)
     {
         return (new self((new Operation\Min())(), [$this]))->current(0, $default);
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -483,7 +483,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return $this->all(false);
     }
 
-    public function key(int $index = 0): mixed
+    public function key(int $index = 0)
     {
         return (new Operation\Key())()($index)($this)->current();
     }

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -271,7 +271,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return (new Operation\Find())()($default)(...$callbacks)($this)->current();
     }
 
-    public function first(mixed $default = null): mixed
+    public function first(mixed $default = null)
     {
         return (new self((new Operation\First())(), [$this]))->current(0, $default);
     }

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -118,7 +118,7 @@ use Traversable;
  * @template-extends Operation\Transposeable<TKey, T>
  * @template-extends Operation\Truthyable<TKey, T>
  * @template-extends Operation\Unlinesable<TKey, T>
- * @template-extends Operation\Unpackable<mixed, array{0: TKey, 1: T}>
+ * @template-extends Operation\Unpackable<TKey, T>
  * @template-extends Operation\Unpairable<TKey, T>
  * @template-extends Operation\Untilable<TKey, T>
  * @template-extends Operation\Unwindowable<TKey, T>

--- a/src/Contract/Operation/Comparable.php
+++ b/src/Contract/Operation/Comparable.php
@@ -29,5 +29,5 @@ interface Comparable
      *
      * @return T|V
      */
-    public function compare(callable $comparator, mixed $default = null): mixed;
+    public function compare(callable $comparator, mixed $default = null);
 }

--- a/src/Contract/Operation/Currentable.php
+++ b/src/Contract/Operation/Currentable.php
@@ -21,5 +21,5 @@ interface Currentable
      *
      * @return T|V
      */
-    public function current(int $index = 0, mixed $default = null): mixed;
+    public function current(int $index = 0, mixed $default = null);
 }

--- a/src/Contract/Operation/Findable.php
+++ b/src/Contract/Operation/Findable.php
@@ -23,5 +23,5 @@ interface Findable
      *
      * @return T|V
      */
-    public function find(mixed $default = null, callable ...$callbacks): mixed;
+    public function find(mixed $default = null, callable ...$callbacks);
 }

--- a/src/Contract/Operation/Firstable.php
+++ b/src/Contract/Operation/Firstable.php
@@ -23,5 +23,5 @@ interface Firstable
      *
      * @return T|V
      */
-    public function first(mixed $default = null): mixed;
+    public function first(mixed $default = null);
 }

--- a/src/Contract/Operation/Getable.php
+++ b/src/Contract/Operation/Getable.php
@@ -24,5 +24,5 @@ interface Getable
      *
      * @return T|V
      */
-    public function get(mixed $key, mixed $default = null): mixed;
+    public function get(mixed $key, mixed $default = null);
 }

--- a/src/Contract/Operation/Headable.php
+++ b/src/Contract/Operation/Headable.php
@@ -23,5 +23,5 @@ interface Headable
      *
      * @return T|V
      */
-    public function head(mixed $default = null): mixed;
+    public function head(mixed $default = null);
 }

--- a/src/Contract/Operation/Keyable.php
+++ b/src/Contract/Operation/Keyable.php
@@ -17,5 +17,5 @@ interface Keyable
      *
      * @return TKey|null
      */
-    public function key(int $index = 0): mixed;
+    public function key(int $index = 0);
 }

--- a/src/Contract/Operation/Lastable.php
+++ b/src/Contract/Operation/Lastable.php
@@ -23,5 +23,5 @@ interface Lastable
      *
      * @return T|V
      */
-    public function last(mixed $default = null): mixed;
+    public function last(mixed $default = null);
 }

--- a/src/Contract/Operation/Maxable.php
+++ b/src/Contract/Operation/Maxable.php
@@ -28,5 +28,5 @@ interface Maxable
      *
      * @return T|V
      */
-    public function max(mixed $default = null): mixed;
+    public function max(mixed $default = null);
 }

--- a/src/Contract/Operation/Minable.php
+++ b/src/Contract/Operation/Minable.php
@@ -28,5 +28,5 @@ interface Minable
      *
      * @return T|V
      */
-    public function min(mixed $default = null): mixed;
+    public function min(mixed $default = null);
 }

--- a/src/Contract/Operation/Prependable.php
+++ b/src/Contract/Operation/Prependable.php
@@ -17,7 +17,11 @@ interface Prependable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#prepend
      *
-     * @return Collection<int|TKey, T>
+     * @template U
+     *
+     * @param U ...$items
+     *
+     * @return Collection<int|TKey, T|U>
      */
     public function prepend(mixed ...$items): Collection;
 }

--- a/src/Contract/Operation/Unpackable.php
+++ b/src/Contract/Operation/Unpackable.php
@@ -17,7 +17,7 @@ interface Unpackable
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#unpack
      *
-     * @return Collection<mixed, mixed>
+     * @return Collection<TKey, T>
      */
     public function unpack(): Collection;
 }

--- a/src/Operation/Append.php
+++ b/src/Operation/Append.php
@@ -17,21 +17,23 @@ use loophp\iterators\ConcatIterableAggregate;
 final class Append extends AbstractOperation
 {
     /**
-     * @return Closure(array<T>): Closure(iterable<TKey, T>): Generator<int|TKey, T>
+     * @template U
+     *
+     * @return Closure(array<U>): Closure(iterable<TKey, T>): Generator<int|TKey, T|U>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param array<T> $items
+             * @param array<U> $items
              *
-             * @return Closure(iterable<TKey, T>): Generator<int|TKey, T>
+             * @return Closure(iterable<TKey, T>): Generator<int|TKey, T|U>
              */
             static fn (array $items): Closure =>
                 /**
                  * @param iterable<TKey, T> $iterable
                  *
-                 * @return Generator<int|TKey, T>
+                 * @return Generator<int|TKey, T|U>
                  */
                 static fn (iterable $iterable): Generator => yield from new ConcatIterableAggregate([$iterable, $items]);
     }

--- a/src/Operation/Pack.php
+++ b/src/Operation/Pack.php
@@ -17,13 +17,13 @@ use loophp\iterators\PackIterableAggregate;
 final class Pack extends AbstractOperation
 {
     /**
-     * @return Closure(iterable<mixed, mixed>): Generator<int, array{0: TKey, 1: T}>
+     * @return Closure(iterable<TKey, T>): Generator<int, array{0: TKey, 1: T}>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param iterable<mixed, mixed> $iterable
+             * @param iterable<TKey, T> $iterable
              *
              * @return Generator<int, array{0: TKey, 1: T}>
              */

--- a/src/Operation/Prepend.php
+++ b/src/Operation/Prepend.php
@@ -17,21 +17,23 @@ use loophp\iterators\ConcatIterableAggregate;
 final class Prepend extends AbstractOperation
 {
     /**
-     * @return Closure(array<T>): Closure(iterable<TKey, T>): iterable<int|TKey, T>
+     * @template U
+     *
+     * @return Closure(array<U>): Closure(iterable<TKey, T>): iterable<int|TKey, T|U>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param array<T> $items
+             * @param array<U> $items
              *
-             * @return Closure(iterable<TKey, T>): iterable<int|TKey, T>
+             * @return Closure(iterable<TKey, T>): iterable<int|TKey, T|U>
              */
             static fn (array $items): Closure =>
                 /**
                  * @param iterable<TKey, T> $iterable
                  *
-                 * @return Generator<int|TKey, T>
+                 * @return Generator<int|TKey, T|U>
                  */
                 static fn (iterable $iterable): Generator => yield from new ConcatIterableAggregate([$items, $iterable]);
     }

--- a/src/Operation/Unpack.php
+++ b/src/Operation/Unpack.php
@@ -17,13 +17,13 @@ use loophp\iterators\UnpackIterableAggregate;
 final class Unpack extends AbstractOperation
 {
     /**
-     * @return Closure(iterable<mixed, mixed>): Generator<TKey, T>
+     * @return Closure(iterable<mixed, array{0: TKey, 1: T}>): Generator<TKey, T>
      */
     public function __invoke(): Closure
     {
         return
            /**
-            * @param iterable<array{0: TKey, 1: T}> $iterable
+            * @param iterable<mixed, array{0: TKey, 1: T}> $iterable
             */
            static fn (iterable $iterable): Generator => yield from new UnpackIterableAggregate($iterable);
     }

--- a/src/Operation/Wrap.php
+++ b/src/Operation/Wrap.php
@@ -16,20 +16,20 @@ use Generator;
 final class Wrap extends AbstractOperation
 {
     /**
-     * @return Closure(iterable<TKey, T>): Generator<int, array<array-key, T>>
+     * @return Closure(iterable<TKey, T>): Generator<int, array<TKey, T>>
      */
     public function __invoke(): Closure
     {
-        /** @var Closure(iterable<TKey, T>): Generator<int, array<array-key, T>> $pipe */
+        /** @var Closure(iterable<TKey, T>): Generator<int, array<TKey, T>> $pipe */
         $pipe = (new Pipe())()(
             (new Map())()(
                 /**
                  * @param T $value
-                 * @param array-key $key
+                 * @param TKey $key
                  *
-                 * @return array<array-key, T>
+                 * @return array<TKey, T>
                  */
-                static fn (mixed $value, int|string $key): array => [$key => $value]
+                static fn (mixed $value, mixed $key): array => [$key => $value]
             ),
             (new Normalize())()
         );

--- a/tests/static-analysis/append.php
+++ b/tests/static-analysis/append.php
@@ -8,15 +8,49 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int, 1> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
-function append_checkList(CollectionInterface $collection): void
+function append_checkList1(CollectionInterface $collection): void
+{
+}
+/**
+ * @psalm-param CollectionInterface<int, 1|2> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
+ */
+function append_checkList2(CollectionInterface $collection): void
+{
+}
+/**
+ * @psalm-param CollectionInterface<int, 2|5> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
+ */
+function append_checkList3(CollectionInterface $collection): void
+{
+}
+/**
+ * @psalm-param CollectionInterface<int, 1|2|5> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
+ */
+function append_checkList4(CollectionInterface $collection): void
+{
+}
+/**
+ * @psalm-param CollectionInterface<int, array<string, int>> $collection
+ *
+ * @phpstan-param CollectionInterface<mixed, array<string, int|string>> $collection
+ */
+function append_checkListWithMap1(CollectionInterface $collection): void
 {
 }
 /**
  * @param CollectionInterface<int, array<string, int>> $collection
  */
-function append_checkListWithMap(CollectionInterface $collection): void
+function append_checkListWithMap2(CollectionInterface $collection): void
 {
 }
 /**
@@ -26,7 +60,9 @@ function append_checkMap(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<int|string, int|string> $collection
+ * @psalm-param CollectionInterface<mixed, '2'|1|mixed> $collection
+ *
+ * @phpstan-param CollectionInterface<int|string, int|string> $collection
  */
 function append_checkMixed(CollectionInterface $collection): void
 {
@@ -39,12 +75,12 @@ function append_checkMixed(CollectionInterface $collection): void
 // multiple parameters passed too append() as potentially part of a union type.
 
 // ## SUCCESS ###
-append_checkList(Collection::empty()->append(1));
-append_checkList(Collection::empty()->append(1, 2));
-append_checkList(Collection::empty()->append(...[1, 2]));
-append_checkList(Collection::fromIterable([5])->append(2));
-append_checkList(Collection::fromIterable([5])->append(1, 2));
-append_checkList(Collection::fromIterable([5])->append(...[1, 2]));
+append_checkList1(Collection::empty()->append(1));
+append_checkList2(Collection::empty()->append(1, 2));
+append_checkList2(Collection::empty()->append(...[1, 2]));
+append_checkList3(Collection::fromIterable([5])->append(2));
+append_checkList4(Collection::fromIterable([5])->append(1, 2));
+append_checkList4(Collection::fromIterable([5])->append(...[1, 2]));
 
 // Analysers sometime need to know the type of the first item in the collection or the appended one
 // otherwise they might narrow it down too much, i.e. only allow array{foo: int} or array{bar: 2}
@@ -52,10 +88,10 @@ append_checkList(Collection::fromIterable([5])->append(...[1, 2]));
 $foo = ['foo' => 1];
 /** @var array<string, int> $bar */
 $bar = ['bar' => 2];
-append_checkListWithMap(Collection::empty()->append($foo));
-append_checkListWithMap(Collection::empty()->append($foo, ['bar' => 2]));
-append_checkListWithMap(Collection::empty()->append(...[$foo, $bar]));
-append_checkListWithMap(Collection::fromIterable([1 => $foo])->append($bar));
+append_checkListWithMap1(Collection::empty()->append($foo));
+append_checkListWithMap1(Collection::empty()->append($foo, ['bar' => 2]));
+append_checkListWithMap1(Collection::empty()->append(...[$foo, $bar]));
+append_checkListWithMap2(Collection::fromIterable([1 => $foo])->append($bar));
 
 // These should work but they don't due to the way analysers interpret empty()
 // or variadic parameters of different types passed to append()
@@ -67,16 +103,16 @@ append_checkMixed(Collection::fromIterable(['foo' => 1, 'bar' => '2'])->append(1
 
 // ## VALID FAILURE ###
 /** @psalm-suppress InvalidArgument */
-append_checkList(Collection::empty()->append(1, 'foo'));
+append_checkList1(Collection::empty()->append(1, 'foo'));
 /** @psalm-suppress InvalidArgument */
-append_checkList(Collection::fromIterable([5])->append('foo')); // @phpstan-ignore-line
+append_checkList1(Collection::fromIterable([5])->append('foo')); // @phpstan-ignore-line
 /** @psalm-suppress InvalidArgument */
-append_checkList(Collection::fromIterable([5])->append('foo', 1)); // @phpstan-ignore-line
+append_checkList1(Collection::fromIterable([5])->append('foo', 1)); // @phpstan-ignore-line
 
 /** @psalm-suppress InvalidArgument */
-append_checkListWithMap(Collection::empty()->append($foo, ['bar' => 'baz']));
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-append_checkListWithMap(Collection::fromIterable([1 => $foo])->append(['bar' => 'baz']));
+append_checkListWithMap1(Collection::empty()->append($foo, ['bar' => 'baz']));
+/** @psalm-suppress InvalidArgument */
+append_checkListWithMap1(Collection::fromIterable([1 => $foo])->append(['bar' => 'baz']));
 
 /**
  * Append will transform any Collection<string, int> into Collection<int|TKey, int>.

--- a/tests/static-analysis/apply.php
+++ b/tests/static-analysis/apply.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, string> $collection
+ * @psalm-param CollectionInterface<int<0,1>, 'bar'|'foo'> $collection
+ *
+ * @phpstan-param CollectionInterface<int, string> $collection
  */
 function apply_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/associate.php
+++ b/tests/static-analysis/associate.php
@@ -14,13 +14,17 @@ function associate_checkIntInt(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<string, string> $collection
+ * @psalm-param CollectionInterface<non-empty-string, non-empty-string> $collection
+ *
+ * @phpstan-param CollectionInterface<string, string> $collection
  */
 function associate_checkStringString(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<string, bool> $collection
+ * @psalm-param CollectionInterface<non-empty-string, bool> $collection
+ *
+ * @phpstan-param CollectionInterface<string, bool> $collection
  */
 function associate_checkStringBool(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/asyncMap.php
+++ b/tests/static-analysis/asyncMap.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, int> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function asyncMap_checkListInt(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/current.php
+++ b/tests/static-analysis/current.php
@@ -37,7 +37,7 @@ current_checkNonNullable(Collection::fromIterable(range(0, 6))->current(0, -1));
 // VALID failures because `current` can return `NULL` when the collection is empty
 /** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line  */
 current_checkNonNullable(Collection::fromIterable(range(0, 6))->current());
-/** @psalm-suppress PossiblyNullArgument PHPStan is lost here, type inference for `empty` is not as good as Psalm */
+/** @psalm-suppress NullArgument PHPStan is lost here, type inference for `empty` is not as good as Psalm */
 current_checkNonNullable(Collection::empty()->current());
 
 // VALID failures because `current` can use a default value of any type

--- a/tests/static-analysis/diff.php
+++ b/tests/static-analysis/diff.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface|CollectionInterface<int<0, 2>, 0|1|2> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function diff_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/distinct.php
+++ b/tests/static-analysis/distinct.php
@@ -9,7 +9,9 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 use tests\loophp\collection\NamedItem;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 3>, 11|12|13> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function distinct_checkIntList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/drop.php
+++ b/tests/static-analysis/drop.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface|CollectionInterface<int<0, 2>, 0|1|2> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function drop_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/filter.php
+++ b/tests/static-analysis/filter.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, 1|2|3> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function filter_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/flip.php
+++ b/tests/static-analysis/flip.php
@@ -10,32 +10,28 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 /**
  * @phpstan-param CollectionInterface<int, int> $collection
  *
- * @psalm-param CollectionInterface<int<0, max>, int> $collection
+ * @psalm-param CollectionInterface<int, int<0, max>> $collection
  */
 function flip_checkIntInt(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, string> $collection
- */
-function flip_checkIntString(CollectionInterface $collection): void
-{
-}
-/**
- * @param CollectionInterface<string, int> $collection
+ * @phpstan-param CollectionInterface<string, int> $collection
+ *
+ * @psalm-param CollectionInterface<string, int<0, max>> $collection
  */
 function flip_checkStringInt(CollectionInterface $collection): void
 {
 }
+/**
+ * @phpstan-param CollectionInterface<int, string> $collection
+ *
+ * @psalm-param CollectionInterface<int<0, max>, string> $collection
+ */
+function flip_checkIntString(CollectionInterface $collection): void
+{
+}
 
-$intIntGenerator = static function (): Generator {
-    yield random_int(0, mt_getrandmax());
-};
-
-$intStringGenerator = static function (): Generator {
-    yield chr(random_int(0, 255));
-};
-
-flip_checkIntInt(Collection::fromIterable($intIntGenerator())->flip());
-flip_checkStringInt(Collection::fromIterable($intStringGenerator())->flip());
-flip_checkIntString(Collection::fromIterable($intStringGenerator())->flip()->flip());
+flip_checkIntInt(Collection::fromIterable(range(0, 3))->flip());
+flip_checkStringInt(Collection::fromIterable(range('a', 'c'))->flip());
+flip_checkIntString(Collection::fromIterable(range('a', 'c'))->flip()->flip());

--- a/tests/static-analysis/fromCallable.php
+++ b/tests/static-analysis/fromCallable.php
@@ -5,24 +5,35 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param Collection<int<0, max>, int>|Collection<int, int<min, max>> $collection
+ *
+ * @phpstan-param Collection<int, int> $collection
  */
-function fromCallable_checkList(CollectionInterface $collection): void
+function fromCallable_checkList(Collection $collection): void
 {
 }
 /**
- * @param CollectionInterface<string, int> $collection
+ * @param Collection<string, int> $collection
  */
-function fromCallable_checkMap(CollectionInterface $collection): void
+function fromCallable_checkMap(Collection $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, int|string> $collection
+ * @psalm-param Collection<1|3|4, '5'|'b'|'c'|2> $collection
+ *
+ * @phpstan-param Collection<int, int|string> $collection
  */
-function fromCallable_checkMixed(CollectionInterface $collection): void
+function fromCallable_checkMixed1(Collection $collection): void
+{
+}
+/**
+ * @psalm-param Collection<int, int|string>|Collection<int<0, 4>, '3'|'b'|1|2|5> $collection
+ *
+ * @phpstan-param Collection<int, int|string> $collection
+ */
+function fromCallable_checkMixed2(Collection $collection): void
 {
 }
 
@@ -122,20 +133,20 @@ $invokableClassMixed = new class() {
 
 fromCallable_checkList(Collection::fromCallable($generatorClosureList));
 fromCallable_checkMap(Collection::fromCallable($generatorClosureMap));
-fromCallable_checkMixed(Collection::fromCallable($generatorClosureMixed));
+fromCallable_checkMixed1(Collection::fromCallable($generatorClosureMixed));
 
 fromCallable_checkList(Collection::fromCallable($arrayList));
 fromCallable_checkMap(Collection::fromCallable($arrayMap));
-fromCallable_checkMixed(Collection::fromCallable($arrayMixed));
+fromCallable_checkMixed2(Collection::fromCallable($arrayMixed));
 
 fromCallable_checkList(Collection::fromCallable([$classWithMethod, 'getValues']));
 fromCallable_checkMap(Collection::fromCallable([$classWithMethod, 'getKeyValues']));
-fromCallable_checkMixed(Collection::fromCallable([$classWithMethod, 'getMixed']));
+fromCallable_checkMixed2(Collection::fromCallable([$classWithMethod, 'getMixed']));
 
 fromCallable_checkList(Collection::fromCallable([$classWithStaticMethod, 'getValues']));
 fromCallable_checkMap(Collection::fromCallable([$classWithStaticMethod, 'getKeyValues']));
-fromCallable_checkMixed(Collection::fromCallable([$classWithStaticMethod, 'getMixed']));
+fromCallable_checkMixed2(Collection::fromCallable([$classWithStaticMethod, 'getMixed']));
 
 fromCallable_checkList(Collection::fromCallable($invokableClassList));
 fromCallable_checkMap(Collection::fromCallable($invokableClassMap));
-fromCallable_checkMixed(Collection::fromCallable($invokableClassMixed));
+fromCallable_checkMixed2(Collection::fromCallable($invokableClassMixed));

--- a/tests/static-analysis/fromGenerator.php
+++ b/tests/static-analysis/fromGenerator.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, max>, int> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function fromGenerator_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/fromIterable.php
+++ b/tests/static-analysis/fromIterable.php
@@ -5,24 +5,27 @@ declare(strict_types=1);
 include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
-use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param Collection<int<0, max>, int> $collection
+ *
+ * @phpstan-param Collection<int, int> $collection
  */
-function fromIterable_checkList(CollectionInterface $collection): void
+function fromIterable_checkList(Collection $collection): void
 {
 }
 /**
- * @param CollectionInterface<string, int> $collection
+ * @param Collection<string, int> $collection
  */
-function fromIterable_checkMap(CollectionInterface $collection): void
+function fromIterable_checkMap(Collection $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, int|string> $collection
+ * @psalm-param Collection<int<0, 4>, '3'|'b'|1|2|5>|Collection<1|3|4, '5'|'b'|'c'|2> $collection
+ *
+ * @phpstan-param Collection<int, string|int> $collection
  */
-function fromIterable_checkMixed(CollectionInterface $collection): void
+function fromIterable_checkMixed(Collection $collection): void
 {
 }
 

--- a/tests/static-analysis/groupby.php
+++ b/tests/static-analysis/groupby.php
@@ -8,14 +8,18 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, non-empty-list<string>> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, non-empty-list<'bar'|'baz'|'foo'>> $collection
+ *
+ * @phpstan-param CollectionInterface<int, non-empty-array<int, string>> $collection
  */
 function groupby_sameKeyType(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<string, non-empty-list<string>> $collection
+ * @psalm-param CollectionInterface<string, non-empty-list<string>> $collection
+ *
+ * @phpstan-param CollectionInterface<string, non-empty-array<int, string>> $collection
  */
 function groupby_newKeyType(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/inits.php
+++ b/tests/static-analysis/inits.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, list<array{0: int, 1: string}>> $collection
+ * @phpstan-param CollectionInterface<int, list<array{0: int, 1: string}>> $collection
+ *
+ * @psalm-param CollectionInterface<int, list<array{0: int<0, max>, 1: string}>> $collection
  */
 function inits_checkListString(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/keys.php
+++ b/tests/static-analysis/keys.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int, int<0, 2>> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function keys_checkIntList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/last.php
+++ b/tests/static-analysis/last.php
@@ -6,6 +6,12 @@ include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
+/**
+ * @param mixed|null $last
+ */
+function last_checkNull($last): void
+{
+}
 function last_checkList(?int $last): void
 {
 }
@@ -28,8 +34,7 @@ function last_checkNullableString(?string $value): void
 last_checkList(Collection::fromIterable([1, 2, 3])->last());
 last_checkMap(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->last());
 
-last_checkList(Collection::empty()->last());
-last_checkMap(Collection::empty()->last());
+last_checkNull(Collection::empty()->last());
 
 last_checkNullableInt(Collection::fromIterable([1, 2, 3])->last());
 last_checkNullableString(Collection::fromIterable(['foo' => 'bar', 'baz' => 'bar'])->last());

--- a/tests/static-analysis/map.php
+++ b/tests/static-analysis/map.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, int> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function map_checkListInt(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/matching.php
+++ b/tests/static-analysis/matching.php
@@ -9,7 +9,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, 1|2|3> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function matching_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/max.php
+++ b/tests/static-analysis/max.php
@@ -6,6 +6,12 @@ include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
+/**
+ * @param null|mixed $_
+ */
+function max_takeNull($_): void
+{
+}
 function max_takeInt(int $int): void
 {
 }
@@ -19,27 +25,27 @@ function max_takeStringOrNull(?string $string): void
 {
 }
 
-max_takeIntOrNull(Collection::empty()->max());
+max_takeNull(Collection::empty()->max());
+
+max_takeInt(Collection::empty()->max(0));
+
 max_takeIntOrNull(Collection::fromIterable([1, 2, 3, -2, 4])->max());
 
-max_takeIntOrNull(Collection::empty()->max());
 max_takeIntOrNull(Collection::fromIterable([1, 2, null, -2, 4])->max());
 
-max_takeStringOrNull(Collection::empty()->max());
 max_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->max());
 
-max_takeStringOrNull(Collection::empty()->max());
 max_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => null])->max());
 
 // VALID failures - `max` can return NULL
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 max_takeInt(Collection::empty()->max());
 
 /** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
 max_takeInt(Collection::fromIterable([1, 2, 3, -2, 4])->max());
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 max_takeString(Collection::empty()->max());
 
 /** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */

--- a/tests/static-analysis/min.php
+++ b/tests/static-analysis/min.php
@@ -6,6 +6,12 @@ include __DIR__ . '/../../vendor/autoload.php';
 
 use loophp\collection\Collection;
 
+/**
+ * @param null|mixed $_
+ */
+function min_takeNull($_): void
+{
+}
 function min_takeInt(int $int): void
 {
 }
@@ -19,27 +25,27 @@ function min_takeStringOrNull(?string $string): void
 {
 }
 
-min_takeIntOrNull(Collection::empty()->min());
+min_takeNull(Collection::empty()->min());
+
+min_takeInt(Collection::empty()->min(0));
+
 min_takeIntOrNull(Collection::fromIterable([1, 2, 3, -2, 4])->min());
 
-min_takeIntOrNull(Collection::empty()->min());
 min_takeIntOrNull(Collection::fromIterable([1, 2, null, -2, 4])->min());
 
-min_takeStringOrNull(Collection::empty()->min());
 min_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => 'bar'])->min());
 
-min_takeStringOrNull(Collection::empty()->min());
 min_takeStringOrNull(Collection::fromIterable(['f' => 'foo', 'b' => null])->min());
 
 // VALID failures - `min` can return NULL
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 min_takeInt(Collection::empty()->min());
 
 /** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */
 min_takeInt(Collection::fromIterable([1, 2, 3, -2, 4])->min());
 
-/** @psalm-suppress PossiblyNullArgument */
+/** @psalm-suppress NullArgument */
 min_takeString(Collection::empty()->min());
 
 /** @psalm-suppress PossiblyNullArgument @phpstan-ignore-next-line */

--- a/tests/static-analysis/pack.php
+++ b/tests/static-analysis/pack.php
@@ -15,7 +15,9 @@ function pack_checkListInt(CollectionInterface $collection): void
 }
 
 /**
- * @param CollectionInterface<int, array{0: int, 1: string}> $collection
+ * @phpstan-param CollectionInterface<int, array{0: int, 1: string}> $collection
+ *
+ * @psalm-param CollectionInterface<int, array{0: int<0, max>, 1: string}> $collection
  */
 function pack_checkListString(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/product.php
+++ b/tests/static-analysis/product.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, list<int|string>> $collection
+ * @psalm-param CollectionInterface<int<0, max>, list<int|string>> $collection
+ *
+ * @phpstan-param CollectionInterface<int, list<int|string>> $collection
  */
 function product_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/random.php
+++ b/tests/static-analysis/random.php
@@ -16,7 +16,9 @@ function random_checkIntList(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, string> $collection
+ * @phpstan-param CollectionInterface<int, string> $collection
+ *
+ * @psalm-param CollectionInterface<int, non-empty-string> $collection
  */
 function random_checkStringList(CollectionInterface $collection): void
 {
@@ -28,7 +30,9 @@ function random_checkBoolList(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<string, string> $collection
+ * @phpstan-param CollectionInterface<string, string> $collection
+ *
+ * @psalm-param CollectionInterface<non-empty-string, non-empty-string> $collection
  */
 function random_checkStringMap(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/reduction.php
+++ b/tests/static-analysis/reduction.php
@@ -11,14 +11,18 @@ $sum = static fn (int $carry, int $value): int => $carry + $value;
 $concat = static fn (?string $carry, string $string): string => sprintf('%s%s', (string) $carry, $string);
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface|CollectionInterface<int<0, 2>, int> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function reduction_checkListInt(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<int, string> $collection
+ * @psalm-param CollectionInterface|CollectionInterface<int<0, max>, string> $collection
+ *
+ * @phpstan-param CollectionInterface<int, string> $collection
  */
 function reduction_checkListString(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/reject.php
+++ b/tests/static-analysis/reject.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, 1|2|3> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function reject_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/reverse.php
+++ b/tests/static-analysis/reverse.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, max>, int> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function reverse_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/scanLeft1.php
+++ b/tests/static-analysis/scanLeft1.php
@@ -18,7 +18,9 @@ function scanLeft1_checkListString(CollectionInterface $collection): void
 }
 
 /**
- * @param CollectionInterface<int, int|string> $collection
+ * @psalm-param CollectionInterface<int, int|non-empty-string> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int|string> $collection
  */
 function scanLeft1_checkListOfSize1String(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/scanRight1.php
+++ b/tests/static-analysis/scanRight1.php
@@ -18,7 +18,9 @@ function scanRight1_checkListString(CollectionInterface $collection): void
 }
 
 /**
- * @param CollectionInterface<int, int|string> $collection
+ * @psalm-param CollectionInterface<int, int|non-empty-string> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int|string> $collection
  */
 function scanRight1_checkListOfSize1String(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/shuffle.php
+++ b/tests/static-analysis/shuffle.php
@@ -16,7 +16,9 @@ function shuffle_checkIntList(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, string> $collection
+ * @phpstan-param CollectionInterface<int, string> $collection
+ *
+ * @psalm-param CollectionInterface<int, non-empty-string> $collection
  */
 function shuffle_checkStringList(CollectionInterface $collection): void
 {
@@ -28,7 +30,9 @@ function shuffle_checkBoolList(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<string, string> $collection
+ * @phpstan-param CollectionInterface<string, string> $collection
+ *
+ * @psalm-param CollectionInterface<non-empty-string, non-empty-string> $collection
  */
 function shuffle_checkStringMap(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/span.php
+++ b/tests/static-analysis/span.php
@@ -8,13 +8,17 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, Collection<int, int>> $collection
+ * @psalm-param CollectionInterface<int, Collection<int<0, 2>, 2|3|4>> $collection
+ *
+ * @phpstan-param CollectionInterface<int, Collection<int, int>> $collection
  */
 function span_checkListCollectionInt(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, 2|3|4> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function span_checkListInt(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/squash.php
+++ b/tests/static-analysis/squash.php
@@ -8,15 +8,35 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, 1|2|3> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
-function squash_checkList(CollectionInterface $collection): void
+function squash_checkList1(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, string> $collection
+ * @psalm-param CollectionInterface<int, 1|2> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
-function squash_checkStringList(CollectionInterface $collection): void
+function squash_checkList2(CollectionInterface $collection): void
+{
+}
+/**
+ * @psalm-param CollectionInterface<int<0, 2>, 'a'|'b'|'c'> $collection
+ *
+ * @phpstan-param CollectionInterface<int, string> $collection
+ */
+function squash_checkStringList1(CollectionInterface $collection): void
+{
+}
+/**
+ * @psalm-param CollectionInterface<int, 'b'|'f'> $collection
+ *
+ * @phpstan-param CollectionInterface<int, string> $collection
+ */
+function squash_checkStringList2(CollectionInterface $collection): void
 {
 }
 /**
@@ -26,18 +46,18 @@ function squash_checkMap(CollectionInterface $collection): void
 {
 }
 
-squash_checkList(Collection::fromIterable([1, 2, 3])->squash());
+squash_checkList1(Collection::fromIterable([1, 2, 3])->squash());
 squash_checkMap(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->squash());
-squash_checkStringList(Collection::fromIterable(['a', 'b', 'c'])->squash());
+squash_checkStringList1(Collection::fromIterable(['a', 'b', 'c'])->squash());
 
 // These work because `normalize` always changes the key to `int`
-squash_checkList(Collection::fromIterable(['foo' => 1, 'bar' => 2])->normalize()->squash());
-squash_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->normalize()->squash());
+squash_checkList2(Collection::fromIterable(['foo' => 1, 'bar' => 2])->normalize()->squash());
+squash_checkStringList2(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->normalize()->squash());
 
 // VALID failures -> `squash` does not change the key and value types
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-squash_checkList(Collection::fromIterable(['a', 'b', 'c'])->squash());
+squash_checkList1(Collection::fromIterable(['a', 'b', 'c'])->squash());
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
-squash_checkStringList(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->squash());
+squash_checkStringList2(Collection::fromIterable(['foo' => 'f', 'bar' => 'b'])->squash());
 /** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
 squash_checkMap(Collection::fromIterable(['foo' => 1, 'bar' => 2])->squash());

--- a/tests/static-analysis/strict.php
+++ b/tests/static-analysis/strict.php
@@ -8,7 +8,9 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, 1|2|3> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function strict_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/tail.php
+++ b/tests/static-analysis/tail.php
@@ -8,14 +8,18 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, 1|2|3> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function tail_checkListInt(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<int, string> $collection
+ * @psalm-param CollectionInterface<int<0, max>, string> $collection
+ *
+ * @phpstan-param CollectionInterface<int, string> $collection
  */
 function tail_checkListString(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/unfold.php
+++ b/tests/static-analysis/unfold.php
@@ -8,23 +8,29 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @phpstan-param CollectionInterface<int, iterable<mixed,mixed>> $collection
+ *
+ * @psalm-param CollectionInterface<int, iterable<int|string, int>> $collection
  */
 function unfold_checkList(CollectionInterface $collection): void
 {
 }
 /**
- * @param CollectionInterface<int, list<int>> $collection
+ * @param CollectionInterface<int, iterable<int|string, int>> $collection
  */
 function unfold_checkListOfLists(CollectionInterface $collection): void
 {
 }
 
-$plusTwo = static fn (int $n = 0): array => [$n + 2];
+$plusTwo =
+    /**
+     * @return array{0: int}
+     */
+    static fn (int $n = 0): array => [$n + 2];
 $fib = static fn (int $a = 0, int $b = 1): array => [$b, $a + $b];
 
-unfold_checkList(Collection::unfold($plusTwo)->unwrap());
-unfold_checkList(Collection::unfold($plusTwo, [-2])->unwrap());
+unfold_checkList(Collection::unfold($plusTwo));
+unfold_checkList(Collection::unfold($plusTwo, [-2]));
 
 // VALID use cases -> PHPStan thinks the collection is of type Collection<int, array<int, mixed>>, but Psalm works
 
@@ -40,7 +46,7 @@ unfold_checkListOfLists(Collection::unfold($fib, 0));
 
 // VALID use case -> `Pluck` can return various things so analysers cannot know the type is correct
 
-/** @psalm-suppress InvalidArgument @phpstan-ignore-next-line */
+/** @psalm-suppress InvalidArgument */
 unfold_checkList(Collection::unfold($fib)->pluck(0));
 
 // INVALID use case -> parameters of different types

--- a/tests/static-analysis/unpack.php
+++ b/tests/static-analysis/unpack.php
@@ -8,38 +8,30 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @phpstan-param CollectionInterface<int, int> $collection
+ *
+ * @psalm-param CollectionInterface<int<0, max>, int> $collection
  */
 function unpack_checkListInt(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<int, string> $collection
+ * @phpstan-param CollectionInterface<int, string> $collection
+ *
+ * @psalm-param CollectionInterface<int<0, max>, string> $collection
  */
 function unpack_checkListString(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<string, string> $collection
+ * @phpstan-param CollectionInterface<string, string> $collection
  */
 function unpack_checkListStringWithString(CollectionInterface $collection): void
 {
 }
 
-$infiniteIntIntGenerator = static function (): Generator {
-    yield [random_int(-10, 10), random_int(-10, 10)];
-};
-
-$infiniteIntStringGenerator = static function (): Generator {
-    yield [random_int(-10, 10), chr(random_int(0, 255))];
-};
-
-$infiniteStringStringGenerator = static function (): Generator {
-    yield [chr(random_int(0, 255)), chr(random_int(0, 255))];
-};
-
-unpack_checkListInt(Collection::fromIterable($infiniteIntIntGenerator())->unpack());
-unpack_checkListString(Collection::fromIterable($infiniteIntStringGenerator())->unpack());
-unpack_checkListStringWithString(Collection::fromIterable($infiniteStringStringGenerator())->unpack());
+unpack_checkListInt(Collection::fromIterable(range(0, 5))->unpack());
+unpack_checkListString(Collection::fromIterable(range('a', 'c'))->unpack());
+unpack_checkListStringWithString(Collection::fromIterable(array_combine(range('a', 'c'), range('a', 'c')))->unpack());

--- a/tests/static-analysis/when.php
+++ b/tests/static-analysis/when.php
@@ -8,14 +8,18 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, string> $collection
+ * @psalm-param CollectionInterface<int<0, max>, string> $collection
+ *
+ * @phpstan-param CollectionInterface<int, string> $collection
  */
 function whenConditionIsTrueT_checkList(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<int, int> $collection
+ * @psalm-param CollectionInterface<int<0, max>, int> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
  */
 function whenConditionIsFalseT_checkList(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/window.php
+++ b/tests/static-analysis/window.php
@@ -8,14 +8,18 @@ use loophp\collection\Collection;
 use loophp\collection\Contract\Collection as CollectionInterface;
 
 /**
- * @param CollectionInterface<int, list<int>> $collection
+ * @psalm-param CollectionInterface<int<0, 2>, list<1|2|3>> $collection
+ *
+ * @phpstan-param CollectionInterface<int, list<int>> $collection
  */
 function window_checkListInt(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<int, list<string>> $collection
+ * @psalm-param CollectionInterface<int<0, max>, list<string>> $collection
+ *
+ * @phpstan-param CollectionInterface<int, list<string>> $collection
  */
 function window_checkListString(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/wrap.php
+++ b/tests/static-analysis/wrap.php
@@ -10,7 +10,7 @@ use loophp\collection\Contract\Collection as CollectionInterface;
 /**
  * @phpstan-param CollectionInterface<int, array<int, int>> $collection
  *
- * @psalm-param CollectionInterface<int, array<int, int<0, max>>> $collection
+ * @psalm-param CollectionInterface<int, array<int<0, max>, int>> $collection
  */
 function wrap_checkList(CollectionInterface $collection): void
 {
@@ -22,13 +22,5 @@ function wrap_checkMap(CollectionInterface $collection): void
 {
 }
 
-$intIntGenerator = static function (): Generator {
-    yield random_int(0, mt_getrandmax());
-};
-
-$stringBoolGenerator = static function (): Generator {
-    yield chr(random_int(0, 255)) => 0 === random_int(0, mt_getrandmax()) % 2;
-};
-
-wrap_checkList(Collection::fromIterable($intIntGenerator())->wrap());
-wrap_checkMap(Collection::fromIterable($stringBoolGenerator())->wrap());
+wrap_checkList(Collection::fromIterable(range(0, 3))->wrap());
+wrap_checkMap(Collection::fromIterable(['a' => true, 'b' => false])->wrap());

--- a/tests/static-analysis/zip.php
+++ b/tests/static-analysis/zip.php
@@ -15,21 +15,27 @@ function zip_checkBoolBool(CollectionInterface $collection): void
 }
 
 /**
- * @param CollectionInterface<list<bool|int>, list<bool|string>> $collection
+ * @phpstan-param CollectionInterface<list<bool|int>, list<bool|string>> $collection
+ *
+ * @psalm-param CollectionInterface<list<bool|int<0, max>>, list<bool|string>> $collection
  */
 function zip_checkBoolString(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<list<int>, list<int|string>> $collection
+ * @phpstan-param CollectionInterface<list<int>, list<int|string>> $collection
+ *
+ * @psalm-param CollectionInterface<list<int<0, max>>, list<int|string>> $collection
  */
 function zip_checkIntString(CollectionInterface $collection): void
 {
 }
 
 /**
- * @param CollectionInterface<list<bool|int>, list<bool|int|string>> $collection
+ * @phpstan-param CollectionInterface<list<bool|int>, list<bool|int|string>> $collection
+ *
+ * @psalm-param CollectionInterface<list<bool|int<0, max>>, list<bool|int|string>> $collection
  */
 function zip_checkBoolStringInt(CollectionInterface $collection): void
 {


### PR DESCRIPTION
This PR:

- [x] Fix issues introduced by Psalm 5.4
- [x] Has static analysis tests (psalm, phpstan)
- [x] Needs PSalm > 5.4.0 to work (_use dev version in the meantime_) 

