### PR TITLE
Adds tap() - allows shorter syntax for chaining no side effects operations

### DIFF
--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -2287,6 +2287,22 @@ Signature: ``Collection::takeWhile(callable ...$callbacks): Collection;``
     Collection::fromIterable([1,2,3,4,5,6,7,8,9,1,2,3])
         ->takeWhile($isSmallerThanThree); // [1,2]
 
+tap
+~~~
+
+Execute callback(s) on each element of the collection.
+
+Iterates on the collection items regardless of the return value of the callback.
+
+It is a simplified version of the ``apply`` operation, as it does not require the callback to return a boolean value, allowing shorter syntax e.g. for logging or event dispatching: ``->tap(fn($value) => $events->emit(new ItemReceived($value)))``.
+
+Interface: `Tappable`_
+
+Signature: ``Collection::tap(callable ...$callbacks): Collection;``
+
+.. literalinclude:: code/operations/tap.php
+  :language: php
+
 transpose
 ~~~~~~~~~
 
@@ -2693,6 +2709,7 @@ Signature: ``Collection::zip(iterable ...$iterables): Collection;``
 .. _Tailable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Tailable.php
 .. _Tailsable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Tailsable.php
 .. _TakeWhileable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/TakeWhileable.php
+.. _Tappable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Tappable.php
 .. _Transposeable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Transposeable.php
 .. _Truthyable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Truthyable.php
 .. _Unlinesable: https://github.com/loophp/collection/blob/master/src/Contract/Operation/Unlinesable.php

--- a/src/Collection.php
+++ b/src/Collection.php
@@ -783,6 +783,11 @@ final class Collection implements CollectionInterface, JsonSerializable, Countab
         return new self((new Operation\TakeWhile())()(...$callbacks), [$this]);
     }
 
+    public function tap(callable ...$callbacks): CollectionInterface
+    {
+        return new self((new Operation\Tap())()(...$callbacks), [$this]);
+    }
+
     /**
      * @template U
      *

--- a/src/CollectionDecorator.php
+++ b/src/CollectionDecorator.php
@@ -646,6 +646,11 @@ abstract class CollectionDecorator implements CollectionInterface
         return new static($this->innerCollection->takeWhile(...$callbacks));
     }
 
+    public function tap(callable ...$callbacks): static
+    {
+        return new static($this->innerCollection->tap(...$callbacks));
+    }
+
     public static function times(int $number = 0, ?callable $callback = null): static
     {
         return new static(Collection::times($number, $callback));

--- a/src/Contract/Collection.php
+++ b/src/Contract/Collection.php
@@ -118,6 +118,7 @@ use Traversable;
  * @template-extends Operation\Tailable<TKey, T>
  * @template-extends Operation\Tailsable<TKey, T>
  * @template-extends Operation\TakeWhileable<TKey, T>
+ * @template-extends Operation\Tappable<TKey, T>
  * @template-extends Operation\Transposeable<TKey, T>
  * @template-extends Operation\Truthyable<TKey, T>
  * @template-extends Operation\Unlinesable<TKey, T>
@@ -243,6 +244,7 @@ interface Collection extends
     Operation\Tailable,
     Operation\Tailsable,
     Operation\TakeWhileable,
+    Operation\Tappable,
     Operation\Timesable,
     Operation\Transposeable,
     Operation\Truthyable,

--- a/src/Contract/Operation/Tappable.php
+++ b/src/Contract/Operation/Tappable.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Contract\Operation;
+
+use loophp\collection\Contract\Collection;
+
+/**
+ * @template TKey
+ * @template T
+ */
+interface Tappable
+{
+    /**
+     * Execute callback(s) on each element of the collection.
+     * Iterates on the collection items regardless of the return value of the callback.
+     *
+     * @see https://loophp-collection.readthedocs.io/en/stable/pages/api.html#apply
+     *
+     * @param callable(T, TKey, iterable<TKey, T>): void ...$callbacks
+     *
+     * @return Collection<TKey, T>
+     */
+    public function tap(callable ...$callbacks): Collection;
+}

--- a/src/Operation/Tap.php
+++ b/src/Operation/Tap.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace loophp\collection\Operation;
+
+use Closure;
+use Generator;
+
+/**
+ * @immutable
+ *
+ * @template TKey
+ * @template T
+ */
+final class Tap extends AbstractOperation
+{
+    /**
+     * @return Closure(callable(T, TKey, iterable<TKey, T>):void ...): Closure(iterable<TKey, T>): Generator<TKey, T>
+     */
+    public function __invoke(): Closure
+    {
+        return
+            /**
+             * @param callable(T, TKey, iterable<TKey, T>): bool ...$callbacks
+             *
+             * @return Closure(iterable<TKey, T>): Generator<TKey, T>
+             */
+            static fn(callable ...$callbacks): Closure => /**
+             * @param iterable<TKey, T> $iterable
+             *
+             * @return Generator<TKey, T>
+             */
+            static function (iterable $iterable) use ($callbacks): Generator {
+                foreach ($iterable as $key => $value) {
+                    foreach ($callbacks as $callback) {
+                        $callback($value, $key, $iterable);
+                    }
+
+                    yield $key => $value;
+                }
+            };
+    }
+}

