### PR TITLE
Update lazy-json-parsing.php

### DIFF
--- a/docs/pages/code/lazy-json-parsing.php
+++ b/docs/pages/code/lazy-json-parsing.php
@@ -6,7 +6,7 @@ namespace App;
 
 require_once __DIR__ . '/../../../vendor/autoload.php';
 
-use JsonMachine\JsonMachine;
+use JsonMachine\Items;
 use loophp\collection\Collection;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\ChunkInterface;
@@ -24,7 +24,7 @@ use Symfony\Contracts\HttpClient\ChunkInterface;
 // Parse a local JSON file
 $composerJson = __DIR__ . '/../../../composer.json';
 
-$json = Collection::fromIterable(JsonMachine::fromFile($composerJson));
+$json = Collection::fromIterable(Items::fromFile($composerJson));
 
 foreach ($json as $key => $value);
 


### PR DESCRIPTION
Update example to be compatible with recent version of halaxa/json-machine.

This PR:

- [x] Fix ...
- [ ] Provide ...
- [ ] It breaks backward compatibility
- [ ] Is covered by unit tests
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
