### PR TITLE
feat: add `countIn` operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -554,7 +554,7 @@ Signature: ``Collection::count(): int;``
 countIn
 ~~~~~~~
 
-This operation requires a reference to a parameter that will contains the amount
+This operation requires a reference to a parameter that will contain the amount
 of items in the collection.
 
 Interface: `CountInAble`_

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -557,6 +557,10 @@ countIn
 This operation requires a reference to a parameter that will contain the amount
 of items in the collection.
 
+The difference with the `count` operation is that the `count` operation will
+return the amount of items in the collection and the `countIn` operation will
+yield over the collection itself while updating the counter variable.
+
 Interface: `CountInAble`_
 
 Signature: ``Collection::countIn(int &$counter): Collection;``

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -551,6 +551,19 @@ Signature: ``Collection::count(): int;``
     $collection = Collection::fromIterable(range('a', 'c'))
         ->count(); // 3
 
+countIn
+~~~~~~~
+
+This operation requires a reference to a parameter that will contains the amount
+of items in the collection.
+
+Interface: `CountInAble`_
+
+Signature: ``Collection::countIn(int &$counter): Collection;``
+
+.. literalinclude:: code/operations/countIn.php
+  :language: php
+
 current
 ~~~~~~~
 
@@ -2537,6 +2550,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Comparable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Comparable.php
 .. _Coalesceable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Coalesceable.php
 .. _Containsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Containsable.php
+.. _CountInAble: https://github.com/loophp/collection/blob/master/src/Contract/Operation/CountInAble.php
 .. _Currentable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Currentable.php
 .. _Cycleable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Cycleable.php
 .. _Diffable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Diffable.php

--- a/docs/pages/code/operations/countIn.php
+++ b/docs/pages/code/operations/countIn.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+$lettersCounter = $wordsCounter = 0;
+
+$collection = Collection::fromString('The quick brown fox jumps over the lazy dog')
+    ->countIn($lettersCounter)
+    ->words()
+    ->countIn($wordsCounter)
+    ->map(
+        static function (string $word, int $k) use ($wordsCounter): string {
+            return sprintf('[%s/%s]: %s', $k + 1, $wordsCounter, $word);
+        }
+    )
+    ->all();

--- a/docs/pages/code/operations/countIn.php
+++ b/docs/pages/code/operations/countIn.php
@@ -17,4 +17,7 @@ $collection = Collection::fromString('The quick brown fox jumps over the lazy do
             return sprintf('[%s/%s]: %s', $k + 1, $wordsCounter, $word);
         }
     )
-    ->all();
+    ->all(); // [ "[1/9]: The", "[2/9]: quick", "[3/9]: brown", "[4/9]: fox", "[5/9]: jumps", "[6/9]: over", "[7/9]: the", "[8/9]: lazy", "[9/9]: dog" ]
+
+    print_r($wordsCounter); // 9
+    print_r($lettersCounter); // 43

--- a/docs/pages/code/operations/countIn.php
+++ b/docs/pages/code/operations/countIn.php
@@ -19,5 +19,5 @@ $collection = Collection::fromString('The quick brown fox jumps over the lazy do
     )
     ->all(); // [ "[1/9]: The", "[2/9]: quick", "[3/9]: brown", "[4/9]: fox", "[5/9]: jumps", "[6/9]: over", "[7/9]: the", "[8/9]: lazy", "[9/9]: dog" ]
 
-    print_r($wordsCounter); // 9
-    print_r($lettersCounter); // 43
+print_r($wordsCounter); // 9
+print_r($lettersCounter); // 43

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -141,6 +141,11 @@ parameters:
 			path: src/Collection.php
 
 		-
+			message: "#^Parameter \\#1 \\.\\.\\.\\$ of closure expects callable\\(mixed, mixed, iterable\\)\\: bool, Closure\\(\\)\\: void given\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
 			message: "#^Template type U of method loophp\\\\collection\\\\Collection\\:\\:empty\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Collection.php

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.9.0@8b9ad1eb9e8b7d3101f949291da2b9f7767cd163">
+<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/Collection.php">
     <InvalidArgument>
       <code>$callback</code>
       <code>$parameters</code>
+      <code><![CDATA[static function () use (&$counter): void {
+                    ++$counter;
+                }]]></code>
     </InvalidArgument>
     <InvalidReturnStatement>
       <code>new self((new Operation\Unfold())()($parameters)($callback))</code>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -142,6 +142,15 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return iterator_count($this);
     }
 
+    public function countIn(int &$counter): CollectionInterface
+    {
+        $callback = static function () use (&$counter): void {
+            ++$counter;
+        };
+
+        return new self((new Operation\Apply())()($callback), [$this]);
+    }
+
     public function current(int $index = 0, $default = null)
     {
         return (new Operation\Current())()($index)($default)($this)->current();

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -144,11 +144,14 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
 
     public function countIn(int &$counter): CollectionInterface
     {
-        $callback = static function () use (&$counter): void {
-            ++$counter;
-        };
-
-        return new self((new Operation\Apply())()($callback), [$this]);
+        return new self(
+            (new Operation\Apply())()(
+                static function () use (&$counter): void {
+                    ++$counter;
+                }
+            ),
+            [$this]
+        );
     }
 
     public function current(int $index = 0, $default = null)

--- a/src/CollectionDecorator.php
+++ b/src/CollectionDecorator.php
@@ -123,6 +123,13 @@ abstract class CollectionDecorator implements CollectionInterface
         return $this->innerCollection->contains(...$values);
     }
 
