### PR TITLE
feat: add `entropy` operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -723,6 +723,27 @@ Signature: ``Collection::duplicate(?callable $comparatorCallback = null, ?callab
 .. literalinclude:: code/operations/duplicate.php
   :language: php
 
+entropy
+~~~~~~~
+
+This method extends the library's functionality by allowing users to calculate
+the normalized Shannon entropy of a collection.
+
+The implementation provides the normalized version of Shannon entropy.
+Normalization ensures that the entropy value is scaled between `0` and `1`,
+making it easier to compare entropy across different collections, irrespective
+of their size or the diversity of elements they contain.
+
+An entropy of `0` indicates no diversity (all elements are the same), while an
+entropy of `1` signifies maximum diversity.
+
+Interface: `Entropyable`_
+
+Signature: ``Collection::entropy(): Collection;``
+
+.. literalinclude:: code/operations/entropy.php
+  :language: php
+
 equals
 ~~~~~~
 
@@ -2564,6 +2585,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _DropWhileable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/DropWhileable.php
 .. _Dumpable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Dumpable.php
 .. _Duplicateable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Duplicateable.php
+.. _Entropyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Entropyable.php
 .. _Equalsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Equalsable.php
 .. _Everyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Everyable.php
 .. _Explodeable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Explodeable.php

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -727,7 +727,11 @@ entropy
 ~~~~~~~
 
 This method extends the library's functionality by allowing users to calculate
-the normalized Shannon entropy of a collection.
+the normalized Shannon entropy of each item in a collection. Since it is not
+possible to calculate it lazily just like in the `average` operation, this
+operation returns a collection of entropy values, calculated individually for
+each item. Therefore, if you're looking for the entropy of the whole collection,
+you must get the last item using `last` operation.
 
 The implementation provides the normalized version of Shannon entropy.
 Normalization ensures that the entropy value is scaled between `0` and `1`,
@@ -735,7 +739,7 @@ making it easier to compare entropy across different collections, irrespective
 of their size or the diversity of elements they contain.
 
 An entropy of `0` indicates no diversity (all elements are the same), while an
-entropy of `1` signifies maximum diversity.
+entropy of `1` signifies maximum diversity (all elements are different).
 
 Interface: `Entropyable`_
 

--- a/docs/pages/code/operations/entropy.php
+++ b/docs/pages/code/operations/entropy.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$collection = Collection::fromIterable(['a'])
+    ->entropy(); // [0]
+
+$collection = Collection::fromIterable(['a', 'b'])
+    ->entropy(); // [0, 1]
+
+$collection = Collection::fromIterable(['a', 'b', 'a'])
+    ->entropy(); // [0, 1, 0.9182958340544896]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:entropy\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, float\\|int\\<0, 1\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, float\\|int\\>\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
 			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:group\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, array\\<int, T\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, array\\<int, mixed\\>\\>\\.$#"
 			count: 1
 			path: src/Collection.php
@@ -121,6 +126,11 @@ parameters:
 			path: src/Collection.php
 
 		-
+			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(mixed \\.\\.\\.\\)\\: iterable\\<int, float\\|int\\>, Closure\\(iterable\\)\\: Generator\\<int, float\\|int\\<0, 1\\>, mixed, mixed\\> given\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
 			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(mixed \\.\\.\\.\\)\\: iterable\\<int, mixed\\>, Closure\\(iterable\\)\\: Generator\\<int, mixed, mixed, mixed\\> given\\.$#"
 			count: 3
 			path: src/Collection.php
@@ -209,6 +219,16 @@ parameters:
 			message: "#^Template type U of method loophp\\\\collection\\\\Operation\\\\Duplicate\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"
 			count: 1
 			path: src/Operation/Duplicate.php
+
+		-
+			message: "#^Parameter \\#1 \\$ of closure expects callable\\(mixed, mixed, iterable\\)\\: mixed, Closure\\(mixed, int, loophp\\\\collection\\\\Collection\\)\\: float given\\.$#"
+			count: 1
+			path: src/Operation/Entropy.php
+
+		-
+			message: "#^Parameter \\#1 \\$callback of method loophp\\\\collection\\\\Contract\\\\Operation\\\\Reduceable\\<int,float\\>\\:\\:reduce\\(\\) expects callable\\(float\\|int, float, int, iterable\\<int, float\\>\\)\\: \\(float\\|int\\), Closure\\(float, float, int, loophp\\\\collection\\\\Collection\\)\\: float given\\.$#"
+			count: 1
+			path: src/Operation/Entropy.php
 
 		-
 			message: "#^Template type V of method loophp\\\\collection\\\\Operation\\\\Find\\:\\:__invoke\\(\\) is not referenced in a parameter\\.$#"

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -35,6 +35,38 @@
       <code><![CDATA[Closure(bool): Closure(iterable<TKey, T>): (Generator<int, T>|Generator<TKey, T>)]]></code>
     </InvalidReturnType>
   </file>
+  <file src="src/Operation/Entropy.php">
+    <InvalidArgument>
+      <code><![CDATA[static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2)]]></code>
+      <code><![CDATA[static fn (mixed $_, int $key, Collection $collection): float => $collection
+                    ->limit($key + 1)
+                    ->frequency()
+                    ->keys()
+                    ->map(
+                        static fn (int $freq): float => $freq / ($key + 1)
+                    )
+                    ->reduce(
+                        static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2),
+                        0
+                    )]]></code>
+    </InvalidArgument>
+    <InvalidReturnStatement>
+      <code><![CDATA[$collection
+                    ->limit($key + 1)
+                    ->frequency()
+                    ->keys()
+                    ->map(
+                        static fn (int $freq): float => $freq / ($key + 1)
+                    )
+                    ->reduce(
+                        static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2),
+                        0
+                    )]]></code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[Collection<int, float>]]></code>
+    </InvalidReturnType>
+  </file>
   <file src="src/Operation/Product.php">
     <InvalidArgument>
       <code>[[]]</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -37,35 +37,21 @@
   </file>
   <file src="src/Operation/Entropy.php">
     <InvalidArgument>
