### PR TITLE
docs: fix light color code over light gray background

### DIFF
--- a/docs/_static/highlight.css
+++ b/docs/_static/highlight.css
@@ -14,7 +14,7 @@ div.highlight pre span.nc,
 div.highlight pre span.nf,
 div.highlight pre span.nx,
 div.highlight pre span.kn {
-  color: white;
+  color: #1e4d06;
 }
 
 div.highlight pre span.nv {


### PR DESCRIPTION
This PR:

- [x] Fix light highlighted code over a light backgound
- [ ] Provides an example of color that will allow a better readability on documentation (which can be any other one)

<img width="650" alt="image" src="https://github.com/loophp/collection/assets/16139308/1557d04f-a44e-4488-a729-511c9057ca80">

