### PR TITLE
Improve return types for psalm

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.16.0@2897ba636551a8cb61601cc26f6ccfbba6c36591">
   <file src="src/Collection.php">
+  <MixedArgument>
+      <code>(new Operation\Product())()(...$iterables)</code>
+      <code>(new Operation\Combinate())()($length)</code>
+  </MixedArgument>
     <InvalidArgument>
       <code>$callback</code>
       <code>$callbacks</code>

--- a/psalm.xml
+++ b/psalm.xml
@@ -14,4 +14,7 @@
             <directory name="tests/unit/" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <MixedArgument errorLevel="error"/>
+    </issueHandlers>
 </psalm>

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -245,7 +245,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
      * @template UKey
      * @template U
      *
-     * @return self<UKey, U>
+     * @return CollectionInterface<UKey, U>&self<UKey, U>
      */
     public static function empty(): CollectionInterface
     {
@@ -345,7 +345,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
      * @param callable(mixed ...$parameters): iterable<NewTKey, NewT> $callable
      * @param iterable<int, mixed> $parameters
      *
-     * @return self<NewTKey, NewT>
+     * @return CollectionInterface<NewTKey, NewT>&self<NewTKey, NewT>
      */
     public static function fromCallable(callable $callable, iterable $parameters = []): CollectionInterface
     {
@@ -355,7 +355,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
     /**
      * @param null|non-negative-int $length
      *
-     * @return self<int, string>
+     * @return CollectionInterface<int, string>&self<int, string>
      */
     public static function fromFile(string $filepath, ?int $length = 2): CollectionInterface
     {
@@ -370,7 +370,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
      *
      * @param Generator<NewTKey, NewT> $generator
      *
-     * @return self<NewTKey, NewT>
+     * @return CollectionInterface<NewTKey, NewT>&self<NewTKey, NewT>
      */
     public static function fromGenerator(Generator $generator): CollectionInterface
     {
@@ -383,7 +383,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
      *
      * @param iterable<UKey, U> $iterable
      *
-     * @return self<UKey, U>
+     * @return CollectionInterface<UKey, U>&self<UKey, U>
      */
     public static function fromIterable(iterable $iterable): CollectionInterface
     {
@@ -393,7 +393,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
     /**
      * @param resource $resource
      *
-     * @return self<int, string>
+     * @return CollectionInterface<int, string>&self<int, string>
      */
     public static function fromResource($resource): CollectionInterface
     {
@@ -401,7 +401,7 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
     }
 
     /**
-     * @return self<int, string>
+     * @return CollectionInterface<int, string>&self<int, string>
      */
     public static function fromString(string $string, string $delimiter = ''): CollectionInterface
     {

--- a/tests/static-analysis/fromIterableAssociateAll.php
+++ b/tests/static-analysis/fromIterableAssociateAll.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+
+enum fromIterableAssociateAll: int
+{
+    case FIFTH = 5;
+    case FIRST = 1;
+    case FOURTH = 4;
+    case SECOND = 2;
+    case THIRD = 3;
+}
+
+/**
+ * @psalm-param array<string, int> $array
+ *
+ * @phpstan-param array<string, int> $array
+ */
+function checklist(array $array): void {}
+
+checklist(Collection::fromIterable(fromIterableAssociateAll::cases())->associate(
+    static fn (int $_, fromIterableAssociateAll $item) => $item->value,
+    static fn (fromIterableAssociateAll $item, int $_) => $item->name,
+)->flip()->all(false));


### PR DESCRIPTION
Psalm cannot always infer the types when not defining the CollectionInterface<Key, Value> type. This makes sure that psalm is aware of the implemented interface and the Collection class.

This PR:

- [x] Fix #318 
- [x] Has static analysis tests (psalm, phpstan)

Still open for debate as it changes the static constructor types.