-      <code><![CDATA[static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2)]]></code>
+      <code><![CDATA[static fn (float $acc, float $p, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $p * log($p, 2) / log($c->count(), 2)]]></code>
       <code><![CDATA[static fn (mixed $_, int $key, Collection $collection): float => $collection
                     ->limit($key + 1)
                     ->frequency()
-                    ->keys()
                     ->map(
-                        static fn (int $freq): float => $freq / ($key + 1)
+                        /**
+                         * @param T $_
+                         */
+                        static fn (mixed $_, int $freq): float => $freq / ($key + 1)
                     )
                     ->reduce(
-                        static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2),
+                        static fn (float $acc, float $p, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $p * log($p, 2) / log($c->count(), 2),
                         0
                     )]]></code>
     </InvalidArgument>
-    <InvalidReturnStatement>
-      <code><![CDATA[$collection
-                    ->limit($key + 1)
-                    ->frequency()
-                    ->keys()
-                    ->map(
-                        static fn (int $freq): float => $freq / ($key + 1)
-                    )
-                    ->reduce(
-                        static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2),
-                        0
-                    )]]></code>
-    </InvalidReturnStatement>
-    <InvalidReturnType>
-      <code><![CDATA[Collection<int, float>]]></code>
-    </InvalidReturnType>
   </file>
   <file src="src/Operation/Product.php">
     <InvalidArgument>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -252,6 +252,11 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return self::fromIterable([]);
     }
 
+    public function entropy(): CollectionInterface
+    {
+        return new self((new Operation\Entropy())(), [$this]);
+    }
+
     public function equals(iterable $other): bool
     {
         return (new Operation\Equals())()($other)($this)->current();

--- a/src/CollectionDecorator.php
+++ b/src/CollectionDecorator.php
@@ -178,6 +178,11 @@ abstract class CollectionDecorator implements CollectionInterface
         return new static(Collection::empty());
     }
 
+    public function entropy(): static
+    {
+        return new static($this->innerCollection->entropy());
+    }
+
     public function equals(iterable $other): bool
     {
         return $this->innerCollection->equals($other);

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -41,6 +41,7 @@ use Traversable;
  * @template-extends Operation\DropWhileable<TKey, T>
  * @template-extends Operation\Dumpable<TKey, T>
  * @template-extends Operation\Duplicateable<TKey, T>
+ * @template-extends Operation\Entropyable<TKey, T>
  * @template-extends Operation\Everyable<TKey, T>
  * @template-extends Operation\Explodeable<TKey, T>
  * @template-extends Operation\Falsyable<TKey, T>
@@ -162,6 +163,7 @@ interface Collection extends
     Operation\Dumpable,
     Operation\Duplicateable,
     Operation\Equalsable,
+    Operation\Entropyable,
     Operation\Everyable,
     Operation\Explodeable,
     Operation\Falsyable,

--- a/src/Contract/Operation/Entropyable.php
+++ b/src/Contract/Operation/Entropyable.php
@@ -13,10 +13,20 @@ use loophp\collection\Contract\Collection;
 interface Entropyable
 {
     /**
-     * Calculate the normalized Shannon entropy for each collection items.
+     * This method extends the library's functionality by allowing users to calculate
+     * the normalized Shannon entropy of each item in a collection. Since it is not
+     * possible to calculate it lazily just like in the `average` operation, this
+     * operation returns a collection of entropy values, calculated individually for
+     * each item. Therefore, if you're looking for the entropy of the whole collection,
+     * you must get the last item using `last` operation.
      *
-     * If you're looking for one single result, you must get the last item using
-     * `last` operation.
+     * The implementation provides the normalized version of Shannon entropy.
+     * Normalization ensures that the entropy value is scaled between `0` and `1`,
+     * making it easier to compare entropy across different collections, irrespective
+     * of their size or the diversity of elements they contain.
+     *
+     * An entropy of `0` indicates no diversity (all elements are the same), while an
+     * entropy of `1` signifies maximum diversity (all elements are different).
      *
      * @see https://en.wikipedia.org/wiki/Entropy_(information_theory)
      * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#entropy

--- a/src/Contract/Operation/Entropyable.php
+++ b/src/Contract/Operation/Entropyable.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Entropyable
+{
+    /**
+     * Calculate the normalized Shannon entropy for each collection items.
+     *
+     * If you're looking for one single result, you must get the last item using
+     * `last` operation.
+     *
+     * @see https://en.wikipedia.org/wiki/Entropy_(information_theory)
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#entropy
+     *
+     * @return Collection<int, int<0,1>|float>
+     */
+    public function entropy(): Collection;
+}

--- a/src/Operation/Entropy.php
+++ b/src/Operation/Entropy.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Entropy extends AbstractOperation
+{
+    /**
+     * @return Closure(iterable<TKey, T>): Generator<int, int<0,1>|float>
+     */
+    public function __invoke(): Closure
+    {
+        /** @var Closure(iterable<TKey, T>): Generator<int, int<0,1>|float> $pipe */
+        $pipe = (new Pipe())()(
+            (
+                /**
+                 * @param iterable<TKey, T> $iterable
+                 *
+                 * @return CollectionInterface<int, T>
+                 */
+                static fn (iterable $iterable): CollectionInterface => Collection::fromIterable($iterable)->normalize()->squash()
+            ),
+            (new Map())()(
+                /**
+                 * @param T $_
+                 * @param int $key
+                 * @param Collection<TKey, T> $collection
+                 *
+                 * @return Collection<int, float>
+                 */
+                static fn (mixed $_, int $key, Collection $collection): float => $collection
+                    ->limit($key + 1)
+                    ->frequency()
+                    ->keys()
+                    ->map(
+                        static fn (int $freq): float => $freq / ($key + 1)
+                    )
+                    ->reduce(
+                        static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2),
+                        0
+                    )
+            ),
+            (new Map())()(
+                /**
+                 * @return int<0,1>|float
+                 */
+                static fn (float $value): float|int => (0.0 === $value || 1.0 === $value) ? (int) $value : $value
+            )
+        );
+
+        // Point free style
+        return $pipe;
+    }
+}

