### PR TITLE
Fix `reducing` operations

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -1793,6 +1793,10 @@ reduce
 ~~~~~~
 
 Reduce a collection of items through a given callback.
+An optional initial value is by default set to `null` and
+can be customized by the user through the second argument.
+
+When the collection is empty, the initial value is returned.
 
 Interface: `Reduceable`_
 
@@ -1804,8 +1808,11 @@ Signature: ``Collection::reduce(callable $callback, $initial = null): mixed;``
 reduction
 ~~~~~~~~~
 
-Reduce a collection of items through a given callback and yield
-each intermediary results.
+Takes the initial value and the first item of the list and applies the function
+to them, then feeds the function with this result and the second argument and
+so on. It returns the list of intermediate and final results.
+
+When the collection is empty, the initial value is yielded.
 
 Interface: `Reductionable`_
 
@@ -1915,8 +1922,11 @@ Signature: ``Collection::scale(float $lowerBound, float $upperBound, float $want
 scanLeft
 ~~~~~~~~
 
-Takes the initial value and the first item of the list and applies the function to them, then feeds the function with
-this result and the second argument and so on. It returns the list of intermediate and final results.
+Takes the initial value and the first item of the list and applies the function
+to them, then feeds the function with this result and the second argument and
+so on. It returns the list of intermediate and final results.
+
+When the collection is empty, the initial value is yielded.
 
 Interface: `ScanLeftable`_
 
@@ -1967,8 +1977,11 @@ Signature: ``Collection::scanLeft1(callable $callback): Collection;``
 scanRight
 ~~~~~~~~~
 
-Takes the initial value and the last item of the list and applies the function, then it takes the penultimate item from
-the end and the result, and so on. It returns the list of intermediate and final results.
+Takes the initial value and the last item of the list and applies the function,
+then it takes the penultimate item from the end and the result, and so on. It
+returns the list of intermediate and final results.
+
+When the collection is empty, the initial value is yielded.
 
 Interface: `ScanRightable`_
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -271,11 +271,6 @@ parameters:
 			path: src/Operation/Reduce.php
 
 		-
-			message: "#^Template type W of method loophp\\\\collection\\\\Operation\\\\Reduce\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
-			count: 1
-			path: src/Operation/Reduce.php
-
-		-
 			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Reduction\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/Reduction.php
@@ -286,22 +281,12 @@ parameters:
 			path: src/Operation/ScanLeft.php
 
 		-
-			message: "#^Template type W of method loophp\\\\collection\\\\Operation\\\\ScanLeft\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
-			count: 1
-			path: src/Operation/ScanLeft.php
-
-		-
 			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\ScanLeft1\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/ScanLeft1.php
 
 		-
 			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\ScanRight\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
-			count: 1
-			path: src/Operation/ScanRight.php
-
-		-
-			message: "#^Template type W of method loophp\\\\collection\\\\Operation\\\\ScanRight\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/ScanRight.php
 

--- a/src/Contract/Operation/Reduceable.php
+++ b/src/Contract/Operation/Reduceable.php
@@ -18,12 +18,11 @@ interface Reduceable
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#reduce
      *
      * @template V
-     * @template W
      *
-     * @param callable((V|W), T, TKey, iterable<TKey, T>): W $callback
+     * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
      * @param V $initial
      *
-     * @return W
+     * @return V
      */
     public function reduce(callable $callback, mixed $initial = null): mixed;
 }

--- a/src/Contract/Operation/Reductionable.php
+++ b/src/Contract/Operation/Reductionable.php
@@ -18,12 +18,11 @@ interface Reductionable
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#reduction
      *
      * @template V
-     * @template W
      *
-     * @param callable((V|W), T, TKey, iterable<TKey, T>): W $callback
+     * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
      * @param V $initial
      *
-     * @return Collection<TKey, W>
+     * @return Collection<TKey|int, V>
      */
     public function reduction(callable $callback, mixed $initial = null): Collection;
 }

--- a/src/Contract/Operation/ScanLeft1able.php
+++ b/src/Contract/Operation/ScanLeft1able.php
@@ -23,7 +23,7 @@ interface ScanLeft1able
      *
      * @param callable((T|V), T, TKey, iterable<TKey, T>): (T|V) $callback
      *
-     * @return Collection<TKey, T|V>
+     * @return Collection<TKey|int, T|V>
      */
     public function scanLeft1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/ScanLeftable.php
