### PR TITLE
docs: fix light color code everywhere where it was white

### DIFF
--- a/docs/_static/highlight.css
+++ b/docs/_static/highlight.css
@@ -4,7 +4,7 @@ div.highlight {
 
 div.highlight pre {
   border: none;
-  color: white !important;
+  color: #1e4d06 !important;
 }
 
 div.highlight pre span.n,


### PR DESCRIPTION
This PR:

- [x ] Fixes another white code block over light gray bg

I spotted another place where it's the case. I didn't want to over do it and change everything at one, so now we can change this too!
<img width="1264" alt="image" src="https://github.com/loophp/collection/assets/16139308/b2d253bb-b087-4016-bb28-ca6a4cc7c81e">
