### PR TITLE
feat: add `dispersion` operation

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -627,6 +627,26 @@ Signature: ``Collection::diffKeys(...$keys): Collection;``
     $collection = Collection::fromIterable(['a', 'b', 'c', 'd', 'e'])
         ->diffKeys(1, 2); // [0 => 'a', 3 => 'd', 4 => 'e']
 
+dispersion
+~~~~~~~~~~
+
+This method extends the library's functionality by allowing users to calculate
+a dispersion value using the amount of value changes within the collection.
+
+For example, the set `[a, b, a]` contains three elements and two changes.
+From `a` to `b` and from `b` to `a`. Therefore, the dispersion value is
+`2 / 2 = 1`.
+
+The dispersion value is normalized between `0` and `1`. A dispersion of `0`
+indicates no dispersion, while a dispersion of `1` means maximum dispersion.
+
+Interface: `Dispersionable`_
+
+Signature: ``Collection::dispersion(): Collection;``
+
+.. literalinclude:: code/operations/dispersion.php
+  :language: php
+
 distinct
 ~~~~~~~~
 
@@ -2584,6 +2604,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Cycleable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Cycleable.php
 .. _Diffable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Diffable.php
 .. _Diffkeysable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Diffkeysable.php
+.. _Dispersionable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Dispersionable.php
 .. _Distinctable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Distinctable.php
 .. _Dropable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Dropable.php
 .. _DropWhileable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/DropWhileable.php

--- a/docs/pages/code/operations/dispersion.php
+++ b/docs/pages/code/operations/dispersion.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use loophp\collection\Collection;
+
+include __DIR__ . '/../../../../vendor/autoload.php';
+
+$collection = Collection::fromIterable(['a'])
+    ->dispersion(); // [0]
+
+$collection = Collection::fromIterable(['a', 'b'])
+    ->dispersion(); // [0, 1]
+
+$collection = Collection::fromIterable(['a', 'b', 'a'])
+    ->dispersion(); // [0, 1, 1]
+
+$collection = Collection::fromIterable(['a', 'b', 'b'])
+    ->dispersion(); // [0, 1, .5]

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:dispersion\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, float\\|int\\<0, 1\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, float\\|int\\>\\.$#"
+			count: 1
+			path: src/Collection.php
+
+		-
 			message: "#^Method loophp\\\\collection\\\\Collection\\:\\:entropy\\(\\) should return loophp\\\\collection\\\\Contract\\\\Collection\\<int, float\\|int\\<0, 1\\>\\> but returns loophp\\\\collection\\\\Collection\\<int, float\\|int\\>\\.$#"
 			count: 1
 			path: src/Collection.php
@@ -127,7 +132,7 @@ parameters:
 
 		-
 			message: "#^Parameter \\#1 \\$callable of class loophp\\\\collection\\\\Collection constructor expects callable\\(mixed \\.\\.\\.\\)\\: iterable\\<int, float\\|int\\>, Closure\\(iterable\\)\\: Generator\\<int, float\\|int\\<0, 1\\>, mixed, mixed\\> given\\.$#"
-			count: 1
+			count: 2
 			path: src/Collection.php
 
 		-

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -65,6 +65,18 @@
       <code>$callbacks</code>
     </InvalidArgument>
   </file>
+  <file src="src/Operation/Dispersion.php">
+    <InvalidReturnStatement>
+      <code>[(0 === $key) ? 0 : (($c * ($key - 1) + (($v === $value) ? 0 : 1)) / $key), $value]</code>
+    </InvalidReturnStatement>
+    <InvalidReturnType>
+      <code><![CDATA[array<float|int<0,1>, T>]]></code>
+    </InvalidReturnType>
+    <MismatchingDocblockParamType>
+      <code><![CDATA[array<float|int<0,1>, T>]]></code>
+      <code><![CDATA[array<float|int<0,1>, T|null>]]></code>
+    </MismatchingDocblockParamType>
+  </file>
   <file src="src/Operation/Entropy.php">
     <InvalidArgument>
       <code><![CDATA[static fn (float $acc, float $p, int $_, Collection $c): float => 0 === $key ? $acc : $acc - $p * log($p, 2) / ((1 === $count = $c->count()) ? 1 : log($count, 2))]]></code>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -174,6 +174,11 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\DiffKeys())()($keys), [$this]);
     }
 
+    public function dispersion(): CollectionInterface
+    {
+        return new self((new Operation\Dispersion())(), [$this]);
+    }
+
     public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): CollectionInterface
     {
         $accessorCallback ??=

--- a/src/CollectionDecorator.php
+++ b/src/CollectionDecorator.php
@@ -148,6 +148,11 @@ abstract class CollectionDecorator implements CollectionInterface
         return new static($this->innerCollection->diffKeys(...$keys));
     }
 
