### PR TITLE
feat: add `length` parameter to `fromFile` constructor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     ],
     "require": {
         "php": ">= 8.1",
-        "loophp/iterators": "^2.3.4"
+        "loophp/iterators": "^2.3.5"
     },
     "require-dev": {
         "ext-pcov": "*",

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -336,12 +336,14 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
     }
 
     /**
+     * @param null|non-negative-int $length
+     *
      * @return self<int, string>
      */
-    public static function fromFile(string $filepath): CollectionInterface
+    public static function fromFile(string $filepath, ?int $length = 2): CollectionInterface
     {
         return new self(
-            static fn (): Generator => yield from new ResourceIteratorAggregate(fopen($filepath, 'rb'), true),
+            static fn (): Generator => yield from new ResourceIteratorAggregate(fopen($filepath, 'rb'), true, $length),
         );
     }
 

--- a/src/CollectionDecorator.php
+++ b/src/CollectionDecorator.php
@@ -267,9 +267,12 @@ abstract class CollectionDecorator implements CollectionInterface
         return new static(Collection::fromCallable($callable, $parameters));
     }
 
-    public static function fromFile(string $filepath): static
+    /**
+     * @param null|non-negative-int $length
+     */
+    public static function fromFile(string $filepath, ?int $length = 2): static
     {
-        return new static(Collection::fromFile($filepath));
+        return new static(Collection::fromFile($filepath, $length));
     }
 
     public static function fromGenerator(Generator $generator): static


### PR DESCRIPTION
This PR:

- [ ] Fix ...
- [ ] Provide ...
- [ ] It breaks backward compatibility
- [ ] Is covered by unit tests
- [ ] Has static analysis tests (psalm, phpstan)
- [ ] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