+    public function countIn(int &$counter): CollectionInterface
+    {
+        $this->innerCollection->countIn($counter);
+
+        return $this;
+    }
+
     public function current(int $index = 0, $default = null): mixed
     {
         return $this->innerCollection->current($index, $default);

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -31,6 +31,7 @@ use Traversable;
  * @template-extends Operation\Compactable<TKey, T>
  * @template-extends Operation\Comparable<TKey, T>
  * @template-extends Operation\Containsable<TKey, T>
+ * @template-extends Operation\CountInAble<TKey, T>
  * @template-extends Operation\Currentable<TKey, T>
  * @template-extends Operation\Cycleable<TKey, T>
  * @template-extends Operation\Diffable<TKey, T>
@@ -150,6 +151,7 @@ interface Collection extends
     Operation\Compactable,
     Operation\Comparable,
     Operation\Containsable,
+    Operation\CountInAble,
     Operation\Currentable,
     Operation\Cycleable,
     Operation\Diffable,

--- a/src/Contract/Operation/CountInAble.php
+++ b/src/Contract/Operation/CountInAble.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface CountInAble
+{
+    /**
+     * This operation requires a reference to a parameter that will contains the
+     * amount of items in the collection.
+     *
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#countIn
+     *
+     * @param non-negative-int $counter
+     *
+     * @return Collection<TKey, T>
+     */
+    public function countIn(int &$counter): Collection;
+}

--- a/src/Contract/Operation/CountInAble.php
+++ b/src/Contract/Operation/CountInAble.php
@@ -13,7 +13,7 @@ use loophp\collection\Contract\Collection;
 interface CountInAble
 {
     /**
-     * This operation requires a reference to a parameter that will contains the
+     * This operation requires a reference to a parameter that will contain the
      * amount of items in the collection.
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#countIn

--- a/src/Contract/Operation/CountInAble.php
+++ b/src/Contract/Operation/CountInAble.php
@@ -14,7 +14,10 @@ interface CountInAble
 {
     /**
      * This operation requires a reference to a parameter that will contain the
-     * amount of items in the collection.
+     * amount of items in the collection. The difference with the `count`
+     * operation is that the `count` operation will return the amount of items
+     * in the collection and the `countIn` operation will yield over the
+     * collection itself while updating the counter variable.
      *
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#countIn
      *

--- a/tests/static-analysis/countIn.php
+++ b/tests/static-analysis/countIn.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+function count_check(int $count): void
+{
+}
+
+$counter = 0;
+
+Collection::fromIterable(range(0, 6))->countIn($counter);
+
+count_check($counter);
+
+/**
+ * @psalm-param CollectionInterface<int<0, 2>, int> $collection
+ *
+ * @phpstan-param CollectionInterface<int, int> $collection
+ */
+function checkListInt(CollectionInterface $collection): void
+{
+}
+
+checkListInt(Collection::fromIterable([1, 2, 3])->countIn($counter));

--- a/tests/static-analysis/countIn.php
+++ b/tests/static-analysis/countIn.php
@@ -18,7 +18,7 @@ Collection::fromIterable(range(0, 6))->countIn($counter);
 count_check($counter);
 
 /**
- * @psalm-param CollectionInterface<int<0, 2>, int> $collection
+ * @psalm-param CollectionInterface<int<0,2>, 1|2|3> $collection
  *
  * @phpstan-param CollectionInterface<int, int> $collection
  */

--- a/tests/unit/CollectionGenericOperationTest.php
+++ b/tests/unit/CollectionGenericOperationTest.php
@@ -169,4 +169,20 @@ final class CollectionGenericOperationTest extends TestCase
             Collection::fromIterable($actual)->{$operation}(...$parameters)
         );
     }
+
+    /**
+     * @dataProvider countInOperationProvider
+     */
+    public function testOperationWithSideEffects(
+        callable $test,
+        string $operation,
+        array $parameters,
+        iterable $actual,
+        mixed $expected
+    ): void {
+        self::assertSame(
+            $expected,
+            $test($operation, $parameters, $actual, $expected)
+        );
+    }
 }

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -623,6 +623,40 @@ trait GenericCollectionProviders
         ];
     }
 
+    public static function countInOperationProvider()
+    {
+        $operation = 'countIn';
+        $parameters = [];
+
+        yield [
+            static function ($operation, $parameters, $actual): int {
+                $counter = 0;
+
+                Collection::fromIterable($actual)->{$operation}($counter)->all();
+
+                return $counter;
+            },
+            $operation,
+            $parameters,
+            [],
+            0,
+        ];
+
+        yield [
+            static function ($operation, $parameters, $actual): int {
+                $counter = 0;
+
+                Collection::fromIterable($actual)->{$operation}($counter)->all();
+
+                return $counter;
+            },
+            $operation,
+            $parameters,
+            range('A', 'C'),
+            3,
+        ];
+    }
+
     public static function countOperationProvider()
     {
         $operation = 'count';


### PR DESCRIPTION
This PR:

- [x] Provide a new operation `countIn` inspired from https://github.com/fiiSoft/fiisoft-jackdaw-stream/ project
- [ ] It breaks backward compatibility
- [x] Is covered by unit tests
- [x] Has static analysis tests (psalm, phpstan)
- [x] Has documentation
- [ ] Is an experimental thing