+++ b/src/Contract/Operation/ScanLeftable.php
@@ -20,12 +20,11 @@ interface ScanLeftable
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanleft
      *
      * @template V
-     * @template W
      *
-     * @param callable((V|W), T, TKey, iterable<TKey, T>): W $callback
+     * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
      * @param V $initial
      *
-     * @return Collection<TKey, V|W>
+     * @return Collection<TKey|int, V>
      */
     public function scanLeft(callable $callback, mixed $initial): Collection;
 }

--- a/src/Contract/Operation/ScanRight1able.php
+++ b/src/Contract/Operation/ScanRight1able.php
@@ -24,7 +24,7 @@ interface ScanRight1able
      *
      * @param callable((T|V), T, TKey, Iterator<TKey, T>): (T|V) $callback
      *
-     * @return Collection<TKey, T|V>
+     * @return Collection<TKey|int, T|V>
      */
     public function scanRight1(callable $callback): Collection;
 }

--- a/src/Contract/Operation/ScanRightable.php
+++ b/src/Contract/Operation/ScanRightable.php
@@ -20,12 +20,11 @@ interface ScanRightable
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#scanright
      *
      * @template V
-     * @template W
      *
-     * @param callable((V|W), T, TKey, iterable<TKey, T>): W $callback
+     * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
      * @param V $initial
      *
-     * @return Collection<TKey, V|W>
+     * @return Collection<TKey|int, V>
      */
     public function scanRight(callable $callback, mixed $initial): Collection;
 }

--- a/src/Operation/Reduce.php
+++ b/src/Operation/Reduce.php
@@ -18,7 +18,6 @@ final class Reduce extends AbstractOperation
 {
     /**
      * @template V
-     * @template W
      *
      * @return Closure(callable(mixed, mixed, mixed, iterable<mixed, mixed>): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<TKey, mixed>
      */
@@ -26,15 +25,15 @@ final class Reduce extends AbstractOperation
     {
         return
             /**
-             * @param callable((V|W), T, TKey, iterable<TKey, T>): W $callback
+             * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
              *
-             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, W>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, V>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(iterable<TKey, T>): Generator<TKey, W>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey, V>
                  */
                 static fn (mixed $initial): Closure =>
                     /**

--- a/src/Operation/Reduction.php
+++ b/src/Operation/Reduction.php
@@ -19,7 +19,7 @@ final class Reduction extends AbstractOperation
     /**
      * @template V
      *
-     * @return Closure(callable(mixed, mixed, mixed, iterable<mixed, mixed>): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<TKey, mixed>
+     * @return Closure(callable(mixed, mixed, mixed, iterable<mixed, mixed>): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<TKey|int, mixed>
      */
     public function __invoke(): Closure
     {
@@ -27,19 +27,19 @@ final class Reduction extends AbstractOperation
             /**
              * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
              *
-             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, V>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey|int, V>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(iterable<TKey, T>): Generator<TKey, V>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey|int, V>
                  */
                 static fn (mixed $initial): Closure =>
                     /**
                      * @param iterable<TKey, T> $iterable
                      *
-                     * @return Generator<TKey, V>
+                     * @return Generator<TKey|int, V>
                      */
                     static fn (iterable $iterable): Generator => yield from new ReductionIterableAggregate($iterable, Closure::fromCallable($callback), $initial);
     }

--- a/src/Operation/ScanLeft.php
+++ b/src/Operation/ScanLeft.php
@@ -6,6 +6,7 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
+use loophp\iterators\ReductionIterableAggregate;
 
 /**
  * @immutable
@@ -17,32 +18,29 @@ final class ScanLeft extends AbstractOperation
 {
     /**
      * @template V
-     * @template W
      *
-     * @return Closure(callable((V|W), T, TKey, iterable<TKey, T>): W): Closure(V): Closure(iterable<TKey, T>): Generator<TKey, V|W>
+     * @return Closure(callable(mixed, mixed, mixed, iterable<mixed, mixed>): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<TKey|int, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable((V|W), T, TKey, iterable<TKey, T>): W $callback
+             * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
              *
-             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, V|W>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey|int, V>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(iterable<TKey, T>): Generator<TKey, V|W>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey|int, V>
                  */
-                static function (mixed $initial) use ($callback): Closure {
-                    /** @var Closure(iterable<TKey, T>): Generator<TKey, V|W> $pipe */
-                    $pipe = (new Pipe())()(
-                        (new Reduction())()($callback)($initial),
-                        (new Prepend())()([$initial])
-                    );
-
-                    return $pipe;
-                };
+                static fn (mixed $initial): Closure =>
+                    /**
+                     * @param iterable<TKey, T> $iterable
+                     *
+                     * @return Generator<TKey|int, V>
+                     */
+                    static fn (iterable $iterable): Generator => yield from new ReductionIterableAggregate($iterable, Closure::fromCallable($callback), $initial);
     }
 }