--- a/src/Operation/Entropy.php
+++ b/src/Operation/Entropy.php
@@ -41,12 +41,14 @@ final class Entropy extends AbstractOperation
                 static fn (mixed $_, int $key, Collection $collection): float => $collection
                     ->limit($key + 1)
                     ->frequency()
-                    ->keys()
                     ->map(
-                        static fn (int $freq): float => $freq / ($key + 1)
+                        /**
+                         * @param T $_
+                         */
+                        static fn (mixed $_, int $freq): float => $freq / ($key + 1)
                     )
                     ->reduce(
-                        static fn (float $acc, float $freq, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $freq * log($freq, 2) / log($c->count(), 2),
+                        static fn (float $acc, float $p, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $p * log($p, 2) / log($c->count(), 2),
                         0
                     )
             ),

--- a/src/Operation/Entropy.php
+++ b/src/Operation/Entropy.php
@@ -37,8 +37,6 @@ final class Entropy extends AbstractOperation
                  * @param T $_
                  * @param int $key
                  * @param Collection<TKey, T> $collection
-                 *
-                 * @return Collection<int, float>
                  */
                 static fn (mixed $_, int $key, Collection $collection): float => $collection
                     ->limit($key + 1)

--- a/tests/static-analysis/entropy.php
+++ b/tests/static-analysis/entropy.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int<0,1>|float> $intOrFloat
+ */
+function takeIntOrFloat(CollectionInterface $intOrFloat): void {}
+
+takeIntOrFloat(Collection::fromIterable(str_split('hello'))->entropy());

--- a/tests/unit/CollectionGenericOperationTest.php
+++ b/tests/unit/CollectionGenericOperationTest.php
@@ -43,6 +43,7 @@ final class CollectionGenericOperationTest extends TestCase
      * @dataProvider dropWhileOperationProvider
      * @dataProvider dumpOperationProvider
      * @dataProvider duplicateOperationProvider
+     * @dataProvider entropyOperationProvider
      * @dataProvider explodeOperationProvider
      * @dataProvider filterOperationProvider
      * @dataProvider flatMapOperationProvider

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -1028,6 +1028,46 @@ trait GenericCollectionProviders
         ];
     }
 
+    public static function entropyOperationProvider()
+    {
+        $operation = 'entropy';
+
+        yield [
+            $operation,
+            [],
+            [],
+            [],
+        ];
+
+        yield [
+            $operation,
+            [],
+            [
+                'a',
+                'b',
+            ],
+            [
+                0,
+                1,
+            ],
+        ];
+
+        yield [
+            $operation,
+            [],
+            [
+                'a',
+                'b',
+                'a',
+            ],
+            [
+                0,
+                1,
+                0.9182958340544896,
+            ],
+        ];
+    }
+
     public static function equalsOperationProvider()
     {
         $operation = 'equals';


### PR DESCRIPTION
This PR:


- [x] Provide the `entropy` operation
- [ ] It breaks backward compatibility
- [x] Is covered by unit tests
- [x] Has static analysis tests (psalm, phpstan)
- [x] Has documentation
- [ ] Is an experimental thing