--- a/src/Operation/Tap.php
+++ b/src/Operation/Tap.php
@@ -22,11 +22,11 @@ final class Tap extends AbstractOperation
     {
         return
             /**
-             * @param callable(T, TKey, iterable<TKey, T>): bool ...$callbacks
+             * @param callable(T, TKey, iterable<TKey, T>): void ...$callbacks
              *
              * @return Closure(iterable<TKey, T>): Generator<TKey, T>
              */
-            static fn(callable ...$callbacks): Closure => /**
+            static fn (callable ...$callbacks): Closure => /**
              * @param iterable<TKey, T> $iterable
              *
              * @return Generator<TKey, T>

--- a/tests/static-analysis/tap.php
+++ b/tests/static-analysis/tap.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+include __DIR__ . '/../../vendor/autoload.php';
+
+use loophp\collection\Collection;
+use loophp\collection\Contract\Collection as CollectionInterface;
+
+/**
+ * @psalm-param CollectionInterface<int<0,1>, 'bar'|'foo'> $collection
+ *
+ * @phpstan-param CollectionInterface<int, string> $collection
+ */
+function tap_checkList(CollectionInterface $collection): void {}
+/**
+ * @param CollectionInterface<string, string> $collection
+ */
+function tap_checkMap(CollectionInterface $collection): void {}
+
+$echoCallback = static function (string $item): void {
+    echo $item;
+};
+
+tap_checkList(Collection::fromIterable(['foo', 'bar'])->tap($echoCallback));
+tap_checkList(Collection::fromIterable(['foo', 'bar'])->tap($echoCallback, $echoCallback));
+
+$echoCallback = static function (string $item, string $key): void {
+    echo $item, $key;
+};
+
+tap_checkMap(Collection::fromIterable(['foo' => 'bar'])->tap($echoCallback));
+tap_checkMap(Collection::fromIterable(['foo' => 'bar'])->tap($echoCallback, $echoCallback));

--- a/tests/unit/CollectionSpecificOperationTest.php
+++ b/tests/unit/CollectionSpecificOperationTest.php
@@ -598,25 +598,6 @@ final class CollectionSpecificOperationTest extends TestCase
                     static function ($item) use (&$stack): void {
                         $stack += [$item => []];
                         $stack[$item][] = 'fn1';
-                    }
-                )
-        );
-
-        $expected = [
-            'a' => ['fn1'],
-        ];
-
-        self::assertSame($expected, $stack);
-
-        $stack = [];
-
-        $this::assertIdenticalIterable(
-            $input,
-            Collection::fromIterable($input)
-                ->tap(
-                    static function ($item) use (&$stack): void {
-                        $stack += [$item => []];
-                        $stack[$item][] = 'fn1';
                     },
                     static function ($item) use (&$stack): void {
                         $stack += [$item => []];

--- a/tests/unit/CollectionSpecificOperationTest.php
+++ b/tests/unit/CollectionSpecificOperationTest.php
@@ -562,4 +562,77 @@ final class CollectionSpecificOperationTest extends TestCase
             $collection->strict($callback)->all()
         );
     }
+
+    public function testTapOperation(): void
+    {
+        $input = range('a', 'e');
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            Collection::fromIterable($input)
+                ->tap(
+                    static function ($item) use (&$stack): void {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1'],
+            'b' => ['fn1'],
+            'c' => ['fn1'],
+            'd' => ['fn1'],
+            'e' => ['fn1'],
+        ];
+
+        self::assertSame($expected, $stack);
+
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            Collection::fromIterable($input)
+                ->tap(
+                    static function ($item) use (&$stack): void {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1'],
+        ];
+
+        self::assertSame($expected, $stack);
+
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            Collection::fromIterable($input)
+                ->tap(
+                    static function ($item) use (&$stack): void {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+                    },
+                    static function ($item) use (&$stack): void {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn2';
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1', 'fn2'],
+            'b' => ['fn1', 'fn2'],
+            'c' => ['fn1', 'fn2'],
+            'd' => ['fn1', 'fn2'],
+            'e' => ['fn1', 'fn2'],
+        ];
+
+        self::assertSame($expected, $stack);
+    }
 }

--- a/tests/unit/CustomCollectionSpecificOperationTest.php
+++ b/tests/unit/CustomCollectionSpecificOperationTest.php
@@ -577,4 +577,58 @@ final class CustomCollectionSpecificOperationTest extends TestCase
             $collection->strict($callback)->all()
         );
     }
+
+    public function testTapOperation(): void
+    {
+        $input = range('a', 'e');
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->tap(
+                    static function ($item) use (&$stack): void {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1'],
+            'b' => ['fn1'],
+            'c' => ['fn1'],
+            'd' => ['fn1'],
+            'e' => ['fn1'],
+        ];
+
+        self::assertSame($expected, $stack);
+
+        $stack = [];
+
+        $this::assertIdenticalIterable(
+            $input,
+            (new CustomCollection(Collection::fromIterable($input)))
+                ->apply(
+                    static function ($item) use (&$stack): void {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn1';
+                    },
+                    static function ($item) use (&$stack): void {
+                        $stack += [$item => []];
+                        $stack[$item][] = 'fn2';
+                    }
+                )
+        );
+
+        $expected = [
+            'a' => ['fn1', 'fn2'],
+            'b' => ['fn1', 'fn2'],
+            'c' => ['fn1', 'fn2'],
+            'd' => ['fn1', 'fn2'],
+            'e' => ['fn1', 'fn2'],
+        ];
+
+        self::assertSame($expected, $stack);
+    }
 }


### PR DESCRIPTION
More convenient than `apply()` for chaining no side effect operations like logging or event dispatching.
Allows for shorter notation:

```php
$collection->tap(fn($item) => Event::dispatch(new ItemReceived($item)))
```

versus

```php
$collection->apply(function($item) {
   Event::dispatch(new ItemReceived($item));
   return true;
})
```

This PR:
- [+] Provides shorter notation for no side effect operations
- [-] It breaks backward compatibility
- [+] Is covered by unit tests
- [+] Has static analysis tests (psalm, phpstan)
- [+] Has documentation
- [-] Is an experimental thing
