### PR TITLE
fix: `pair` and `chunk` operation when using empty input

### DIFF
--- a/src/Operation/Chunk.php
+++ b/src/Operation/Chunk.php
@@ -59,7 +59,9 @@ final class Chunk extends AbstractOperation
                         $values = [$value];
                     }
 
-                    yield $values;
+                    if ([] !== $values) {
+                        yield $values;
+                    }
                 };
     }
 }

--- a/tests/unit/Traits/GenericCollectionProviders.php
+++ b/tests/unit/Traits/GenericCollectionProviders.php
@@ -3220,6 +3220,13 @@ trait GenericCollectionProviders
             $input,
             $output(),
         ];
+
+        yield [
+            $operation,
+            [],
+            [],
+            [],
+        ];
     }
 
     public static function permutateOperationProvider()


### PR DESCRIPTION
This PR:

- [x] Fix #326
- [x] Is covered by unit tests