--- a/src/Operation/ScanLeft1.php
+++ b/src/Operation/ScanLeft1.php
@@ -19,7 +19,7 @@ final class ScanLeft1 extends AbstractOperation
     /**
      * @template V
      *
-     * @return Closure(callable((T|V), T, TKey, iterable<TKey, T>): (T|V)): Closure(iterable<TKey, T>): Generator<TKey, T|V>
+     * @return Closure(callable((T|V), T, TKey, iterable<TKey, T>): (T|V)): Closure(iterable<TKey, T>): Generator<TKey|int, T|V>
      */
     public function __invoke(): Closure
     {
@@ -27,13 +27,13 @@ final class ScanLeft1 extends AbstractOperation
             /**
              * @param callable((T|V), T, TKey, iterable<TKey, T>): (T|V) $callback
              *
-             * @return Closure(iterable<TKey, T>): Generator<TKey, T|V>
+             * @return Closure(iterable<TKey, T>): Generator<TKey|int, T|V>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param iterable<TKey, T> $iterable
                  *
-                 * @return Generator<TKey, T|V>
+                 * @return Generator<TKey|int, T|V>
                  */
                 static function (iterable $iterable) use ($callback): Generator {
                     $iteratorAggregate = new IterableIteratorAggregate($iterable);
@@ -46,11 +46,10 @@ final class ScanLeft1 extends AbstractOperation
 
                     $initial = $iteratorInitial->current();
 
-                    /** @var Closure(iterable<TKey, T>): Generator<TKey, T|V> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey|int, T|V> $pipe */
                     $pipe = (new Pipe())()(
                         (new Tail())(),
                         (new Reduction())()($callback)($initial),
-                        (new Prepend())()([$initial])
                     );
 
                     yield from $pipe($iteratorAggregate);

--- a/src/Operation/ScanRight.php
+++ b/src/Operation/ScanRight.php
@@ -17,26 +17,25 @@ final class ScanRight extends AbstractOperation
 {
     /**
      * @template V
-     * @template W
      *
-     * @return Closure(callable((V|W), T, TKey, iterable<TKey, T>): W): Closure(V): Closure(iterable<TKey, T>): Generator<TKey, V|W>
+     * @return Closure(callable(mixed, mixed, mixed, iterable<mixed, mixed>): mixed): Closure(mixed): Closure(iterable<TKey, T>): Generator<TKey|int, mixed>
      */
     public function __invoke(): Closure
     {
         return
             /**
-             * @param callable((V|W), T, TKey, iterable<TKey, T>): W $callback
+             * @param callable(V, T, TKey, iterable<TKey, T>): V $callback
              *
-             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey, V|W>
+             * @return Closure(V): Closure(iterable<TKey, T>): Generator<TKey|int, V>
              */
             static fn (callable $callback): Closure =>
                 /**
                  * @param V $initial
                  *
-                 * @return Closure(iterable<TKey, T>): Generator<TKey, V|W>
+                 * @return Closure(iterable<TKey, T>): Generator<TKey|int, V>
                  */
                 static function (mixed $initial) use ($callback): Closure {
-                    /** @var Closure(iterable<TKey, T>): Generator<TKey, V|W> $pipe */
+                    /** @var Closure(iterable<TKey, T>): Generator<TKey|int, V> $pipe */
                     $pipe = (new Pipe())()(
                         (new Reverse())(),
                         (new ScanLeft())()($callback)($initial),

--- a/src/Operation/ScanRight1.php
+++ b/src/Operation/ScanRight1.php
@@ -18,7 +18,7 @@ final class ScanRight1 extends AbstractOperation
     /**
      * @template V
      *
-     * @return Closure(callable((T|V), T, TKey, iterable<TKey, T>): (T|V)): Closure(iterable<TKey, T>): Generator<TKey, T|V>
+     * @return Closure(callable((T|V), T, TKey, iterable<TKey, T>): (T|V)): Closure(iterable<TKey, T>): Generator<TKey|int, T|V>
      */
     public function __invoke(): Closure
     {
@@ -26,10 +26,10 @@ final class ScanRight1 extends AbstractOperation
             /**
              * @param callable((T|V), T, TKey, iterable<TKey, T>): (T|V) $callback
              *
-             * @return Closure(iterable<TKey, T>): Generator<TKey, T|V>
+             * @return Closure(iterable<TKey, T>): Generator<TKey|int, T|V>
              */
             static function (callable $callback): Closure {
-                /** @var Closure(iterable<TKey, T>): Generator<TKey, T|V> $pipe */
+                /** @var Closure(iterable<TKey, T>): Generator<TKey|int, T|V> $pipe */
                 $pipe = (new Pipe())()(
                     (new Reverse())(),
                     (new ScanLeft1())()($callback),

--- a/src/Operation/Tails.php
+++ b/src/Operation/Tails.php
@@ -7,6 +7,7 @@ namespace loophp\collection\Operation;
 use Closure;
 use Generator;
 use loophp\iterators\IterableIteratorAggregate;
+use loophp\iterators\LimitIterableAggregate;
 use loophp\iterators\NormalizeIterableAggregate;
 use loophp\iterators\ReductionIterableAggregate;
 
@@ -37,7 +38,7 @@ final class Tails extends AbstractOperation
                 // be too complex to deal with S.A. annotations.
                 array_unshift($generator, current($generator));
 
-                yield from new NormalizeIterableAggregate(new ReductionIterableAggregate(
+                yield from new NormalizeIterableAggregate(new LimitIterableAggregate(new ReductionIterableAggregate(
                     $generator,
                     /**
                      * @param list<T> $stack
@@ -46,7 +47,7 @@ final class Tails extends AbstractOperation
                      */
                     static fn (array $stack): array => array_slice($stack, 1),
                     $generator
-                ));
+                ), 1));
             };
     }
 }

--- a/src/Operation/Window.php
+++ b/src/Operation/Window.php
@@ -6,6 +6,7 @@ namespace loophp\collection\Operation;
 
 use Closure;
 use Generator;
+use loophp\iterators\LimitIterableAggregate;
 use loophp\iterators\ReductionIterableAggregate;
 
 use function array_slice;
@@ -33,7 +34,7 @@ final class Window extends AbstractOperation
                  *
                  * @return Generator<TKey, list<T>>
                  */
-                static fn (iterable $iterable): Generator => yield from new ReductionIterableAggregate(
+                static fn (iterable $iterable): Generator => yield from new LimitIterableAggregate(new ReductionIterableAggregate(
                     $iterable,
                     /**
                      * @param list<T> $stack
@@ -43,6 +44,6 @@ final class Window extends AbstractOperation
                      */
                     static fn (array $stack, mixed $current): array => array_slice([...$stack, $current], ++$size * -1),
                     []
-                );
+                ), 1);
     }
 }

--- a/tests/static-analysis/reduce.php
+++ b/tests/static-analysis/reduce.php
@@ -18,15 +18,25 @@ function reduce_takeString(string $string): void
 {
 }
 
+function reduce_takeStringOrNull(?string $string): void
+{
+}
+
+function reduce_takeIntOrBool(int|bool $v): void
+{
+}
+
 $sumNullable = static fn (?int $carry, int $value): int => null === $carry ? $value : $carry + $value;
 $sum = static fn (int $carry, int $value): int => $carry + $value;
 
 $concatNullable = static fn (?string $carry, string $string): string => null === $carry ? $string : $carry . $string;
 $concat = static fn (string $carry, string $string): string => sprintf('%s%s', $carry, $string);
 
-reduce_takeInt(Collection::fromIterable([1, 2, 3])->reduce($sumNullable));
+reduce_takeIntOrNull(Collection::fromIterable([1, 2, 3])->reduce($sumNullable));
 reduce_takeIntOrNull(Collection::fromIterable([])->reduce($sumNullable));
 reduce_takeInt(Collection::fromIterable([1, 2, 3])->reduce($sum, 0));
 
-reduce_takeString(Collection::fromIterable(['z' => 'a', 'y' => 'b', 'x' => 'c'])->reduce($concatNullable));
+reduce_takeStringOrNull(Collection::fromIterable(['z' => 'a', 'y' => 'b', 'x' => 'c'])->reduce($concatNullable));
 reduce_takeString(Collection::fromIterable(['z' => 'a', 'y' => 'b', 'x' => 'c'])->reduce($concat, ''));
+
+reduce_takeIntOrBool(Collection::fromIterable([1, 2, 3])->reduce(static fn (bool|int $c, $v): int => $v, 123));

--- a/tests/static-analysis/reduction.php
+++ b/tests/static-analysis/reduction.php
@@ -25,7 +25,7 @@ function reduction_checkListString(CollectionInterface $collection): void
 }
 
 /**
- * @param CollectionInterface<int, string> $collection
+ * @param CollectionInterface<int, ?string> $collection
  */
 function reduction_checkListStringWithNull(CollectionInterface $collection): void
 {

--- a/tests/static-analysis/scanLeft1.php
+++ b/tests/static-analysis/scanLeft1.php
@@ -28,6 +28,13 @@ function scanLeft1_checkListOfSize1String(CollectionInterface $collection): void
 {
 }
 
+/**
+ * @param CollectionInterface<string|int, string|int> $collection
+ */
+function scanLeft1_checkMixedInput(CollectionInterface $collection): void
+{
+}
+
 $intGenerator =
     /**
      * @return Generator<int, int>
@@ -43,3 +50,4 @@ $intGenerator =
 // see Psalm bug: https://github.com/vimeo/psalm/issues/6108
 scanLeft1_checkListString(Collection::fromIterable(range('a', 'c'))->scanLeft1($concat));
 scanLeft1_checkListOfSize1String(Collection::fromIterable($intGenerator())->scanLeft1($toString));
+scanLeft1_checkMixedInput(Collection::fromIterable(array_combine(range('a', 'e'), range('a', 'e')))->scanLeft1(static fn (int|string $carry, string $value): int => ord($value)));

--- a/tests/static-analysis/scanRight1.php
+++ b/tests/static-analysis/scanRight1.php
@@ -28,6 +28,13 @@ function scanRight1_checkListOfSize1String(CollectionInterface $collection): voi
 {
 }
 
+/**
+ * @param CollectionInterface<string|int, string|int> $collection
+ */
+function scanRight1_checkMixedInput(CollectionInterface $collection): void
+{
+}
+
 $intGenerator =
     /**
      * @return Generator<int, int>
@@ -43,3 +50,4 @@ $intGenerator =
 // see Psalm bug: https://github.com/vimeo/psalm/issues/6108
 scanRight1_checkListString(Collection::fromIterable(range('a', 'c'))->scanRight1($concat));
 scanRight1_checkListOfSize1String(Collection::fromIterable($intGenerator())->scanRight1($toString));
+scanRight1_checkMixedInput(Collection::fromIterable(array_combine(range('a', 'e'), range('a', 'e')))->scanRight1(static fn (int|string $carry, string $value): int => ord($value)));

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -1088,7 +1088,7 @@ trait GenericCollectionProviders
             [
                 Collection::fromIterable([1, 2, 3]),
             ],
-            [1, 2, 3, 4],
+            range(1, 4),
             false,
         ];
 
@@ -1096,7 +1096,7 @@ trait GenericCollectionProviders
         yield [
             $operation,
             [
-                Collection::fromIterable([1, 2, 3, 4]),
+                Collection::fromIterable(range(1, 4)),
             ],
             [1, 2, 3],
             false,
@@ -3263,7 +3263,7 @@ trait GenericCollectionProviders
                 'foo',
             ],
             [],
-            null,
+            'foo',
         ];
 
         yield [
@@ -3289,14 +3289,26 @@ trait GenericCollectionProviders
 
     public function reductionOperationProvider()
     {
+        $output = static function () {
+            yield 0 => 0;
+
+            yield 0 => 1;
+
+            yield 1 => 3;
+
+            yield 2 => 6;
+
+            yield 3 => 10;
+        };
+
         yield [
             'reduction',
             [
                 static fn ($carry, $item) => $carry + $item,
                 0,
             ],
-            range(1, 5),
-            [1, 3, 6, 10, 15],
+            range(1, 4),
+            $output(),
         ];
     }
 
@@ -3432,14 +3444,14 @@ trait GenericCollectionProviders
         yield [
             $operation,
             [Collection::fromIterable([1, 2, 3])],
-            [1, 2, 3, 4],
+            range(1, 4),
             false,
         ];
 
         // different lengths, extra elements in second
         yield [
             $operation,
-            [Collection::fromIterable([1, 2, 3, 4])],
+            [Collection::fromIterable(range(1, 4))],
             [1, 2, 3],
             false,
         ];
@@ -3565,15 +3577,15 @@ trait GenericCollectionProviders
     public function scanLeft1OperationProvider()
     {
         $operation = 'scanLeft1';
-        $callback = static fn ($carry, $value) => $carry / $value;
+        $callback = static fn ($carry, $value) => $carry + $value;
 
         yield [
             $operation,
             [
                 $callback,
             ],
-            [64, 4, 2, 8],
-            [64, 16, 8, 1],
+            range(1, 4),
+            [1, 3, 6, 10],
         ];
 
         yield [
@@ -3598,24 +3610,26 @@ trait GenericCollectionProviders
     public function scanLeftOperationProvider()
     {
         $operation = 'scanLeft';
-        $callback = static fn ($carry, $value) => $carry / $value;
+        $callback = static fn ($carry, $value) => $carry + $value;
         $output = static function () {
-            yield 0 => 64;
+            yield 0 => 0;
 
-            yield 0 => 16;
+            yield 0 => 1;
 
-            yield 1 => 8;
+            yield 1 => 3;
 
-            yield 2 => 2;
+            yield 2 => 6;
+
+            yield 3 => 10;
         };
 
         yield [
             $operation,
             [
                 $callback,
-                64,
+                0,
             ],
-            [4, 2, 4],
+            range(1, 4),
             $output(),
         ];
 
@@ -3623,25 +3637,25 @@ trait GenericCollectionProviders
             $operation,
             [
                 $callback,
-                3,
+                42,
             ],
             [],
-            [0 => 3],
+            [0 => 42],
         ];
     }
 
     public function scanRight1OperationProvider()
     {
         $operation = 'scanRight1';
-        $callback = static fn ($carry, $value) => $value / $carry;
+        $callback = static fn (int $carry, int $value): int => $value + $carry;
         $output = static function () {
-            yield 0 => 8;
+            yield 0 => 10;
 
-            yield 1 => 1;
+            yield 1 => 9;
 
-            yield 2 => 12;
+            yield 2 => 7;
 
-            yield 0 => 2;
+            yield 0 => 4;
         };
 
         yield [
@@ -3649,7 +3663,7 @@ trait GenericCollectionProviders
             [
                 $callback,
             ],
-            [8, 12, 24, 2],
+            range(1, 4),
             $output(),
         ];
 
@@ -3666,27 +3680,26 @@ trait GenericCollectionProviders
     public function scanRightOperationProvider()
     {
         $operation = 'scanRight';
-        $callback = static fn ($carry, $value) => $value / $carry;
-
+        $callback = static fn ($carry, $value) => $value + $carry;
         $output = static function () {
-            yield 0 => 8;
+            yield 0 => 10;
 
-            yield 1 => 1;
+            yield 1 => 9;
 
-            yield 2 => 12;
+            yield 2 => 7;
 
-            yield 3 => 2;
+            yield 3 => 4;
 
-            yield 0 => 2;
+            yield 0 => 0;
         };
 
         yield [
             $operation,
             [
                 $callback,
-                2,
+                0,
             ],
-            [8, 12, 24, 4],
+            range(1, 4),
             $output(),
         ];
 
@@ -3697,7 +3710,7 @@ trait GenericCollectionProviders
                 3,
             ],
             [],
-            [3],
+            [0 => 3],
         ];
     }
 


### PR DESCRIPTION
This PR:

- [x] Fix `reduce`, `reduction`, `scanLeft`, `scanRight`
- [x] Is covered by unit tests
- [x] Has static analysis tests (psalm, phpstan)
- [x] Has documentation

Note, the psalm issues are related to the upgrade to 5.4, they will be fixed in a follow up PR which is almost done.

Follows a discussion on Mastodon with @azjezz at https://mathstodon.xyz/@Pol/109588243184619262