+    public function dispersion(): static
+    {
+        return new static($this->innerCollection->dispersion());
+    }
+
     public function distinct(?callable $comparatorCallback = null, ?callable $accessorCallback = null): static
     {
         return new static($this->innerCollection->distinct($comparatorCallback, $accessorCallback));

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -36,6 +36,7 @@ use Traversable;
  * @template-extends Operation\Cycleable<TKey, T>
  * @template-extends Operation\Diffable<TKey, T>
  * @template-extends Operation\Diffkeysable<TKey, T>
+ * @template-extends Operation\Dispersionable<TKey, T>
  * @template-extends Operation\Distinctable<TKey, T>
  * @template-extends Operation\Dropable<TKey, T>
  * @template-extends Operation\DropWhileable<TKey, T>
@@ -157,6 +158,7 @@ interface Collection extends
     Operation\Cycleable,
     Operation\Diffable,
     Operation\Diffkeysable,
+    Operation\Dispersionable,
     Operation\Distinctable,
     Operation\Dropable,
     Operation\DropWhileable,

--- a/src/Contract/Operation/Dispersionable.php
+++ b/src/Contract/Operation/Dispersionable.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Dispersionable
+{
+    /**
+     * This method extends the library's functionality by allowing users to calculate
+     * a dispersion value using the amount of value changes within the collection.
+     *
+     * For example, the set `[a, b, a]` contains three elements and two changes.
+     * From `a` to `b` and from `b` to `a`. Therefore, the dispersion value is
+     * `2 / 2 = 1`.
+     *
+     * The dispersion value is normalized between `0` and `1`. A dispersion of `0`
+     * indicates no dispersion, while a dispersion of `1` means maximum dispersion.
+     *
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#dispersion
+     *
+     * @return Collection<int, float|int<0,1>>
+     */
+    public function dispersion(): Collection;
+}

--- a/src/Operation/Dispersion.php
+++ b/src/Operation/Dispersion.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Dispersion extends AbstractOperation
+{
+    /**
+     * @return Closure(iterable<TKey, T>): Generator<int, float|int<0,1>>
+     */
+    public function __invoke(): Closure
+    {
+        /** @var Closure(iterable<TKey, T>): Generator<int, float|int<0,1>> $pipe */
+        $pipe = (new Pipe())()(
+            (new Normalize())(),
+            (new ScanLeft())()(
+                /**
+                 * @param array<float|int<0,1>, T|null> $acc
+                 * @param T $value
+                 *
+                 * @return array<float|int<0,1>, T>
+                 */
+                static function (array $acc, mixed $value, int $key): array {
+                    [$c, $v] = $acc;
+
+                    return [(0 === $key) ? 0 : (($c * ($key - 1) + (($v === $value) ? 0 : 1)) / $key), $value];
+                }
+            )([0, null]),
+            (new Drop())()(1),
+            (new Map())()(
+                /**
+                 * @param array<float|int<0,1>, T> $value
+                 *
+                 * @return float|int<0,1>
+                 */
+                static fn (array $value): float|int => (0.0 === $value[0] || 1.0 === $value[0]) ? (int) $value[0] : $value[0]
+            )
+        );
+
+        return $pipe;
+    }
+}

--- a/tests/static-analysis/dispersion.php
+++ b/tests/static-analysis/dispersion.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @param CollectionInterface<int, int<0,1>|float> $intOrFloat
+ */
+function takeIntOrFloat(CollectionInterface $intOrFloat): void {}
+
+takeIntOrFloat(Collection::fromIterable(str_split('hello'))->dispersion());

--- a/tests/unit/CollectionGenericOperationTest.php
+++ b/tests/unit/CollectionGenericOperationTest.php
@@ -38,6 +38,7 @@ final class CollectionGenericOperationTest extends TestCase
      * @dataProvider cycleOperationProvider
      * @dataProvider diffOperationProvider
      * @dataProvider diffKeysOperationProvider
+     * @dataProvider dispersionOperationProvider
      * @dataProvider distinctOperationProvider
      * @dataProvider dropOperationProvider
      * @dataProvider dropWhileOperationProvider

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -803,6 +803,63 @@ trait GenericCollectionProviders
         }
     }
 
+    public static function dispersionOperationProvider()
+    {
+        $operation = 'dispersion';
+
+        yield [
+            $operation,
+            [],
+            [],
+            [],
+        ];
+
+        yield [
+            $operation,
+            [],
+            [
+                'a',
+                'b',
+            ],
+            [
+                0,
+                1,
+            ],
+        ];
+
+        yield [
+            $operation,
+            [],
+            [
+                'a',
+                'a',
+                'b',
+                'b',
+            ],
+            [
+                0,
+                0,
+                .5,
+                1 / 3,
+            ],
+        ];
+
+        yield [
+            $operation,
+            [],
+            [
+                'a',
+                'a',
+                'a',
+            ],
+            [
+                0,
+                0,
+                0,
+            ],
+        ];
+    }
+
     public static function distinctOperationProvider()
     {
         $operation = 'distinct';


### PR DESCRIPTION
This PR:

- [x] Provide a new operation `dispersion` (Thanks for the idea @lietapa !)
- [ ] It breaks backward compatibility
- [x] Is covered by unit tests
- [x] Has static analysis tests (psalm, phpstan)
- [x] Has documentation
- [ ] Is an experimental thing

Follows #. Related to #. Fixes #.
